### PR TITLE
Fixed qbdi_mode/build.sh script

### DIFF
--- a/qbdi_mode/build.sh
+++ b/qbdi_mode/build.sh
@@ -52,6 +52,6 @@ ${compiler_prefix}${CC} -shared -o libdemo.so demo-so.c -w -g
 echo "[+] Building afl-fuzz for Android"
 # build afl-fuzz
 cd ..
-${compiler_prefix}${CC} -DANDROID_DISABLE_FANCY=1 -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -I include/ -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DDOC_PATH=\"/usr/local/share/doc/afl\" -Wno-unused-function src/afl-fuzz-misc.c src/afl-fuzz-extras.c src/afl-fuzz-queue.c src/afl-fuzz-one.c src/afl-fuzz-python.c src/afl-fuzz-stats.c src/afl-fuzz-init.c src/afl-fuzz.c src/afl-fuzz-bitmap.c src/afl-fuzz-run.c src/afl-fuzz-state.c src/afl-common.c src/afl-sharedmem.c src/afl-forkserver.c -o qbdi_mode/afl-fuzz  -ldl -w
+${compiler_prefix}${CC} -DANDROID_DISABLE_FANCY=1 -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -I include/ -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DDOC_PATH=\"/usr/local/share/doc/afl\" -Wno-unused-function src/afl-fuzz-*.c src/afl-fuzz.c src/afl-common.c src/afl-sharedmem.c src/afl-forkserver.c -o qbdi_mode/afl-fuzz  -ldl -w
 
 echo "[+] All done. Enjoy!"


### PR DESCRIPTION
Hi,
the `build.sh` script was failing to build `afl-fuzz` for Android due to missing source files:
```
Ξ pyno(fearless) qbdi_mode git:(master) ▶ STANDALONE_TOOLCHAIN_PATH=/fuzz/android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64 QBDI_SDK_PATH=/fuzz/code/AFLplusplus/qbdi_mode/android-qbdi-sdk-x86_64/ CC=x86_64-linux-android29-clang CXX=x86_64-linux-android29-clang++ ./build.sh x86_64
build x86_64 qbdi
[+] Building the QBDI template
[+] Building the demo library
[+] Building afl-fuzz for Android
clang: error: no such file or directory: 'src/afl-fuzz-misc.c'
[+] All done. Enjoy!
```
I have fixed by modifying the related line to include `src/afl-fuzz-*.c` instead of specifying single files to be compiled.

Hope this helps,
pyno