### PR TITLE
fixes crash triage example

### DIFF
--- a/examples/crash_triage/triage_crashes.sh
+++ b/examples/crash_triage/triage_crashes.sh
@@ -91,10 +91,10 @@ for crash in $DIR/crashes/id:*; do
   for a in $@; do
 
     if [ "$a" = "@@" ] ; then
-      args="$use_args $crash"
+      use_args="$use_args $crash"
       unset use_stdio
     else
-      args="$use_args $a"
+      use_args="$use_args $a"
     fi
 
   done


### PR DESCRIPTION
The script uses an otherwise unused variable to collect the arguments for the target and thus always executes it without arguments