### PR TITLE
Integer swapping mutation in havoc

### DIFF
--- a/examples/custom_mutators/custom_mutator_helpers.h
+++ b/examples/custom_mutators/custom_mutator_helpers.h
@@ -27,7 +27,7 @@ static void surgical_havoc_mutate(u8 *out_buf, s32 begin, s32 end) {
   static s16 interesting_16[] = {INTERESTING_8, INTERESTING_16};
   static s32 interesting_32[] = {INTERESTING_8, INTERESTING_16, INTERESTING_32};
 
-  switch (RAND_BELOW(12)) {
+  switch (RAND_BELOW(13)) {
 
     case 0: {
 
@@ -277,7 +277,8 @@ static void surgical_havoc_mutate(u8 *out_buf, s32 begin, s32 end) {
       if(end - begin <= 8) break;
       u32 offset_1 = RAND_BELOW((end - begin -8)) / 2;
       u32 offset_2 = (offset_1 ^ 0xffadeb)%(end - begin -8);
-
+      
+      /* If the offsets are different swap */
       if(offset_1 != offset_2) {
           SWAPQ((*(u64 *)(out_buf + offset_1)), (*(u64 *)(out_buf + offset_2)));
       }      

--- a/examples/custom_mutators/custom_mutator_helpers.h
+++ b/examples/custom_mutators/custom_mutator_helpers.h
@@ -272,6 +272,17 @@ static void surgical_havoc_mutate(u8 *out_buf, s32 begin, s32 end) {
       break;
 
     }
+    case 12: {
+      /* Swap 2 random qwords in the out_buf */
+      if(end - begin <= 8) break;
+      u32 offset_1 = RAND_BELOW((end - begin -8)) / 2;
+      u32 offset_2 = (offset_1 ^ 0xffadeb)%(end - begin -8);
+
+      if(offset_1 != offset_2) {
+          SWAPQ((*(u64 *)(out_buf + offset_1)), (*(u64 *)(out_buf + offset_2)));
+      }      
+      break;  
+  }
 
   }
 

--- a/include/types.h
+++ b/include/types.h
@@ -107,6 +107,15 @@ typedef int64_t s64;
                                                                                \
   })
 
+#define SWAPQ(_x, _y)   \
+  (                     \
+      {                 \
+          u64 _t = _x;  \
+          _x     = _y;  \
+          _y     = _t;  \
+      }                 \
+  ) 
+
 #ifdef AFL_LLVM_PASS
 #if defined(__linux__)
 #define AFL_SR(s) (srandom(s))


### PR DESCRIPTION
Added a mutation rule in surgical_havoc_mutate

Function :
Swap 2 remote chunks in the same data buffer. This is inspired by crossover mutation within the same data buffer. The mutation is unique.

Performance:
There has been No Degradation of performance due to the addition of the custom rule. The following graph proves the same .

For creating the graph, we take an output buffer of size varying from 3 to 1000. For each out_buf, we run the surgical_havoc_mutate for 200 times, one time without mutation, one time with mutation.
![filename](https://user-images.githubusercontent.com/62256100/78800983-b6cd6680-79d9-11ea-84a7-a5bca1df87d8.png)


