### PR TITLE
llvm_mode: using MaybeAlign wrapper over the deprecated setter.

### DIFF
--- a/llvm_mode/afl-llvm-lto-instrumentation.so.cc
+++ b/llvm_mode/afl-llvm-lto-instrumentation.so.cc
@@ -378,7 +378,7 @@ bool AFLLTOPass::runOnModule(Module &M) {
         M, Int32Ty, true, GlobalValue::ExternalLinkage, 0, "__afl_final_loc", 0,
         GlobalVariable::GeneralDynamicTLSModel, 0, false);
     ConstantInt *const_loc = ConstantInt::get(Int32Ty, afl_global_id);
-    AFLFinalLoc->setAlignment(4);
+    AFLFinalLoc->setAlignment(MaybeAlign(4));
     AFLFinalLoc->setInitializer(const_loc);
 
   }


### PR DESCRIPTION
seems to be available even on LLVM 3.7