### PR TITLE
Android build fix proposal.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,6 +36,7 @@ SH_PROGS    = afl-plot afl-cmin afl-cmin.bash afl-whatsup afl-system-config
 MANPAGES=$(foreach p, $(PROGS) $(SH_PROGS), $(p).8) afl-as.8
 ASAN_OPTIONS=detect_leaks=0
 
+ifeq "$(findstring android, $(shell $(CC) --version 2>/dev/null))" ""
 ifeq "$(shell echo 'int main() {return 0; }' | $(CC) $(CFLAGS) -Werror -x c - -flto=full -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
 	CFLAGS_FLTO ?= -flto=full
 else
@@ -46,6 +47,7 @@ else
 	CFLAGS_FLTO ?= -flto
   endif
  endif
+endif
 endif
 
 ifneq "$(shell uname)" "Darwin"

--- a/src/afl-fuzz-extras.c
+++ b/src/afl-fuzz-extras.c
@@ -451,7 +451,7 @@ void load_auto(afl_state_t *afl) {
     u8 *fn = alloc_printf("%s/.state/auto_extras/auto_%06u", afl->in_dir, i);
     s32 fd, len;
 
-    fd = open(fn, O_RDONLY, 0600);
+    fd = open(fn, O_RDONLY);
 
     if (fd < 0) {
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -154,7 +154,8 @@ static u32 write_results_to_file(afl_forkserver_t *fsrv, u8 *outfile) {
 
   if (!strncmp(outfile, "/dev/", 5)) {
 
-    fd = open(outfile, O_WRONLY, 0600);
+    fd = open(outfile, O_WRONLY);
+
     if (fd < 0) PFATAL("Unable to open '%s'", fsrv->out_file);
 
   } else if (!strcmp(outfile, "-")) {


### PR DESCRIPTION
LTO flag is recognised but however broken on Android (tested with armv7 arch).
Thus giving the choice not to enable it.
In fortify mode, open required O_CREAT or O_TMPFILE when mode is set.