### PR TITLE
afl-clang-fast: fail when binary name can't be used to determine build mode

### DIFF
--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -184,7 +184,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
       sprintf(llvm_fullpath, CLANGPP_BIN);
     cc_params[0] = alt_cxx && *alt_cxx ? alt_cxx : (u8 *)llvm_fullpath;
 
-  } else {
+  } else if (!strcmp(name, "afl-clang-fast") || !strcmp(name, "afl-clang-lto")) {
 
     u8 *alt_cc = getenv("AFL_CC");
     if (USE_BINDIR)
@@ -193,6 +193,9 @@ static void edit_params(u32 argc, char **argv, char **envp) {
       sprintf(llvm_fullpath, CLANG_BIN);
     cc_params[0] = alt_cc && *alt_cc ? alt_cc : (u8 *)llvm_fullpath;
 
+  } else {
+    fprintf(stderr, "Name of the binary: %s\n", argv[0]);
+    FATAL("Name of the binary is not a known name, expected afl-clang-fast(++) or afl-clang-lto(++)");
   }
 
   /* There are three ways to compile with afl-clang-fast. In the traditional


### PR DESCRIPTION
I'm not too sure about the specific error message, but this may be helpful when someone is trying to do things with the filename, such as wrapping it in an `exec` script. Another solution might be to generate a warning here, but doing nothing might make people shoot themselves in the foot.

In my case, the program was wrapped in a script that setup some environment stuff. Because the script called `exec`, the program name was the name of the script. Trying to compile c++ binaries failed because the c compiler was invoked (the `else` branch was used), resulting in errors like `fatal error: 'new' file not found`. Generating a failure or warning because the wrong compiler might be invoked seems like a valid choice.

Ultimately, the aforementioned script is unnecessary after applying the solution to #316, so it doesn't affect me anymore. However, it would be a good idea to warn or fail when users are trying to do such things. In the future, it might be a good improvement to do partial matching or allowing users to specify which binary to run using environment variables. However, that's not relevant right now, I think.