### PR TITLE
[Discussion] Code Style: Readability Braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false

--- a/examples/qemu_persistent_hook/test.c
+++ b/examples/qemu_persistent_hook/test.c
@@ -16,7 +16,8 @@ int target_func(unsigned char *buf, int size) {
       }
 
       break;
-    default: break;
+    default:
+      break;
 
   }
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -953,7 +953,7 @@ static inline u32 rand_below(afl_state_t *afl, u32 limit) {
 
 static inline u32 get_rand_seed(afl_state_t *afl) {
 
-  if (unlikely(afl->fixed_seed)) return (u32)afl->init_seed;
+  if (unlikely(afl->fixed_seed)) { return (u32)afl->init_seed; }
   return afl->rand_seed[0];
 
 }
@@ -964,8 +964,12 @@ static inline u32 get_rand_seed(afl_state_t *afl) {
 static inline u64 next_p2(u64 val) {
 
   u64 ret = 1;
-  while (val > ret)
+  while (val > ret) {
+
     ret <<= 1;
+
+  }
+
   return ret;
 
 }

--- a/include/alloc-inl.h
+++ b/include/alloc-inl.h
@@ -87,7 +87,7 @@ static inline void *DFL_ck_alloc_nozero(u32 size) {
 
   void *ret;
 
-  if (!size) return NULL;
+  if (!size) { return NULL; }
 
   ALLOC_CHECK_SIZE(size);
   ret = malloc(size);
@@ -103,7 +103,7 @@ static inline void *DFL_ck_alloc(u32 size) {
 
   void *mem;
 
-  if (!size) return NULL;
+  if (!size) { return NULL; }
   mem = DFL_ck_alloc_nozero(size);
 
   return memset(mem, 0, size);
@@ -115,7 +115,7 @@ static inline void *DFL_ck_alloc(u32 size) {
 
 static inline void DFL_ck_free(void *mem) {
 
-  if (!mem) return;
+  if (!mem) { return; }
 
   free(mem);
 
@@ -165,7 +165,7 @@ static inline u8 *DFL_ck_strdup(u8 *str) {
   u8 *ret;
   u32 size;
 
-  if (!str) return NULL;
+  if (!str) { return NULL; }
 
   size = strlen((char *)str) + 1;
 
@@ -184,7 +184,7 @@ static inline void *DFL_ck_memdup(void *mem, u32 size) {
 
   void *ret;
 
-  if (!mem || !size) return NULL;
+  if (!mem || !size) { return NULL; }
 
   ALLOC_CHECK_SIZE(size);
   ret = malloc(size);
@@ -201,7 +201,7 @@ static inline u8 *DFL_ck_memdup_str(u8 *mem, u32 size) {
 
   u8 *ret;
 
-  if (!mem || !size) return NULL;
+  if (!mem || !size) { return NULL; }
 
   ALLOC_CHECK_SIZE(size);
   ret = malloc(size + 1);
@@ -772,8 +772,12 @@ static inline void TRK_ck_free(void *ptr, const char *file, const char *func,
 */
 static inline size_t next_pow2(size_t in) {
 
-  if (in == 0 || in > (size_t)-1)
+  if (in == 0 || in > (size_t)-1) {
+
     return 0;                  /* avoid undefined behaviour under-/overflow */
+
+  }
+
   size_t out = in - 1;
   out |= out >> 1;
   out |= out >> 2;
@@ -794,10 +798,10 @@ static inline size_t next_pow2(size_t in) {
 static inline void *maybe_grow(void **buf, size_t *size, size_t size_needed) {
 
   /* No need to realloc */
-  if (likely(size_needed && *size >= size_needed)) return *buf;
+  if (likely(size_needed && *size >= size_needed)) { return *buf; }
 
   /* No initial size was set */
-  if (size_needed < INITIAL_GROWTH_SIZE) size_needed = INITIAL_GROWTH_SIZE;
+  if (size_needed < INITIAL_GROWTH_SIZE) { size_needed = INITIAL_GROWTH_SIZE; }
 
   /* grow exponentially */
   size_t next_size = next_pow2(size_needed);
@@ -824,13 +828,13 @@ static inline void *ck_maybe_grow(void **buf, size_t *size,
                                   size_t size_needed) {
 
   /* Oops. found a bug? */
-  if (unlikely(size_needed < 1)) FATAL("cannot grow to non-positive size");
+  if (unlikely(size_needed < 1)) { FATAL("cannot grow to non-positive size"); }
 
   /* No need to realloc */
-  if (likely(*size >= size_needed)) return *buf;
+  if (likely(*size >= size_needed)) { return *buf; }
 
   /* No initial size was set */
-  if (size_needed < INITIAL_GROWTH_SIZE) size_needed = INITIAL_GROWTH_SIZE;
+  if (size_needed < INITIAL_GROWTH_SIZE) { size_needed = INITIAL_GROWTH_SIZE; }
 
   /* grow exponentially */
   size_t next_size = next_pow2(size_needed);

--- a/include/android-ashmem.h
+++ b/include/android-ashmem.h
@@ -26,6 +26,8 @@
 #ifndef _ANDROID_ASHMEM_H
 #define _ANDROID_ASHMEM_H
 
+#ifdef __ANDROID__
+
 #include <fcntl.h>
 #include <linux/shm.h>
 #include <linux/ashmem.h>
@@ -102,6 +104,8 @@ static inline void *shmat(int __shmid, const void *__shmaddr, int __shmflg) {
   return ptr;
 
 }
+
+#endif
 
 #endif
 

--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include "types.h"
 
 typedef struct afl_forkserver {
 

--- a/include/list.h
+++ b/include/list.h
@@ -83,7 +83,7 @@ static inline void list_append(list_t *list, void *el) {
   element_t *el_box = NULL;
   PRE_ALLOC(el_box, list->element_prealloc_buf, LIST_PREALLOC_SIZE,
             list->element_prealloc_count);
-  if (!el_box) FATAL("failed to allocate list element");
+  if (!el_box) { FATAL("failed to allocate list element"); }
   el_box->data = el;
   el_box->next = head;
   el_box->prev = head->prev;

--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -28,6 +28,8 @@
 #ifndef __AFL_SHAREDMEM_H
 #define __AFL_SHAREDMEM_H
 
+#include "types.h"
+
 typedef struct sharedmem {
 
   // extern unsigned char *trace_bits;

--- a/libtokencap/libtokencap.so.c
+++ b/libtokencap/libtokencap.so.c
@@ -274,7 +274,8 @@ static void __tokencap_dump(const u8 *ptr, size_t len, u8 is_text) {
         pos += 4;
         break;
 
-      default: buf[pos++] = ptr[i];
+      default:
+        buf[pos++] = ptr[i];
 
     }
 

--- a/llvm_mode/cmplog-instructions-pass.cc
+++ b/llvm_mode/cmplog-instructions-pass.cc
@@ -360,11 +360,20 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
 
     switch (max_size) {
 
-      case 8: IRB.CreateCall(cmplogHookIns1, args, "tmp"); break;
-      case 16: IRB.CreateCall(cmplogHookIns2, args, "tmp"); break;
-      case 32: IRB.CreateCall(cmplogHookIns4, args, "tmp"); break;
-      case 64: IRB.CreateCall(cmplogHookIns8, args, "tmp"); break;
-      default: break;
+      case 8:
+        IRB.CreateCall(cmplogHookIns1, args, "tmp");
+        break;
+      case 16:
+        IRB.CreateCall(cmplogHookIns2, args, "tmp");
+        break;
+      case 32:
+        IRB.CreateCall(cmplogHookIns4, args, "tmp");
+        break;
+      case 64:
+        IRB.CreateCall(cmplogHookIns8, args, "tmp");
+        break;
+      default:
+        break;
 
     }
 

--- a/llvm_mode/split-compares-pass.so.cc
+++ b/llvm_mode/split-compares-pass.so.cc
@@ -318,10 +318,18 @@ bool SplitComparesTransform::simplifyCompares(Module &M) {
     CmpInst::Predicate new_pred;
     switch (pred) {
 
-      case CmpInst::ICMP_UGE: new_pred = CmpInst::ICMP_UGT; break;
-      case CmpInst::ICMP_SGE: new_pred = CmpInst::ICMP_SGT; break;
-      case CmpInst::ICMP_ULE: new_pred = CmpInst::ICMP_ULT; break;
-      case CmpInst::ICMP_SLE: new_pred = CmpInst::ICMP_SLT; break;
+      case CmpInst::ICMP_UGE:
+        new_pred = CmpInst::ICMP_UGT;
+        break;
+      case CmpInst::ICMP_SGE:
+        new_pred = CmpInst::ICMP_SGT;
+        break;
+      case CmpInst::ICMP_ULE:
+        new_pred = CmpInst::ICMP_ULT;
+        break;
+      case CmpInst::ICMP_SLE:
+        new_pred = CmpInst::ICMP_SLT;
+        break;
       default:  // keep the compiler happy
         continue;
 
@@ -384,10 +392,18 @@ bool SplitComparesTransform::simplifyCompares(Module &M) {
     CmpInst::Predicate new_pred;
     switch (pred) {
 
-      case CmpInst::FCMP_UGE: new_pred = CmpInst::FCMP_UGT; break;
-      case CmpInst::FCMP_OGE: new_pred = CmpInst::FCMP_OGT; break;
-      case CmpInst::FCMP_ULE: new_pred = CmpInst::FCMP_ULT; break;
-      case CmpInst::FCMP_OLE: new_pred = CmpInst::FCMP_OLT; break;
+      case CmpInst::FCMP_UGE:
+        new_pred = CmpInst::FCMP_UGT;
+        break;
+      case CmpInst::FCMP_OGE:
+        new_pred = CmpInst::FCMP_OGT;
+        break;
+      case CmpInst::FCMP_ULE:
+        new_pred = CmpInst::FCMP_ULT;
+        break;
+      case CmpInst::FCMP_OLE:
+        new_pred = CmpInst::FCMP_OLT;
+        break;
       default:  // keep the compiler happy
         continue;
 
@@ -855,7 +871,8 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
         icmp_exponent_result =
             BinaryOperator::Create(Instruction::Xor, icmp_exponent, t_s0);
         break;
-      default: continue;
+      default:
+        continue;
 
     }
 
@@ -958,7 +975,8 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
         icmp_fraction_result =
             BinaryOperator::Create(Instruction::Xor, icmp_fraction, t_s0);
         break;
-      default: continue;
+      default:
+        continue;
 
     }
 
@@ -1004,7 +1022,8 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
         PN->addIncoming(icmp_exponent_result, signequal_bb);
         PN->addIncoming(icmp_fraction_result, middle_bb);
         break;
-      default: continue;
+      default:
+        continue;
 
     }
 

--- a/qbdi_mode/demo-so.c
+++ b/qbdi_mode/demo-so.c
@@ -29,7 +29,9 @@ int target_func(char *buf, int size) {
       }
 
       break;
-    default: puts("default action"); break;
+    default:
+      puts("default action");
+      break;
 
   }
 

--- a/qemu_mode/libcompcov/compcovtest.cc
+++ b/qemu_mode/libcompcov/compcovtest.cc
@@ -51,9 +51,11 @@ int main() {
 
   switch (z) {
 
-    case 0xBEEF: break;
+    case 0xBEEF:
+      break;
 
-    default: return 4;
+    default:
+      return 4;
 
   }
 

--- a/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
+++ b/qemu_mode/patches/afl-qemu-cpu-translate-inl.h
@@ -55,11 +55,20 @@ static void afl_gen_compcov(target_ulong cur_loc, TCGv arg1, TCGv arg2,
 
     switch (ot & MO_SIZE) {
 
-      case MO_64: gen_helper_afl_cmplog_64(cur_loc_v, arg1, arg2); break;
-      case MO_32: gen_helper_afl_cmplog_32(cur_loc_v, arg1, arg2); break;
-      case MO_16: gen_helper_afl_cmplog_16(cur_loc_v, arg1, arg2); break;
-      case MO_8: gen_helper_afl_cmplog_8(cur_loc_v, arg1, arg2); break;
-      default: break;
+      case MO_64:
+        gen_helper_afl_cmplog_64(cur_loc_v, arg1, arg2);
+        break;
+      case MO_32:
+        gen_helper_afl_cmplog_32(cur_loc_v, arg1, arg2);
+        break;
+      case MO_16:
+        gen_helper_afl_cmplog_16(cur_loc_v, arg1, arg2);
+        break;
+      case MO_8:
+        gen_helper_afl_cmplog_8(cur_loc_v, arg1, arg2);
+        break;
+      default:
+        break;
 
     }
 
@@ -78,10 +87,17 @@ static void afl_gen_compcov(target_ulong cur_loc, TCGv arg1, TCGv arg2,
 
     switch (ot & MO_SIZE) {
 
-      case MO_64: gen_helper_afl_compcov_64(cur_loc_v, arg1, arg2); break;
-      case MO_32: gen_helper_afl_compcov_32(cur_loc_v, arg1, arg2); break;
-      case MO_16: gen_helper_afl_compcov_16(cur_loc_v, arg1, arg2); break;
-      default: break;
+      case MO_64:
+        gen_helper_afl_compcov_64(cur_loc_v, arg1, arg2);
+        break;
+      case MO_32:
+        gen_helper_afl_compcov_32(cur_loc_v, arg1, arg2);
+        break;
+      case MO_16:
+        gen_helper_afl_compcov_16(cur_loc_v, arg1, arg2);
+        break;
+      default:
+        break;
 
     }
 

--- a/src/afl-analyze.c
+++ b/src/afl-analyze.c
@@ -122,7 +122,7 @@ static void classify_counts(u8 *mem) {
 
     while (i--) {
 
-      if (*mem) *mem = 1;
+      if (*mem) { *mem = 1; }
       mem++;
 
     }
@@ -147,8 +147,11 @@ static inline u8 anything_set(void) {
   u32 *ptr = (u32 *)trace_bits;
   u32  i = (map_size >> 2);
 
-  while (i--)
-    if (*(ptr++)) return 1;
+  while (i--) {
+
+    if (*(ptr++)) { return 1; }
+
+  }
 
   return 0;
 
@@ -169,12 +172,15 @@ static void read_initial_file(void) {
   struct stat st;
   s32         fd = open(in_file, O_RDONLY);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", in_file);
+  if (fd < 0) { PFATAL("Unable to open '%s'", in_file); }
 
-  if (fstat(fd, &st) || !st.st_size) FATAL("Zero-sized input file.");
+  if (fstat(fd, &st) || !st.st_size) { FATAL("Zero-sized input file."); }
 
-  if (st.st_size >= TMIN_MAX_FILE)
+  if (st.st_size >= TMIN_MAX_FILE) {
+
     FATAL("Input file is too large (%u MB max)", TMIN_MAX_FILE / 1024 / 1024);
+
+  }
 
   in_len = st.st_size;
   in_data = ck_alloc_nozero(in_len);
@@ -197,7 +203,7 @@ static s32 write_to_file(u8 *path, u8 *mem, u32 len) {
 
   ret = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
 
-  if (ret < 0) PFATAL("Unable to create '%s'", path);
+  if (ret < 0) { PFATAL("Unable to create '%s'", path); }
 
   ck_write(ret, mem, len, path);
 
@@ -225,7 +231,7 @@ static u32 analyze_run_target(char **argv, u8 *mem, u32 len, u8 first_run) {
 
   child_pid = fork();
 
-  if (child_pid < 0) PFATAL("fork() failed");
+  if (child_pid < 0) { PFATAL("fork() failed"); }
 
   if (!child_pid) {
 
@@ -278,7 +284,7 @@ static u32 analyze_run_target(char **argv, u8 *mem, u32 len, u8 first_run) {
 
   setitimer(ITIMER_REAL, &it, NULL);
 
-  if (waitpid(child_pid, &status, 0) <= 0) FATAL("waitpid() failed");
+  if (waitpid(child_pid, &status, 0) <= 0) { FATAL("waitpid() failed"); }
 
   child_pid = 0;
   it.it_value.tv_sec = 0;
@@ -290,8 +296,11 @@ static u32 analyze_run_target(char **argv, u8 *mem, u32 len, u8 first_run) {
 
   /* Clean up bitmap, analyze exit condition, etc. */
 
-  if (*(u32 *)trace_bits == EXEC_FAIL_SIG)
+  if (*(u32 *)trace_bits == EXEC_FAIL_SIG) {
+
     FATAL("Unable to execute '%s'", argv[0]);
+
+  }
 
   classify_counts(trace_bits);
   total_execs++;
@@ -325,7 +334,7 @@ static u32 analyze_run_target(char **argv, u8 *mem, u32 len, u8 first_run) {
 
   }
 
-  if (first_run) orig_cksum = cksum;
+  if (first_run) { orig_cksum = cksum; }
 
   return cksum;
 
@@ -340,9 +349,12 @@ static void show_char(u8 val) {
   switch (val) {
 
     case 0 ... 32:
-    case 127 ... 255: SAYF("#%02x", val); break;
+    case 127 ... 255:
+      SAYF("#%02x", val);
+      break;
 
-    default: SAYF(" %c ", val);
+    default:
+      SAYF(" %c ", val);
 
   }
 
@@ -387,7 +399,12 @@ static void dump_hex(u8 *buf, u32 len, u8 *b_data) {
 
     while (i + rlen < len && (b_data[i] >> 7) == (b_data[i + rlen] >> 7)) {
 
-      if (rtype < (b_data[i + rlen] & 0x0f)) rtype = b_data[i + rlen] & 0x0f;
+      if (rtype < (b_data[i + rlen] & 0x0f)) {
+
+        rtype = b_data[i + rlen] & 0x0f;
+
+      }
+
       rlen++;
 
     }
@@ -454,9 +471,11 @@ static void dump_hex(u8 *buf, u32 len, u8 *b_data) {
 
         case 1:
         case 3:
-        case 5 ... MAX_AUTO_EXTRA - 1: break;
+        case 5 ... MAX_AUTO_EXTRA - 1:
+          break;
 
-        default: rtype = RESP_SUSPECT;
+        default:
+          rtype = RESP_SUSPECT;
 
       }
 
@@ -472,33 +491,57 @@ static void dump_hex(u8 *buf, u32 len, u8 *b_data) {
 
       if (!((i + off) % 16)) {
 
-        if (off) SAYF(cRST cLCY ">");
+        if (off) { SAYF(cRST cLCY ">"); }
 
-        if (use_hex_offsets)
+        if (use_hex_offsets) {
+
           SAYF(cRST cGRA "%s[%06x] " cRST, (i + off) ? "\n" : "", i + off);
-        else
+
+        } else {
+
           SAYF(cRST cGRA "%s[%06u] " cRST, (i + off) ? "\n" : "", i + off);
+
+        }
 
       }
 
       switch (rtype) {
 
-        case RESP_NONE: SAYF(cLGR bgGRA); break;
-        case RESP_MINOR: SAYF(cBRI bgGRA); break;
-        case RESP_VARIABLE: SAYF(cBLK bgCYA); break;
-        case RESP_FIXED: SAYF(cBLK bgMGN); break;
-        case RESP_LEN: SAYF(cBLK bgLGN); break;
-        case RESP_CKSUM: SAYF(cBLK bgYEL); break;
-        case RESP_SUSPECT: SAYF(cBLK bgLRD); break;
+        case RESP_NONE:
+          SAYF(cLGR bgGRA);
+          break;
+        case RESP_MINOR:
+          SAYF(cBRI bgGRA);
+          break;
+        case RESP_VARIABLE:
+          SAYF(cBLK bgCYA);
+          break;
+        case RESP_FIXED:
+          SAYF(cBLK bgMGN);
+          break;
+        case RESP_LEN:
+          SAYF(cBLK bgLGN);
+          break;
+        case RESP_CKSUM:
+          SAYF(cBLK bgYEL);
+          break;
+        case RESP_SUSPECT:
+          SAYF(cBLK bgLRD);
+          break;
 
       }
 
       show_char(in_data[i + off]);
 
-      if (off != rlen - 1 && (i + off + 1) % 16)
+      if (off != rlen - 1 && (i + off + 1) % 16) {
+
         SAYF(" ");
-      else
+
+      } else {
+
         SAYF(cRST " ");
+
+      }
 
     }
 
@@ -511,13 +554,27 @@ static void dump_hex(u8 *buf, u32 len, u8 *b_data) {
 
     switch (rtype) {
 
-      case RESP_NONE: SAYF("no-op block\n"); break;
-      case RESP_MINOR: SAYF("superficial content\n"); break;
-      case RESP_VARIABLE: SAYF("critical stream\n"); break;
-      case RESP_FIXED: SAYF("\"magic value\" section\n"); break;
-      case RESP_LEN: SAYF("suspected length field\n"); break;
-      case RESP_CKSUM: SAYF("suspected cksum or magic int\n"); break;
-      case RESP_SUSPECT: SAYF("suspected checksummed block\n"); break;
+      case RESP_NONE:
+        SAYF("no-op block\n");
+        break;
+      case RESP_MINOR:
+        SAYF("superficial content\n");
+        break;
+      case RESP_VARIABLE:
+        SAYF("critical stream\n");
+        break;
+      case RESP_FIXED:
+        SAYF("\"magic value\" section\n");
+        break;
+      case RESP_LEN:
+        SAYF("suspected length field\n");
+        break;
+      case RESP_CKSUM:
+        SAYF("suspected cksum or magic int\n");
+        break;
+      case RESP_SUSPECT:
+        SAYF("suspected checksummed block\n");
+        break;
 
     }
 
@@ -594,15 +651,20 @@ static void analyze(char **argv) {
 
       b_data[i] = RESP_FIXED;
 
-    } else
+    } else {
 
       b_data[i] = RESP_VARIABLE;
+
+    }
 
     /* When all checksums change, flip most significant bit of b_data. */
 
     if (prev_xff != xor_ff && prev_x01 != xor_01 && prev_s10 != sub_10 &&
-        prev_a10 != add_10)
+        prev_a10 != add_10) {
+
       seq_byte ^= 0x80;
+
+    }
 
     b_data[i] |= seq_byte;
 
@@ -620,9 +682,12 @@ static void analyze(char **argv) {
   OKF("Analysis complete. Interesting bits: %0.02f%% of the input file.",
       100.0 - ((double)boring_len * 100) / in_len);
 
-  if (exec_hangs)
+  if (exec_hangs) {
+
     WARNF(cLRD "Encountered %u timeouts - results may be skewed." cRST,
           exec_hangs);
+
+  }
 
   ck_free(b_data);
 
@@ -634,7 +699,7 @@ static void handle_stop_sig(int sig) {
 
   stop_soon = 1;
 
-  if (child_pid > 0) kill(child_pid, SIGKILL);
+  if (child_pid > 0) { kill(child_pid, SIGKILL); }
 
 }
 
@@ -645,7 +710,7 @@ static void set_up_environment(void) {
   u8 *x;
 
   dev_null_fd = open("/dev/null", O_RDWR);
-  if (dev_null_fd < 0) PFATAL("Unable to open /dev/null");
+  if (dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
   if (!prog_in) {
 
@@ -654,7 +719,7 @@ static void set_up_environment(void) {
     if (access(use_dir, R_OK | W_OK | X_OK)) {
 
       use_dir = get_afl_env("TMPDIR");
-      if (!use_dir) use_dir = "/tmp";
+      if (!use_dir) { use_dir = "/tmp"; }
 
     }
 
@@ -668,11 +733,17 @@ static void set_up_environment(void) {
 
   if (x) {
 
-    if (!strstr(x, "abort_on_error=1"))
+    if (!strstr(x, "abort_on_error=1")) {
+
       FATAL("Custom ASAN_OPTIONS set without abort_on_error=1 - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom ASAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -680,12 +751,18 @@ static void set_up_environment(void) {
 
   if (x) {
 
-    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR)))
+    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR))) {
+
       FATAL("Custom MSAN_OPTIONS set without exit_code=" STRINGIFY(
           MSAN_ERROR) " - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom MSAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -713,19 +790,27 @@ static void set_up_environment(void) {
       s32 i, afl_preload_size = strlen(afl_preload);
       for (i = 0; i < afl_preload_size; ++i) {
 
-        if (afl_preload[i] == ',')
+        if (afl_preload[i] == ',') {
+
           PFATAL(
               "Comma (',') is not allowed in AFL_PRELOAD when -Q is "
               "specified!");
 
+        }
+
       }
 
-      if (qemu_preload)
+      if (qemu_preload) {
+
         buf = alloc_printf("%s,LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            qemu_preload, afl_preload, afl_preload);
-      else
+
+      } else {
+
         buf = alloc_printf("LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            afl_preload, afl_preload);
+
+      }
 
       setenv("QEMU_SET_ENV", buf, 1);
 
@@ -820,26 +905,26 @@ int main(int argc, char **argv, char **envp) {
 
   SAYF(cCYA "afl-analyze" VERSION cRST " by Michal Zalewski\n");
 
-  while ((opt = getopt(argc, argv, "+i:f:m:t:eQUWh")) > 0)
+  while ((opt = getopt(argc, argv, "+i:f:m:t:eQUWh")) > 0) {
 
     switch (opt) {
 
       case 'i':
 
-        if (in_file) FATAL("Multiple -i options not supported");
+        if (in_file) { FATAL("Multiple -i options not supported"); }
         in_file = optarg;
         break;
 
       case 'f':
 
-        if (prog_in) FATAL("Multiple -f options not supported");
+        if (prog_in) { FATAL("Multiple -f options not supported"); }
         use_stdin = 0;
         prog_in = optarg;
         break;
 
       case 'e':
 
-        if (edges_only) FATAL("Multiple -e options not supported");
+        if (edges_only) { FATAL("Multiple -e options not supported"); }
         edges_only = 1;
         break;
 
@@ -847,7 +932,7 @@ int main(int argc, char **argv, char **envp) {
 
         u8 suffix = 'M';
 
-        if (mem_limit_given) FATAL("Multiple -m options not supported");
+        if (mem_limit_given) { FATAL("Multiple -m options not supported"); }
         mem_limit_given = 1;
 
         if (!optarg) { FATAL("Wrong usage of -m"); }
@@ -860,24 +945,38 @@ int main(int argc, char **argv, char **envp) {
         }
 
         if (sscanf(optarg, "%llu%c", &mem_limit, &suffix) < 1 ||
-            optarg[0] == '-')
+            optarg[0] == '-') {
+
           FATAL("Bad syntax used for -m");
-
-        switch (suffix) {
-
-          case 'T': mem_limit *= 1024 * 1024; break;
-          case 'G': mem_limit *= 1024; break;
-          case 'k': mem_limit /= 1024; break;
-          case 'M': break;
-
-          default: FATAL("Unsupported suffix or bad syntax for -m");
 
         }
 
-        if (mem_limit < 5) FATAL("Dangerously low value of -m");
+        switch (suffix) {
 
-        if (sizeof(rlim_t) == 4 && mem_limit > 2000)
+          case 'T':
+            mem_limit *= 1024 * 1024;
+            break;
+          case 'G':
+            mem_limit *= 1024;
+            break;
+          case 'k':
+            mem_limit /= 1024;
+            break;
+          case 'M':
+            break;
+
+          default:
+            FATAL("Unsupported suffix or bad syntax for -m");
+
+        }
+
+        if (mem_limit < 5) { FATAL("Dangerously low value of -m"); }
+
+        if (sizeof(rlim_t) == 4 && mem_limit > 2000) {
+
           FATAL("Value of -m out of range on 32-bit systems");
+
+        }
 
       }
 
@@ -885,41 +984,44 @@ int main(int argc, char **argv, char **envp) {
 
       case 't':
 
-        if (timeout_given) FATAL("Multiple -t options not supported");
+        if (timeout_given) { FATAL("Multiple -t options not supported"); }
         timeout_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -t");
+        if (!optarg) { FATAL("Wrong usage of -t"); }
 
         exec_tmout = atoi(optarg);
 
-        if (exec_tmout < 10 || optarg[0] == '-')
+        if (exec_tmout < 10 || optarg[0] == '-') {
+
           FATAL("Dangerously low value of -t");
+
+        }
 
         break;
 
       case 'Q':
 
-        if (qemu_mode) FATAL("Multiple -Q options not supported");
-        if (!mem_limit_given) mem_limit = MEM_LIMIT_QEMU;
+        if (qemu_mode) { FATAL("Multiple -Q options not supported"); }
+        if (!mem_limit_given) { mem_limit = MEM_LIMIT_QEMU; }
 
         qemu_mode = 1;
         break;
 
       case 'U':
 
-        if (unicorn_mode) FATAL("Multiple -U options not supported");
-        if (!mem_limit_given) mem_limit = MEM_LIMIT_UNICORN;
+        if (unicorn_mode) { FATAL("Multiple -U options not supported"); }
+        if (!mem_limit_given) { mem_limit = MEM_LIMIT_UNICORN; }
 
         unicorn_mode = 1;
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
 
-        if (use_wine) FATAL("Multiple -W options not supported");
+        if (use_wine) { FATAL("Multiple -W options not supported"); }
         qemu_mode = 1;
         use_wine = 1;
 
-        if (!mem_limit_given) mem_limit = 0;
+        if (!mem_limit_given) { mem_limit = 0; }
 
         break;
 
@@ -928,11 +1030,14 @@ int main(int argc, char **argv, char **envp) {
         return -1;
         break;
 
-      default: usage(argv[0]);
+      default:
+        usage(argv[0]);
 
     }
 
-  if (optind == argc || !in_file) usage(argv[0]);
+  }
+
+  if (optind == argc || !in_file) { usage(argv[0]); }
 
   map_size = get_map_size();
 
@@ -952,16 +1057,23 @@ int main(int argc, char **argv, char **envp) {
 
   if (qemu_mode) {
 
-    if (use_wine)
+    if (use_wine) {
+
       use_argv =
           get_wine_argv(argv[0], &target_path, argc - optind, argv + optind);
-    else
+
+    } else {
+
       use_argv =
           get_qemu_argv(argv[0], &target_path, argc - optind, argv + optind);
 
-  } else
+    }
+
+  } else {
 
     use_argv = argv + optind;
+
+  }
 
   SAYF("\n");
 
@@ -972,17 +1084,23 @@ int main(int argc, char **argv, char **envp) {
 
   analyze_run_target(use_argv, in_data, in_len, 1);
 
-  if (child_timed_out)
+  if (child_timed_out) {
+
     FATAL("Target binary times out (adjusting -t may help).");
 
-  if (get_afl_env("AFL_SKIP_BIN_CHECK") == NULL && !anything_set())
+  }
+
+  if (get_afl_env("AFL_SKIP_BIN_CHECK") == NULL && !anything_set()) {
+
     FATAL("No instrumentation detected.");
+
+  }
 
   analyze(use_argv);
 
   OKF("We're done here. Have a nice day!\n");
 
-  if (target_path) ck_free(target_path);
+  if (target_path) { ck_free(target_path); }
 
   afl_shm_deinit(&shm);
 

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -101,7 +101,7 @@ void detect_file_args(char **argv, u8 *prog_in, u8 *use_stdin) {
 
     if (aa_loc) {
 
-      if (!prog_in) FATAL("@@ syntax is not supported by this tool.");
+      if (!prog_in) { FATAL("@@ syntax is not supported by this tool."); }
 
       *use_stdin = 0;
 
@@ -198,7 +198,7 @@ char **get_qemu_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
 
     cp = alloc_printf("%s/afl-qemu-trace", tmp);
 
-    if (access(cp, X_OK)) FATAL("Unable to find '%s'", tmp);
+    if (access(cp, X_OK)) { FATAL("Unable to find '%s'", tmp); }
 
     *target_path_p = new_argv[0] = cp;
     return new_argv;
@@ -230,7 +230,7 @@ char **get_qemu_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
 
   if (!access(BIN_PATH "/afl-qemu-trace", X_OK)) {
 
-    if (cp) ck_free(cp);
+    if (cp) { ck_free(cp); }
     *target_path_p = new_argv[0] = ck_strdup(BIN_PATH "/afl-qemu-trace");
 
     return new_argv;
@@ -277,13 +277,13 @@ char **get_wine_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
 
     cp = alloc_printf("%s/afl-qemu-trace", tmp);
 
-    if (access(cp, X_OK)) FATAL("Unable to find '%s'", tmp);
+    if (access(cp, X_OK)) { FATAL("Unable to find '%s'", tmp); }
 
     ck_free(cp);
 
     cp = alloc_printf("%s/afl-wine-trace", tmp);
 
-    if (access(cp, X_OK)) FATAL("Unable to find '%s'", tmp);
+    if (access(cp, X_OK)) { FATAL("Unable to find '%s'", tmp); }
 
     *target_path_p = new_argv[0] = cp;
     return new_argv;
@@ -416,15 +416,22 @@ u8 *find_binary(u8 *fname) {
       ck_free(cur_elem);
 
       if (!stat(target_path, &st) && S_ISREG(st.st_mode) &&
-          (st.st_mode & 0111) && st.st_size >= 4)
+          (st.st_mode & 0111) && st.st_size >= 4) {
+
         break;
+
+      }
 
       ck_free(target_path);
       target_path = NULL;
 
     }
 
-    if (!target_path) FATAL("Program '%s' not found or not executable", fname);
+    if (!target_path) {
+
+      FATAL("Program '%s' not found or not executable", fname);
+
+    }
 
   }
 
@@ -434,7 +441,7 @@ u8 *find_binary(u8 *fname) {
 
 void check_environment_vars(char **envp) {
 
-  if (be_quiet) return;
+  if (be_quiet) { return; }
 
   int   index = 0, found = 0;
   char *env, *val;
@@ -448,23 +455,29 @@ void check_environment_vars(char **envp) {
     } else if (strncmp(env, "AFL_", 4) == 0) {
 
       int i = 0, match = 0;
-      while (match == 0 && afl_environment_variables[i] != NULL)
+      while (match == 0 && afl_environment_variables[i] != NULL) {
+
         if (strncmp(env, afl_environment_variables[i],
                     strlen(afl_environment_variables[i])) == 0 &&
             env[strlen(afl_environment_variables[i])] == '=') {
 
           match = 1;
-          if ((val = getenv(afl_environment_variables[i])) && !*val)
+          if ((val = getenv(afl_environment_variables[i])) && !*val) {
+
             WARNF(
                 "AFL environment variable %s defined but is empty, this can "
                 "lead to unexpected consequences",
                 afl_environment_variables[i]);
+
+          }
 
         } else {
 
           i++;
 
         }
+
+      }
 
       if (match == 0) {
 
@@ -477,7 +490,7 @@ void check_environment_vars(char **envp) {
 
   }
 
-  if (found) sleep(2);
+  if (found) { sleep(2); }
 
 }
 
@@ -485,9 +498,15 @@ char *get_afl_env(char *env) {
 
   char *val;
 
-  if ((val = getenv(env)) != NULL)
-    if (!be_quiet)
+  if ((val = getenv(env)) != NULL) {
+
+    if (!be_quiet) {
+
       OKF("Loaded environment variable %s with value %s", env, val);
+
+    }
+
+  }
 
   return val;
 
@@ -499,7 +518,7 @@ void read_bitmap(u8 *fname, u8 *map, size_t len) {
 
   s32 fd = open(fname, O_RDONLY);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", fname);
+  if (fd < 0) { PFATAL("Unable to open '%s'", fname); }
 
   ck_read(fd, map, len, fname);
 
@@ -906,9 +925,13 @@ u32 get_map_size() {
   if ((ptr = getenv("AFL_MAP_SIZE")) || (ptr = getenv("AFL_MAPSIZE"))) {
 
     map_size = atoi(ptr);
-    if (map_size < 8 || map_size > (1 << 29))
+    if (map_size < 8 || map_size > (1 << 29)) {
+
       FATAL("illegal AFL_MAP_SIZE %u, must be between 2^3 and 2^30", map_size);
-    if (map_size % 8) map_size = (((map_size >> 3) + 1) << 3);
+
+    }
+
+    if (map_size % 8) { map_size = (((map_size >> 3) + 1) << 3); }
 
   }
 

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -128,12 +128,16 @@ static void afl_fauxsrv_execv(afl_forkserver_t *fsrv, char **argv) {
   unsigned char tmp[4] = {0, 0, 0, 0};
   pid_t         child_pid = -1;
 
-  if (!be_quiet) ACTF("Using Fauxserver:");
+  if (!be_quiet) { ACTF("Using Fauxserver:"); }
 
   /* Phone home and tell the parent that we're OK. If parent isn't there,
      assume we're not running in forkserver mode and just execute program. */
 
-  if (write(FORKSRV_FD + 1, tmp, 4) != 4) abort();  // TODO: Abort?
+  if (write(FORKSRV_FD + 1, tmp, 4) != 4) {
+
+    abort();  // TODO: Abort?
+
+  }
 
   void (*old_sigchld_handler)(int) = signal(SIGCHLD, SIG_DFL);
 
@@ -144,13 +148,13 @@ static void afl_fauxsrv_execv(afl_forkserver_t *fsrv, char **argv) {
 
     /* Wait for parent by reading from the pipe. Exit if read fails. */
 
-    if (read(FORKSRV_FD, &was_killed, 4) != 4) exit(0);
+    if (read(FORKSRV_FD, &was_killed, 4) != 4) { exit(0); }
 
     /* Create a clone of our process. */
 
     child_pid = fork();
 
-    if (child_pid < 0) PFATAL("Fork failed");
+    if (child_pid < 0) { PFATAL("Fork failed"); }
 
     /* In child process: close fds, resume execution. */
 
@@ -177,7 +181,7 @@ static void afl_fauxsrv_execv(afl_forkserver_t *fsrv, char **argv) {
 
     /* In parent process: write PID to AFL. */
 
-    if (write(FORKSRV_FD + 1, &child_pid, 4) != 4) exit(0);
+    if (write(FORKSRV_FD + 1, &child_pid, 4) != 4) { exit(0); }
 
     /* after child exited, get and relay exit status to parent through waitpid.
      */
@@ -191,7 +195,7 @@ static void afl_fauxsrv_execv(afl_forkserver_t *fsrv, char **argv) {
 
     /* Relay wait status to AFL pipe, then loop back. */
 
-    if (write(FORKSRV_FD + 1, &status, 4) != 4) exit(0);
+    if (write(FORKSRV_FD + 1, &status, 4) != 4) { exit(0); }
 
   }
 
@@ -212,25 +216,28 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
   int status;
   s32 rlen;
 
-  if (!be_quiet) ACTF("Spinning up the fork server...");
+  if (!be_quiet) { ACTF("Spinning up the fork server..."); }
 
   if (fsrv->use_fauxsrv) {
 
     /* TODO: Come up with sone nice way to initalize this all */
 
-    if (fsrv->init_child_func != fsrv_exec_child)
+    if (fsrv->init_child_func != fsrv_exec_child) {
+
       FATAL("Different forkserver not compatible with fauxserver");
+
+    }
 
     fsrv->init_child_func = afl_fauxsrv_execv;
 
   }
 
-  if (pipe(st_pipe) || pipe(ctl_pipe)) PFATAL("pipe() failed");
+  if (pipe(st_pipe) || pipe(ctl_pipe)) { PFATAL("pipe() failed"); }
 
   fsrv->last_run_timed_out = 0;
   fsrv->fsrv_pid = fork();
 
-  if (fsrv->fsrv_pid < 0) PFATAL("fork() failed");
+  if (fsrv->fsrv_pid < 0) { PFATAL("fork() failed"); }
 
   if (!fsrv->fsrv_pid) {
 
@@ -295,8 +302,8 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     /* Set up control and status pipes, close the unneeded original fds. */
 
-    if (dup2(ctl_pipe[0], FORKSRV_FD) < 0) PFATAL("dup2() failed");
-    if (dup2(st_pipe[1], FORKSRV_FD + 1) < 0) PFATAL("dup2() failed");
+    if (dup2(ctl_pipe[0], FORKSRV_FD) < 0) { PFATAL("dup2() failed"); }
+    if (dup2(st_pipe[1], FORKSRV_FD + 1) < 0) { PFATAL("dup2() failed"); }
 
     close(ctl_pipe[0]);
     close(ctl_pipe[1]);
@@ -308,12 +315,12 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 #ifndef HAVE_ARC4RANDOM
     close(fsrv->dev_urandom_fd);
 #endif
-    if (fsrv->plot_file != NULL) fclose(fsrv->plot_file);
+    if (fsrv->plot_file != NULL) { fclose(fsrv->plot_file); }
 
     /* This should improve performance a bit, since it stops the linker from
        doing extra work post-fork(). */
 
-    if (!getenv("LD_BIND_LAZY")) setenv("LD_BIND_NOW", "1", 0);
+    if (!getenv("LD_BIND_LAZY")) { setenv("LD_BIND_NOW", "1", 0); }
 
     /* Set sane defaults for ASAN if nothing else specified. */
 
@@ -391,17 +398,20 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
   if (rlen == 4) {
 
-    if (!be_quiet) OKF("All right - fork server is up.");
+    if (!be_quiet) { OKF("All right - fork server is up."); }
 
     if ((status & FS_OPT_ENABLED) == FS_OPT_ENABLED) {
 
-      if (!be_quiet && getenv("AFL_DEBUG"))
+      if (!be_quiet && getenv("AFL_DEBUG")) {
+
         ACTF("Extended forkserver functions received (%08x).", status);
+
+      }
 
       if ((status & FS_OPT_SNAPSHOT) == FS_OPT_SNAPSHOT) {
 
         fsrv->snapshot = 1;
-        if (!be_quiet) ACTF("Using SNAPSHOT feature.");
+        if (!be_quiet) { ACTF("Using SNAPSHOT feature."); }
 
       }
 
@@ -409,7 +419,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         u32 tmp_map_size = FS_OPT_GET_MAPSIZE(status);
 
-        if (!fsrv->map_size) fsrv->map_size = MAP_SIZE;
+        if (!fsrv->map_size) { fsrv->map_size = MAP_SIZE; }
 
         if (unlikely(tmp_map_size % 8)) {
 
@@ -419,13 +429,17 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         }
 
-        if (!be_quiet) ACTF("Target map size: %u", tmp_map_size);
-        if (tmp_map_size > fsrv->map_size)
+        if (!be_quiet) { ACTF("Target map size: %u", tmp_map_size); }
+        if (tmp_map_size > fsrv->map_size) {
+
           FATAL(
               "Target's coverage map size of %u is larger than the one this "
               "afl++ is set with (%u) (change MAP_SIZE_POW2 in config.h and "
               "recompile or set AFL_MAP_SIZE)\n",
               tmp_map_size, fsrv->map_size);
+
+        }
+
         fsrv->map_size = tmp_map_size;
 
       }
@@ -436,26 +450,43 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
           // this is not afl-fuzz - we deny and return
           status = (0xffffffff ^ (FS_OPT_ENABLED | FS_OPT_AUTODICT));
-          if (write(fsrv->fsrv_ctl_fd, &status, 4) != 4)
+          if (write(fsrv->fsrv_ctl_fd, &status, 4) != 4) {
+
             FATAL("Writing to forkserver failed.");
+
+          }
+
           return;
 
         }
 
-        if (!be_quiet) ACTF("Using AUTODICT feature.");
+        if (!be_quiet) { ACTF("Using AUTODICT feature."); }
         status = (FS_OPT_ENABLED | FS_OPT_AUTODICT);
-        if (write(fsrv->fsrv_ctl_fd, &status, 4) != 4)
+        if (write(fsrv->fsrv_ctl_fd, &status, 4) != 4) {
+
           FATAL("Writing to forkserver failed.");
-        if (read(fsrv->fsrv_st_fd, &status, 4) != 4)
+
+        }
+
+        if (read(fsrv->fsrv_st_fd, &status, 4) != 4) {
+
           FATAL("Reading from forkserver failed.");
 
-        if (status < 2 || (u32)status > 0xffffff)
+        }
+
+        if (status < 2 || (u32)status > 0xffffff) {
+
           FATAL("Dictionary has an illegal size: %d", status);
+
+        }
 
         u32 len = status, offset = 0, count = 0;
         u8 *dict = ck_alloc(len);
-        if (dict == NULL)
+        if (dict == NULL) {
+
           FATAL("Could not allocate %u bytes of autodictionary memory", len);
+
+        }
 
         while (len != 0) {
 
@@ -486,7 +517,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         }
 
-        if (!be_quiet) ACTF("Loaded %u autodictionary entries", count);
+        if (!be_quiet) { ACTF("Loaded %u autodictionary entries", count); }
         ck_free(dict);
 
       }
@@ -497,10 +528,13 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
   }
 
-  if (fsrv->last_run_timed_out)
+  if (fsrv->last_run_timed_out) {
+
     FATAL("Timeout while initializing fork server (adjusting -t may help)");
 
-  if (waitpid(fsrv->fsrv_pid, &status, 0) <= 0) PFATAL("waitpid() failed");
+  }
+
+  if (waitpid(fsrv->fsrv_pid, &status, 0) <= 0) { PFATAL("waitpid() failed"); }
 
   if (WIFSIGNALED(status)) {
 
@@ -580,8 +614,11 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
   }
 
-  if (*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG)
+  if (*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG) {
+
     FATAL("Unable to execute target application ('%s')", argv[0]);
+
+  }
 
   if (fsrv->mem_limit && fsrv->mem_limit < 500 && fsrv->uses_asan) {
 
@@ -651,7 +688,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
 static void afl_fsrv_kill(afl_forkserver_t *fsrv) {
 
-  if (fsrv->child_pid > 0) kill(fsrv->child_pid, SIGKILL);
+  if (fsrv->child_pid > 0) { kill(fsrv->child_pid, SIGKILL); }
   if (fsrv->fsrv_pid > 0) {
 
     kill(fsrv->fsrv_pid, SIGKILL);
@@ -680,7 +717,7 @@ void afl_fsrv_write_to_testcase(afl_forkserver_t *fsrv, u8 *buf, size_t len) {
 
     }
 
-    if (fd < 0) PFATAL("Unable to create '%s'", fsrv->out_file);
+    if (fd < 0) { PFATAL("Unable to create '%s'", fsrv->out_file); }
 
   } else {
 
@@ -692,7 +729,7 @@ void afl_fsrv_write_to_testcase(afl_forkserver_t *fsrv, u8 *buf, size_t len) {
 
   if (!fsrv->out_file) {
 
-    if (ftruncate(fd, len)) PFATAL("ftruncate() failed");
+    if (ftruncate(fd, len)) { PFATAL("ftruncate() failed"); }
     lseek(fd, 0, SEEK_SET);
 
   } else {
@@ -727,7 +764,7 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
   if ((res = write(fsrv->fsrv_ctl_fd, &fsrv->last_run_timed_out, 4)) != 4) {
 
-    if (*stop_soon_p) return 0;
+    if (*stop_soon_p) { return 0; }
     RPFATAL(res, "Unable to request new process from fork server (OOM?)");
 
   }
@@ -736,12 +773,12 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
   if ((res = read(fsrv->fsrv_st_fd, &fsrv->child_pid, 4)) != 4) {
 
-    if (*stop_soon_p) return 0;
+    if (*stop_soon_p) { return 0; }
     RPFATAL(res, "Unable to request new process from fork server (OOM?)");
 
   }
 
-  if (fsrv->child_pid <= 0) FATAL("Fork server is misbehaving (OOM?)");
+  if (fsrv->child_pid <= 0) { FATAL("Fork server is misbehaving (OOM?)"); }
 
   exec_ms = read_timed(fsrv->fsrv_st_fd, &status, 4, timeout, stop_soon_p);
 
@@ -752,13 +789,13 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
     kill(fsrv->child_pid, SIGKILL);
     fsrv->last_run_timed_out = 1;
-    if (read(fsrv->fsrv_st_fd, &status, 4) < 4) exec_ms = 0;
+    if (read(fsrv->fsrv_st_fd, &status, 4) < 4) { exec_ms = 0; }
 
   }
 
   if (!exec_ms) {
 
-    if (*stop_soon_p) return 0;
+    if (*stop_soon_p) { return 0; }
     SAYF("\n" cLRD "[-] " cRST
          "Unable to communicate with fork server. Some possible reasons:\n\n"
          "    - You've run out of memory. Use -m to increase the the memory "
@@ -784,7 +821,7 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
   }
 
-  if (!WIFSTOPPED(status)) fsrv->child_pid = 0;
+  if (!WIFSTOPPED(status)) { fsrv->child_pid = 0; }
 
   fsrv->total_execs++;
 
@@ -800,8 +837,11 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
     fsrv->last_kill_signal = WTERMSIG(status);
 
-    if (fsrv->last_run_timed_out && fsrv->last_kill_signal == SIGKILL)
+    if (fsrv->last_run_timed_out && fsrv->last_kill_signal == SIGKILL) {
+
       return FSRV_RUN_TMOUT;
+
+    }
 
     return FSRV_RUN_CRASH;
 

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -35,13 +35,13 @@ void write_bitmap(afl_state_t *afl) {
   u8  fname[PATH_MAX];
   s32 fd;
 
-  if (!afl->bitmap_changed) return;
+  if (!afl->bitmap_changed) { return; }
   afl->bitmap_changed = 0;
 
   snprintf(fname, PATH_MAX, "%s/fuzz_bitmap", afl->out_dir);
   fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", fname);
+  if (fd < 0) { PFATAL("Unable to open '%s'", fname); }
 
   ck_write(fd, afl->virgin_bits, afl->fsrv.map_size, fname);
 
@@ -102,10 +102,15 @@ u8 has_new_bits(afl_state_t *afl, u8 *virgin_map) {
             (cur[1] && vir[1] == 0xff) || (cur[2] && vir[2] == 0xff) ||
             (cur[3] && vir[3] == 0xff) || (cur[4] && vir[4] == 0xff) ||
             (cur[5] && vir[5] == 0xff) || (cur[6] && vir[6] == 0xff) ||
-            (cur[7] && vir[7] == 0xff))
+            (cur[7] && vir[7] == 0xff)) {
+
           ret = 2;
-        else
+
+        } else {
+
           ret = 1;
+
+        }
 
 #else
 
@@ -129,8 +134,11 @@ u8 has_new_bits(afl_state_t *afl, u8 *virgin_map) {
 
   }
 
-  if (unlikely(ret) && likely(virgin_map == afl->virgin_bits))
+  if (unlikely(ret) && likely(virgin_map == afl->virgin_bits)) {
+
     afl->bitmap_changed = 1;
+
+  }
 
   return ret;
 
@@ -183,11 +191,11 @@ u32 count_bytes(afl_state_t *afl, u8 *mem) {
 
     u32 v = *(ptr++);
 
-    if (!v) continue;
-    if (v & 0x000000ff) ++ret;
-    if (v & 0x0000ff00) ++ret;
-    if (v & 0x00ff0000) ++ret;
-    if (v & 0xff000000) ++ret;
+    if (!v) { continue; }
+    if (v & 0x000000ff) { ++ret; }
+    if (v & 0x0000ff00) { ++ret; }
+    if (v & 0x00ff0000) { ++ret; }
+    if (v & 0xff000000) { ++ret; }
 
   }
 
@@ -211,11 +219,11 @@ u32 count_non_255_bytes(afl_state_t *afl, u8 *mem) {
     /* This is called on the virgin bitmap, so optimize for the most likely
        case. */
 
-    if (v == 0xffffffff) continue;
-    if ((v & 0x000000ff) != 0x000000ff) ++ret;
-    if ((v & 0x0000ff00) != 0x0000ff00) ++ret;
-    if ((v & 0x00ff0000) != 0x00ff0000) ++ret;
-    if ((v & 0xff000000) != 0xff000000) ++ret;
+    if (v == 0xffffffff) { continue; }
+    if ((v & 0x000000ff) != 0x000000ff) { ++ret; }
+    if ((v & 0x0000ff00) != 0x0000ff00) { ++ret; }
+    if ((v & 0x00ff0000) != 0x00ff0000) { ++ret; }
+    if ((v & 0xff000000) != 0xff000000) { ++ret; }
 
   }
 
@@ -257,9 +265,11 @@ void simplify_trace(afl_state_t *afl, u64 *mem) {
       mem8[6] = simplify_lookup[mem8[6]];
       mem8[7] = simplify_lookup[mem8[7]];
 
-    } else
+    } else {
 
       *mem = 0x0101010101010101ULL;
+
+    }
 
     ++mem;
 
@@ -322,10 +332,16 @@ void init_count_class16(void) {
 
   u32 b1, b2;
 
-  for (b1 = 0; b1 < 256; b1++)
-    for (b2 = 0; b2 < 256; b2++)
+  for (b1 = 0; b1 < 256; b1++) {
+
+    for (b2 = 0; b2 < 256; b2++) {
+
       count_class_lookup16[(b1 << 8) + b2] =
           (count_class_lookup8[b1] << 8) | count_class_lookup8[b2];
+
+    }
+
+  }
 
 }
 
@@ -397,7 +413,7 @@ void minimize_bits(afl_state_t *afl, u8 *dst, u8 *src) {
 
   while (i < afl->fsrv.map_size) {
 
-    if (*(src++)) dst[i >> 3] |= 1 << (i & 7);
+    if (*(src++)) { dst[i >> 3] |= 1 << (i & 7); }
     ++i;
 
   }
@@ -423,8 +439,11 @@ u8 *describe_op(afl_state_t *afl, u8 hnb) {
 
     sprintf(ret + strlen(ret), ",time:%llu", get_cur_time() - afl->start_time);
 
-    if (afl->splicing_with >= 0)
+    if (afl->splicing_with >= 0) {
+
       sprintf(ret + strlen(ret), "+%06d", afl->splicing_with);
+
+    }
 
     sprintf(ret + strlen(ret), ",op:%s", afl->stage_short);
 
@@ -432,18 +451,23 @@ u8 *describe_op(afl_state_t *afl, u8 hnb) {
 
       sprintf(ret + strlen(ret), ",pos:%d", afl->stage_cur_byte);
 
-      if (afl->stage_val_type != STAGE_VAL_NONE)
+      if (afl->stage_val_type != STAGE_VAL_NONE) {
+
         sprintf(ret + strlen(ret), ",val:%s%+d",
                 (afl->stage_val_type == STAGE_VAL_BE) ? "be:" : "",
                 afl->stage_cur_val);
 
-    } else
+      }
+
+    } else {
 
       sprintf(ret + strlen(ret), ",rep:%d", afl->stage_cur_val);
 
+    }
+
   }
 
-  if (hnb == 2) strcat(ret, ",+cov");
+  if (hnb == 2) { strcat(ret, ",+cov"); }
 
   return ret;
 
@@ -467,7 +491,7 @@ static void write_crash_readme(afl_state_t *afl) {
 
   /* Do not die on errors here - that would be impolite. */
 
-  if (unlikely(fd < 0)) return;
+  if (unlikely(fd < 0)) { return; }
 
   f = fdopen(fd, "w");
 
@@ -512,7 +536,7 @@ static void write_crash_readme(afl_state_t *afl) {
 
 u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
-  if (unlikely(len == 0)) return 0;
+  if (unlikely(len == 0)) { return 0; }
 
   u8 *queue_fn = "";
   u8  hnb = '\0';
@@ -545,7 +569,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
     if (!(hnb = has_new_bits(afl, afl->virgin_bits))) {
 
-      if (unlikely(afl->crash_mode)) ++afl->total_crashes;
+      if (unlikely(afl->crash_mode)) { ++afl->total_crashes; }
       return 0;
 
     }
@@ -578,11 +602,14 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
     res = calibrate_case(afl, afl->queue_top, mem, afl->queue_cycle - 1, 0);
 
-    if (unlikely(res == FSRV_RUN_ERROR))
+    if (unlikely(res == FSRV_RUN_ERROR)) {
+
       FATAL("Unable to execute target application");
 
+    }
+
     fd = open(queue_fn, O_WRONLY | O_CREAT | O_EXCL, 0600);
-    if (unlikely(fd < 0)) PFATAL("Unable to create '%s'", queue_fn);
+    if (unlikely(fd < 0)) { PFATAL("Unable to create '%s'", queue_fn); }
     ck_write(fd, mem, len, queue_fn);
     close(fd);
 
@@ -601,7 +628,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
       ++afl->total_tmouts;
 
-      if (afl->unique_hangs >= KEEP_UNIQUE_HANG) return keeping;
+      if (afl->unique_hangs >= KEEP_UNIQUE_HANG) { return keeping; }
 
       if (likely(!afl->dumb_mode)) {
 
@@ -611,7 +638,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
         simplify_trace(afl, (u32 *)afl->fsrv.trace_bits);
 #endif                                                     /* ^WORD_SIZE_64 */
 
-        if (!has_new_bits(afl, afl->virgin_tmout)) return keeping;
+        if (!has_new_bits(afl, afl->virgin_tmout)) { return keeping; }
 
       }
 
@@ -631,9 +658,13 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
            timeout actually uncovers a crash. Make sure we don't discard it if
            so. */
 
-        if (!afl->stop_soon && new_fault == FSRV_RUN_CRASH) goto keep_as_crash;
+        if (!afl->stop_soon && new_fault == FSRV_RUN_CRASH) {
 
-        if (afl->stop_soon || new_fault != FSRV_RUN_TMOUT) return keeping;
+          goto keep_as_crash;
+
+        }
+
+        if (afl->stop_soon || new_fault != FSRV_RUN_TMOUT) { return keeping; }
 
       }
 
@@ -665,7 +696,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
       ++afl->total_crashes;
 
-      if (afl->unique_crashes >= KEEP_UNIQUE_CRASH) return keeping;
+      if (afl->unique_crashes >= KEEP_UNIQUE_CRASH) { return keeping; }
 
       if (likely(!afl->dumb_mode)) {
 
@@ -675,11 +706,11 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
         simplify_trace(afl, (u32 *)afl->fsrv.trace_bits);
 #endif                                                     /* ^WORD_SIZE_64 */
 
-        if (!has_new_bits(afl, afl->virgin_crash)) return keeping;
+        if (!has_new_bits(afl, afl->virgin_crash)) { return keeping; }
 
       }
 
-      if (unlikely(!afl->unique_crashes)) write_crash_readme(afl);
+      if (unlikely(!afl->unique_crashes)) { write_crash_readme(afl); }
 
 #ifndef SIMPLE_FILES
 
@@ -715,9 +746,11 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
       break;
 
-    case FSRV_RUN_ERROR: FATAL("Unable to execute target application");
+    case FSRV_RUN_ERROR:
+      FATAL("Unable to execute target application");
 
-    default: return keeping;
+    default:
+      return keeping;
 
   }
 
@@ -725,7 +758,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
      test case, too. */
 
   fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, 0600);
-  if (unlikely(fd < 0)) PFATAL("Unable to create '%s'", fn);
+  if (unlikely(fd < 0)) { PFATAL("Unable to create '%s'", fn); }
   ck_write(fd, mem, len, fn);
   close(fd);
 

--- a/src/afl-fuzz-cmplog.c
+++ b/src/afl-fuzz-cmplog.c
@@ -37,8 +37,11 @@ void cmplog_exec_child(afl_forkserver_t *fsrv, char **argv) {
 
   setenv("___AFL_EINS_ZWEI_POLIZEI___", "1", 1);
 
-  if (!fsrv->qemu_mode && argv[0] != fsrv->cmplog_binary)
+  if (!fsrv->qemu_mode && argv[0] != fsrv->cmplog_binary) {
+
     argv[0] = fsrv->cmplog_binary;
+
+  }
 
   execv(argv[0], argv);
 
@@ -54,7 +57,7 @@ u8 common_fuzz_cmplog_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
     size_t post_len =
         afl->post_handler(afl->post_data, out_buf, len, &post_buf);
-    if (!post_buf || !post_len) return 0;
+    if (!post_buf || !post_len) { return 0; }
     out_buf = post_buf;
     len = post_len;
 
@@ -64,7 +67,7 @@ u8 common_fuzz_cmplog_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
   fault = fuzz_run_target(afl, &afl->cmplog_fsrv, afl->fsrv.exec_tmout);
 
-  if (afl->stop_soon) return 1;
+  if (afl->stop_soon) { return 1; }
 
   if (fault == FSRV_RUN_TMOUT) {
 
@@ -75,9 +78,11 @@ u8 common_fuzz_cmplog_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
     }
 
-  } else
+  } else {
 
     afl->subseq_tmouts = 0;
+
+  }
 
   /* Users can hit us with SIGUSR1 to request the current input
      to be abandoned. */

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -42,7 +42,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
   u8  cpu_used[4096] = {0};
   u32 i;
 
-  if (afl->cpu_core_count < 2) return;
+  if (afl->cpu_core_count < 2) { return; }
 
   if (afl->afl_env.afl_no_affinity) {
 
@@ -82,7 +82,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
     u8    tmp[MAX_LINE];
     u8    has_vmsize = 0;
 
-    if (!isdigit(de->d_name[0])) continue;
+    if (!isdigit(de->d_name[0])) { continue; }
 
     snprintf(fn, PATH_MAX, "/proc/%s/status", de->d_name);
 
@@ -94,7 +94,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
 
       /* Processes without VmSize are probably kernel tasks. */
 
-      if (!strncmp(tmp, "VmSize:\t", 8)) has_vmsize = 1;
+      if (!strncmp(tmp, "VmSize:\t", 8)) { has_vmsize = 1; }
 
       if (!strncmp(tmp, "Cpus_allowed_list:\t", 19) && !strchr(tmp, '-') &&
           !strchr(tmp, ',') && sscanf(tmp + 19, "%u", &hval) == 1 &&
@@ -190,8 +190,12 @@ void bind_to_free_cpu(afl_state_t *afl) {
 
   try:
 #ifndef __ANDROID__
-    for (i = cpu_start; i < afl->cpu_core_count; i++)
-      if (!cpu_used[i]) break;
+    for (i = cpu_start; i < afl->cpu_core_count; i++) {
+
+      if (!cpu_used[i]) { break; }
+
+    }
+
   if (i == afl->cpu_core_count) {
 
 #else
@@ -229,8 +233,12 @@ void bind_to_free_cpu(afl_state_t *afl) {
 #if defined(__linux__)
   if (sched_setaffinity(0, sizeof(c), &c)) {
 
-    if (cpu_start == afl->cpu_core_count)
+    if (cpu_start == afl->cpu_core_count) {
+
       PFATAL("sched_setaffinity failed for CPU %d, exit", i);
+
+    }
+
     WARNF("sched_setaffinity failed to CPU %d, trying next CPU", i);
     cpu_start++;
     goto try
@@ -282,29 +290,36 @@ void setup_post(afl_state_t *afl) {
   u32   tlen = 6;
   strncpy(tbuf, "hello", tlen);
 
-  if (!fn) return;
+  if (!fn) { return; }
 
   ACTF("Loading postprocessor from '%s'...", fn);
 
   dh = dlopen(fn, RTLD_NOW);
-  if (!dh) FATAL("%s", dlerror());
+  if (!dh) { FATAL("%s", dlerror()); }
 
   afl->post_handler = dlsym(dh, "afl_postprocess");
-  if (!afl->post_handler) FATAL("Symbol 'afl_postprocess' not found.");
+  if (!afl->post_handler) { FATAL("Symbol 'afl_postprocess' not found."); }
   afl->post_init = dlsym(dh, "afl_postprocess_init");
-  if (!afl->post_init) FATAL("Symbol 'afl_postprocess_init' not found.");
+  if (!afl->post_init) { FATAL("Symbol 'afl_postprocess_init' not found."); }
   afl->post_deinit = dlsym(dh, "afl_postprocess_deinit");
-  if (!afl->post_deinit) FATAL("Symbol 'afl_postprocess_deinit' not found.");
+  if (!afl->post_deinit) {
+
+    FATAL("Symbol 'afl_postprocess_deinit' not found.");
+
+  }
 
   /* Do a quick test. It's better to segfault now than later =) */
 
   u8 *post_buf = NULL;
   afl->post_data = afl->post_init(afl);
-  if (!afl->post_data) FATAL("Could not initialize post handler.");
+  if (!afl->post_data) { FATAL("Could not initialize post handler."); }
 
   size_t post_len = afl->post_handler(afl->post_data, tbuf, tlen, &post_buf);
-  if (!post_len || !post_buf)
+  if (!post_len || !post_buf) {
+
     SAYF("Empty return in test post handler for buf=\"hello\\0\".");
+
+  }
 
   OKF("Postprocessor installed successfully.");
 
@@ -342,10 +357,15 @@ void read_testcases(afl_state_t *afl) {
   /* Auto-detect non-in-place resumption attempts. */
 
   fn1 = alloc_printf("%s/queue", afl->in_dir);
-  if (!access(fn1, F_OK))
+  if (!access(fn1, F_OK)) {
+
     afl->in_dir = fn1;
-  else
+
+  } else {
+
     ck_free(fn1);
+
+  }
 
   ACTF("Scanning '%s'...", afl->in_dir);
 
@@ -357,7 +377,7 @@ void read_testcases(afl_state_t *afl) {
 
   if (nl_cnt < 0) {
 
-    if (errno == ENOENT || errno == ENOTDIR)
+    if (errno == ENOENT || errno == ENOTDIR) {
 
       SAYF("\n" cLRD "[-] " cRST
            "The input directory does not seem to be valid - try again. The "
@@ -367,6 +387,8 @@ void read_testcases(afl_state_t *afl) {
            "    or so. The cases must be stored as regular files directly in "
            "the input\n"
            "    directory.\n");
+
+    }
 
     PFATAL("Unable to open '%s'", afl->in_dir);
 
@@ -392,8 +414,11 @@ void read_testcases(afl_state_t *afl) {
 
     free(nl[i]);                                             /* not tracked */
 
-    if (lstat(fn2, &st) || access(fn2, R_OK))
+    if (lstat(fn2, &st) || access(fn2, R_OK)) {
+
       PFATAL("Unable to access '%s'", fn2);
+
+    }
 
     /* This also takes care of . and .. */
 
@@ -404,17 +429,20 @@ void read_testcases(afl_state_t *afl) {
 
     }
 
-    if (st.st_size > MAX_FILE)
+    if (st.st_size > MAX_FILE) {
+
       FATAL("Test case '%s' is too big (%s, limit is %s)", fn2,
             stringify_mem_size(val_buf[0], sizeof(val_buf[0]), st.st_size),
             stringify_mem_size(val_buf[1], sizeof(val_buf[1]), MAX_FILE));
+
+    }
 
     /* Check for metadata that indicates that deterministic fuzzing
        is complete for this entry. We don't want to repeat deterministic
        fuzzing when resuming aborted scans, because it would be pointless
        and probably very time-consuming. */
 
-    if (!access(dfn, F_OK)) passed_det = 1;
+    if (!access(dfn, F_OK)) { passed_det = 1; }
 
     add_to_queue(afl, fn2, st.st_size, passed_det);
 
@@ -462,29 +490,35 @@ void perform_dry_run(afl_state_t *afl) {
     ACTF("Attempting dry run with '%s'...", fn);
 
     fd = open(q->fname, O_RDONLY);
-    if (fd < 0) PFATAL("Unable to open '%s'", q->fname);
+    if (fd < 0) { PFATAL("Unable to open '%s'", q->fname); }
 
     use_mem = ck_alloc_nozero(q->len);
 
-    if (read(fd, use_mem, q->len) != q->len)
+    if (read(fd, use_mem, q->len) != q->len) {
+
       FATAL("Short read from '%s'", q->fname);
+
+    }
 
     close(fd);
 
     res = calibrate_case(afl, q, use_mem, 0, 1);
     ck_free(use_mem);
 
-    if (afl->stop_soon) return;
+    if (afl->stop_soon) { return; }
 
-    if (res == afl->crash_mode || res == FSRV_RUN_NOBITS)
+    if (res == afl->crash_mode || res == FSRV_RUN_NOBITS) {
+
       SAYF(cGRA "    len = %u, map size = %u, exec speed = %llu us\n" cRST,
            q->len, q->bitmap_size, q->exec_us);
+
+    }
 
     switch (res) {
 
       case FSRV_RUN_OK:
 
-        if (afl->crash_mode) FATAL("Test case '%s' does *NOT* crash", fn);
+        if (afl->crash_mode) { FATAL("Test case '%s' does *NOT* crash", fn); }
 
         break;
 
@@ -539,7 +573,7 @@ void perform_dry_run(afl_state_t *afl) {
 
       case FSRV_RUN_CRASH:
 
-        if (afl->crash_mode) break;
+        if (afl->crash_mode) { break; }
 
         if (skip_crashes) {
 
@@ -635,20 +669,28 @@ void perform_dry_run(afl_state_t *afl) {
 
         FATAL("Unable to execute target application ('%s')", afl->argv[0]);
 
-      case FSRV_RUN_NOINST: FATAL("No instrumentation detected");
+      case FSRV_RUN_NOINST:
+        FATAL("No instrumentation detected");
 
       case FSRV_RUN_NOBITS:
 
         ++afl->useless_at_start;
 
-        if (!afl->in_bitmap && !afl->shuffle_queue)
+        if (!afl->in_bitmap && !afl->shuffle_queue) {
+
           WARNF("No new instrumentation output, test case may be useless.");
+
+        }
 
         break;
 
     }
 
-    if (q->var_behavior) WARNF("Instrumentation output varies across runs.");
+    if (q->var_behavior) {
+
+      WARNF("Instrumentation output varies across runs.");
+
+    }
 
     q = q->next;
 
@@ -656,16 +698,22 @@ void perform_dry_run(afl_state_t *afl) {
 
   if (cal_failures) {
 
-    if (cal_failures == afl->queued_paths)
+    if (cal_failures == afl->queued_paths) {
+
       FATAL("All test cases time out%s, giving up!",
             skip_crashes ? " or crash" : "");
+
+    }
 
     WARNF("Skipped %u test cases (%0.02f%%) due to timeouts%s.", cal_failures,
           ((double)cal_failures) * 100 / afl->queued_paths,
           skip_crashes ? " or crashes" : "");
 
-    if (cal_failures * 5 > afl->queued_paths)
+    if (cal_failures * 5 > afl->queued_paths) {
+
       WARNF(cLRD "High percentage of rejected test cases, check settings!");
+
+    }
 
   }
 
@@ -681,20 +729,23 @@ static void link_or_copy(u8 *old_path, u8 *new_path) {
   s32 sfd, dfd;
   u8 *tmp;
 
-  if (!i) return;
+  if (!i) { return; }
 
   sfd = open(old_path, O_RDONLY);
-  if (sfd < 0) PFATAL("Unable to open '%s'", old_path);
+  if (sfd < 0) { PFATAL("Unable to open '%s'", old_path); }
 
   dfd = open(new_path, O_WRONLY | O_CREAT | O_EXCL, 0600);
-  if (dfd < 0) PFATAL("Unable to create '%s'", new_path);
+  if (dfd < 0) { PFATAL("Unable to create '%s'", new_path); }
 
   tmp = ck_alloc(64 * 1024);
 
-  while ((i = read(sfd, tmp, 64 * 1024)) > 0)
+  while ((i = read(sfd, tmp, 64 * 1024)) > 0) {
+
     ck_write(dfd, tmp, i, new_path);
 
-  if (i < 0) PFATAL("read() failed");
+  }
+
+  if (i < 0) { PFATAL("read() failed"); }
 
   ck_free(tmp);
   close(sfd);
@@ -717,10 +768,15 @@ void pivot_inputs(afl_state_t *afl) {
     u8 *nfn, *rsl = strrchr(q->fname, '/');
     u32 orig_id;
 
-    if (!rsl)
+    if (!rsl) {
+
       rsl = q->fname;
-    else
+
+    } else {
+
       ++rsl;
+
+    }
 
     /* If the original file name conforms to the syntax and the recorded
        ID matches the one we'd assign, just use the original file name.
@@ -743,11 +799,15 @@ void pivot_inputs(afl_state_t *afl) {
       if (src_str && sscanf(src_str + 1, "%06u", &src_id) == 1) {
 
         struct queue_entry *s = afl->queue;
-        while (src_id-- && s)
-          s = s->next;
-        if (s) q->depth = s->depth + 1;
+        while (src_id-- && s) {
 
-        if (afl->max_depth < q->depth) afl->max_depth = q->depth;
+          s = s->next;
+
+        }
+
+        if (s) { q->depth = s->depth + 1; }
+
+        if (afl->max_depth < q->depth) { afl->max_depth = q->depth; }
 
       }
 
@@ -760,10 +820,16 @@ void pivot_inputs(afl_state_t *afl) {
 
       u8 *use_name = strstr(rsl, ",orig:");
 
-      if (use_name)
+      if (use_name) {
+
         use_name += 6;
-      else
+
+      } else {
+
         use_name = rsl;
+
+      }
+
       nfn = alloc_printf("%s/queue/id:%06u,time:0,orig:%s", afl->out_dir, id,
                          use_name);
 
@@ -783,14 +849,14 @@ void pivot_inputs(afl_state_t *afl) {
 
     /* Make sure that the passed_det value carries over, too. */
 
-    if (q->passed_det) mark_as_det_done(afl, q);
+    if (q->passed_det) { mark_as_det_done(afl, q); }
 
     q = q->next;
     ++id;
 
   }
 
-  if (afl->in_place_resume) nuke_resume_dir(afl);
+  if (afl->in_place_resume) { nuke_resume_dir(afl); }
 
 }
 
@@ -805,27 +871,32 @@ u32 find_start_position(afl_state_t *afl) {
   s32 fd, i;
   u32 ret;
 
-  if (!afl->resuming_fuzz) return 0;
+  if (!afl->resuming_fuzz) { return 0; }
 
-  if (afl->in_place_resume)
+  if (afl->in_place_resume) {
+
     fn = alloc_printf("%s/fuzzer_stats", afl->out_dir);
-  else
+
+  } else {
+
     fn = alloc_printf("%s/../fuzzer_stats", afl->in_dir);
+
+  }
 
   fd = open(fn, O_RDONLY);
   ck_free(fn);
 
-  if (fd < 0) return 0;
+  if (fd < 0) { return 0; }
 
   i = read(fd, tmp, sizeof(tmp) - 1);
   (void)i;                                                 /* Ignore errors */
   close(fd);
 
   off = strstr(tmp, "cur_path          : ");
-  if (!off) return 0;
+  if (!off) { return 0; }
 
   ret = atoi(off + 20);
-  if (ret >= afl->queued_paths) ret = 0;
+  if (ret >= afl->queued_paths) { ret = 0; }
   return ret;
 
 }
@@ -842,27 +913,32 @@ void find_timeout(afl_state_t *afl) {
   s32 fd, i;
   u32 ret;
 
-  if (!afl->resuming_fuzz) return;
+  if (!afl->resuming_fuzz) { return; }
 
-  if (afl->in_place_resume)
+  if (afl->in_place_resume) {
+
     fn = alloc_printf("%s/fuzzer_stats", afl->out_dir);
-  else
+
+  } else {
+
     fn = alloc_printf("%s/../fuzzer_stats", afl->in_dir);
+
+  }
 
   fd = open(fn, O_RDONLY);
   ck_free(fn);
 
-  if (fd < 0) return;
+  if (fd < 0) { return; }
 
   i = read(fd, tmp, sizeof(tmp) - 1);
   (void)i;                                                 /* Ignore errors */
   close(fd);
 
   off = strstr(tmp, "exec_timeout      : ");
-  if (!off) return;
+  if (!off) { return; }
 
   ret = atoi(off + 20);
-  if (ret <= 4) return;
+  if (ret <= 4) { return; }
 
   afl->fsrv.exec_tmout = ret;
   afl->timeout_given = 3;
@@ -879,7 +955,7 @@ static u8 delete_files(u8 *path, u8 *prefix) {
 
   d = opendir(path);
 
-  if (!d) return 0;
+  if (!d) { return 0; }
 
   while ((d_ent = readdir(d))) {
 
@@ -887,7 +963,7 @@ static u8 delete_files(u8 *path, u8 *prefix) {
         (!prefix || !strncmp(d_ent->d_name, prefix, strlen(prefix)))) {
 
       u8 *fname = alloc_printf("%s/%s", path, d_ent->d_name);
-      if (unlink(fname)) PFATAL("Unable to delete '%s'", fname);
+      if (unlink(fname)) { PFATAL("Unable to delete '%s'", fname); }
       ck_free(fname);
 
     }
@@ -925,13 +1001,16 @@ double get_runnable_processes(void) {
   u8 tmp[1024];
   u32 val = 0;
 
-  if (!f) return 0;
+  if (!f) { return 0; }
 
   while (fgets(tmp, sizeof(tmp), f)) {
 
     if (!strncmp(tmp, "procs_running ", 14) ||
-        !strncmp(tmp, "procs_blocked ", 14))
+        !strncmp(tmp, "procs_blocked ", 14)) {
+
       val += atoi(tmp + 14);
+
+    }
 
   }
 
@@ -961,27 +1040,27 @@ void nuke_resume_dir(afl_state_t *afl) {
   u8 *fn;
 
   fn = alloc_printf("%s/_resume/.state/deterministic_done", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/_resume/.state/auto_extras", afl->out_dir);
-  if (delete_files(fn, "auto_")) goto dir_cleanup_failed;
+  if (delete_files(fn, "auto_")) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/_resume/.state/redundant_edges", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/_resume/.state/variable_behavior", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/_resume/.state", afl->out_dir);
-  if (rmdir(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (rmdir(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/_resume", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   return;
@@ -1006,7 +1085,7 @@ static void handle_existing_out_dir(afl_state_t *afl) {
      (this requires leaving the descriptor open).*/
 
   afl->fsrv.out_dir_fd = open(afl->out_dir, O_RDONLY);
-  if (afl->fsrv.out_dir_fd < 0) PFATAL("Unable to open '%s'", afl->out_dir);
+  if (afl->fsrv.out_dir_fd < 0) { PFATAL("Unable to open '%s'", afl->out_dir); }
 
 #ifndef __sun
 
@@ -1034,8 +1113,11 @@ static void handle_existing_out_dir(afl_state_t *afl) {
     if (fscanf(f,
                "start_time     : %llu\n"
                "last_update    : %llu\n",
-               &start_time2, &last_update) != 2)
+               &start_time2, &last_update) != 2) {
+
       FATAL("Malformed data in '%s'", fn);
+
+    }
 
     fclose(f);
 
@@ -1110,7 +1192,7 @@ static void handle_existing_out_dir(afl_state_t *afl) {
   if (!afl->in_place_resume) {
 
     fn = alloc_printf("%s/.synced", afl->out_dir);
-    if (delete_files(fn, NULL)) goto dir_cleanup_failed;
+    if (delete_files(fn, NULL)) { goto dir_cleanup_failed; }
     ck_free(fn);
 
   }
@@ -1118,30 +1200,30 @@ static void handle_existing_out_dir(afl_state_t *afl) {
   /* Next, we need to clean up <afl->out_dir>/queue/.state/ subdirectories: */
 
   fn = alloc_printf("%s/queue/.state/deterministic_done", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/queue/.state/auto_extras", afl->out_dir);
-  if (delete_files(fn, "auto_")) goto dir_cleanup_failed;
+  if (delete_files(fn, "auto_")) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/queue/.state/redundant_edges", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/queue/.state/variable_behavior", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   /* Then, get rid of the .state subdirectory itself (should be empty by now)
      and everything matching <afl->out_dir>/queue/id:*. */
 
   fn = alloc_printf("%s/queue/.state", afl->out_dir);
-  if (rmdir(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (rmdir(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/queue", afl->out_dir);
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   /* All right, let's do <afl->out_dir>/crashes/id:* and
@@ -1184,7 +1266,7 @@ static void handle_existing_out_dir(afl_state_t *afl) {
 
   }
 
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/hangs", afl->out_dir);
@@ -1215,7 +1297,7 @@ static void handle_existing_out_dir(afl_state_t *afl) {
 
   }
 
-  if (delete_files(fn, CASE_PREFIX)) goto dir_cleanup_failed;
+  if (delete_files(fn, CASE_PREFIX)) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   /* And now, for some finishing touches. */
@@ -1230,27 +1312,27 @@ static void handle_existing_out_dir(afl_state_t *afl) {
 
   }
 
-  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/fuzz_bitmap", afl->out_dir);
-  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   if (!afl->in_place_resume) {
 
     fn = alloc_printf("%s/fuzzer_stats", afl->out_dir);
-    if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+    if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
     ck_free(fn);
 
   }
 
   fn = alloc_printf("%s/plot_data", afl->out_dir);
-  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   fn = alloc_printf("%s/cmdline", afl->out_dir);
-  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
   ck_free(fn);
 
   OKF("Output dir cleanup successful.");
@@ -1287,27 +1369,36 @@ void setup_dirs_fds(afl_state_t *afl) {
 
   ACTF("Setting up output directories...");
 
-  if (afl->sync_id && mkdir(afl->sync_dir, 0700) && errno != EEXIST)
+  if (afl->sync_id && mkdir(afl->sync_dir, 0700) && errno != EEXIST) {
+
     PFATAL("Unable to create '%s'", afl->sync_dir);
+
+  }
 
   if (mkdir(afl->out_dir, 0700)) {
 
-    if (errno != EEXIST) PFATAL("Unable to create '%s'", afl->out_dir);
+    if (errno != EEXIST) { PFATAL("Unable to create '%s'", afl->out_dir); }
 
     handle_existing_out_dir(afl);
 
   } else {
 
-    if (afl->in_place_resume)
+    if (afl->in_place_resume) {
+
       FATAL("Resume attempted but old output directory not found");
+
+    }
 
     afl->fsrv.out_dir_fd = open(afl->out_dir, O_RDONLY);
 
 #ifndef __sun
 
     if (afl->fsrv.out_dir_fd < 0 ||
-        flock(afl->fsrv.out_dir_fd, LOCK_EX | LOCK_NB))
+        flock(afl->fsrv.out_dir_fd, LOCK_EX | LOCK_NB)) {
+
       PFATAL("Unable to flock() output directory.");
+
+    }
 
 #endif                                                            /* !__sun */
 
@@ -1316,39 +1407,39 @@ void setup_dirs_fds(afl_state_t *afl) {
   /* Queue directory for any starting & discovered paths. */
 
   tmp = alloc_printf("%s/queue", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* Top-level directory for queue metadata used for session
      resume and related tasks. */
 
   tmp = alloc_printf("%s/queue/.state/", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* Directory for flagging queue entries that went through
      deterministic fuzzing in the past. */
 
   tmp = alloc_printf("%s/queue/.state/deterministic_done/", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* Directory with the auto-selected dictionary entries. */
 
   tmp = alloc_printf("%s/queue/.state/auto_extras/", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* The set of paths currently deemed redundant. */
 
   tmp = alloc_printf("%s/queue/.state/redundant_edges/", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* The set of paths showing variable behavior. */
 
   tmp = alloc_printf("%s/queue/.state/variable_behavior/", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* Sync directory for keeping track of cooperating fuzzers. */
@@ -1357,8 +1448,11 @@ void setup_dirs_fds(afl_state_t *afl) {
 
     tmp = alloc_printf("%s/.synced/", afl->out_dir);
 
-    if (mkdir(tmp, 0700) && (!afl->in_place_resume || errno != EEXIST))
+    if (mkdir(tmp, 0700) && (!afl->in_place_resume || errno != EEXIST)) {
+
       PFATAL("Unable to create '%s'", tmp);
+
+    }
 
     ck_free(tmp);
 
@@ -1367,34 +1461,34 @@ void setup_dirs_fds(afl_state_t *afl) {
   /* All recorded crashes. */
 
   tmp = alloc_printf("%s/crashes", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* All recorded hangs. */
 
   tmp = alloc_printf("%s/hangs", afl->out_dir);
-  if (mkdir(tmp, 0700)) PFATAL("Unable to create '%s'", tmp);
+  if (mkdir(tmp, 0700)) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   /* Generally useful file descriptors. */
 
   afl->fsrv.dev_null_fd = open("/dev/null", O_RDWR);
-  if (afl->fsrv.dev_null_fd < 0) PFATAL("Unable to open /dev/null");
+  if (afl->fsrv.dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
 #ifndef HAVE_ARC4RANDOM
   afl->fsrv.dev_urandom_fd = open("/dev/urandom", O_RDONLY);
-  if (afl->fsrv.dev_urandom_fd < 0) PFATAL("Unable to open /dev/urandom");
+  if (afl->fsrv.dev_urandom_fd < 0) { PFATAL("Unable to open /dev/urandom"); }
 #endif
 
   /* Gnuplot output file. */
 
   tmp = alloc_printf("%s/plot_data", afl->out_dir);
   fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL, 0600);
-  if (fd < 0) PFATAL("Unable to create '%s'", tmp);
+  if (fd < 0) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   afl->fsrv.plot_file = fdopen(fd, "w");
-  if (!afl->fsrv.plot_file) PFATAL("fdopen() failed");
+  if (!afl->fsrv.plot_file) { PFATAL("fdopen() failed"); }
 
   fprintf(afl->fsrv.plot_file,
           "# unix_time, cycles_done, cur_path, paths_total, "
@@ -1417,11 +1511,11 @@ void setup_cmdline_file(afl_state_t *afl, char **argv) {
   /* Store the command line to reproduce our findings */
   tmp = alloc_printf("%s/cmdline", afl->out_dir);
   fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL, 0600);
-  if (fd < 0) PFATAL("Unable to create '%s'", tmp);
+  if (fd < 0) { PFATAL("Unable to create '%s'", tmp); }
   ck_free(tmp);
 
   cmdline_file = fdopen(fd, "w");
-  if (!cmdline_file) PFATAL("fdopen() failed");
+  if (!cmdline_file) { PFATAL("fdopen() failed"); }
 
   while (argv[i]) {
 
@@ -1453,7 +1547,7 @@ void setup_stdio_file(afl_state_t *afl) {
 
   afl->fsrv.out_fd = open(fn, O_RDWR | O_CREAT | O_EXCL, 0600);
 
-  if (afl->fsrv.out_fd < 0) PFATAL("Unable to create '%s'", fn);
+  if (afl->fsrv.out_fd < 0) { PFATAL("Unable to create '%s'", fn); }
 
   ck_free(fn);
 
@@ -1501,7 +1595,7 @@ void check_crash_handling(void) {
   s32 fd = open("/proc/sys/kernel/core_pattern", O_RDONLY);
   u8 fchar;
 
-  if (fd < 0) return;
+  if (fd < 0) { return; }
 
   ACTF("Checking core_pattern...");
 
@@ -1524,8 +1618,11 @@ void check_crash_handling(void) {
 
         "    echo core >/proc/sys/kernel/core_pattern\n");
 
-    if (!getenv("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES"))
+    if (!getenv("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES")) {
+
       FATAL("Pipe at the beginning of 'core_pattern'");
+
+    }
 
   }
 
@@ -1544,24 +1641,36 @@ void check_cpu_governor(afl_state_t *afl) {
   u8    tmp[128];
   u64   min = 0, max = 0;
 
-  if (afl->afl_env.afl_skip_cpufreq) return;
+  if (afl->afl_env.afl_skip_cpufreq) { return; }
 
-  if (afl->cpu_aff > 0)
+  if (afl->cpu_aff > 0) {
+
     snprintf(tmp, sizeof(tmp), "%s%d%s", "/sys/devices/system/cpu/cpu",
              afl->cpu_aff, "/cpufreq/scaling_governor");
-  else
+
+  } else {
+
     snprintf(tmp, sizeof(tmp), "%s",
              "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
+
+  }
+
   f = fopen("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", "r");
   if (!f) {
 
-    if (afl->cpu_aff > 0)
+    if (afl->cpu_aff > 0) {
+
       snprintf(tmp, sizeof(tmp), "%s%d%s",
                "/sys/devices/system/cpu/cpufreq/policy", afl->cpu_aff,
                "/scaling_governor");
-    else
+
+    } else {
+
       snprintf(tmp, sizeof(tmp), "%s",
                "/sys/devices/system/cpu/cpufreq/policy0/scaling_governor");
+
+    }
+
     f = fopen(tmp, "r");
 
   }
@@ -1575,17 +1684,17 @@ void check_cpu_governor(afl_state_t *afl) {
 
   ACTF("Checking CPU scaling governor...");
 
-  if (!fgets(tmp, 128, f)) PFATAL("fgets() failed");
+  if (!fgets(tmp, 128, f)) { PFATAL("fgets() failed"); }
 
   fclose(f);
 
-  if (!strncmp(tmp, "perf", 4)) return;
+  if (!strncmp(tmp, "perf", 4)) { return; }
 
   f = fopen("/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq", "r");
 
   if (f) {
 
-    if (fscanf(f, "%llu", &min) != 1) min = 0;
+    if (fscanf(f, "%llu", &min) != 1) { min = 0; }
     fclose(f);
 
   }
@@ -1594,12 +1703,12 @@ void check_cpu_governor(afl_state_t *afl) {
 
   if (f) {
 
-    if (fscanf(f, "%llu", &max) != 1) max = 0;
+    if (fscanf(f, "%llu", &max) != 1) { max = 0; }
     fclose(f);
 
   }
 
-  if (min == max) return;
+  if (min == max) { return; }
 
   SAYF("\n" cLRD "[-] " cRST
        "Whoops, your system uses on-demand CPU frequency scaling, adjusted\n"
@@ -1752,11 +1861,11 @@ void fix_up_sync(afl_state_t *afl) {
 
   u8 *x = afl->sync_id;
 
-  if (afl->dumb_mode) FATAL("-S / -M and -n are mutually exclusive");
+  if (afl->dumb_mode) { FATAL("-S / -M and -n are mutually exclusive"); }
 
   if (afl->skip_deterministic) {
 
-    if (afl->force_deterministic) FATAL("use -S instead of -M -d");
+    if (afl->force_deterministic) { FATAL("use -S instead of -M -d"); }
     // else
     //  FATAL("-S already implies -d");
 
@@ -1764,14 +1873,17 @@ void fix_up_sync(afl_state_t *afl) {
 
   while (*x) {
 
-    if (!isalnum(*x) && *x != '_' && *x != '-')
+    if (!isalnum(*x) && *x != '_' && *x != '-') {
+
       FATAL("Non-alphanumeric fuzzer ID specified via -S or -M");
+
+    }
 
     ++x;
 
   }
 
-  if (strlen(afl->sync_id) > 32) FATAL("Fuzzer ID too long");
+  if (strlen(afl->sync_id) > 32) { FATAL("Fuzzer ID too long"); }
 
   x = alloc_printf("%s/%s", afl->out_dir, afl->sync_id);
 
@@ -1803,11 +1915,17 @@ void check_asan_opts(void) {
 
   if (x) {
 
-    if (!strstr(x, "abort_on_error=1"))
+    if (!strstr(x, "abort_on_error=1")) {
+
       FATAL("Custom ASAN_OPTIONS set without abort_on_error=1 - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom ASAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -1815,12 +1933,18 @@ void check_asan_opts(void) {
 
   if (x) {
 
-    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR)))
+    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR))) {
+
       FATAL("Custom MSAN_OPTIONS set without exit_code=" STRINGIFY(
           MSAN_ERROR) " - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom MSAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -1868,8 +1992,11 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
     afl->fsrv.target_path = ck_strdup(fname);
     if (stat(afl->fsrv.target_path, &st) || !S_ISREG(st.st_mode) ||
-        !(st.st_mode & 0111) || (f_len = st.st_size) < 4)
+        !(st.st_mode & 0111) || (f_len = st.st_size) < 4) {
+
       FATAL("Program '%s' not found or not executable", fname);
+
+    }
 
   } else {
 
@@ -1883,51 +2010,70 @@ void check_binary(afl_state_t *afl, u8 *fname) {
         memcpy(cur_elem, env_path, delim - env_path);
         ++delim;
 
-      } else
+      } else {
 
         cur_elem = ck_strdup(env_path);
 
+      }
+
       env_path = delim;
 
-      if (cur_elem[0])
+      if (cur_elem[0]) {
+
         afl->fsrv.target_path = alloc_printf("%s/%s", cur_elem, fname);
-      else
+
+      } else {
+
         afl->fsrv.target_path = ck_strdup(fname);
+
+      }
 
       ck_free(cur_elem);
 
       if (!stat(afl->fsrv.target_path, &st) && S_ISREG(st.st_mode) &&
-          (st.st_mode & 0111) && (f_len = st.st_size) >= 4)
+          (st.st_mode & 0111) && (f_len = st.st_size) >= 4) {
+
         break;
+
+      }
 
       ck_free(afl->fsrv.target_path);
       afl->fsrv.target_path = 0;
 
     }
 
-    if (!afl->fsrv.target_path)
+    if (!afl->fsrv.target_path) {
+
       FATAL("Program '%s' not found or not executable", fname);
+
+    }
 
   }
 
-  if (afl->afl_env.afl_skip_bin_check || afl->use_wine) return;
+  if (afl->afl_env.afl_skip_bin_check || afl->use_wine) { return; }
 
   /* Check for blatant user errors. */
 
   if ((!strncmp(afl->fsrv.target_path, "/tmp/", 5) &&
        !strchr(afl->fsrv.target_path + 5, '/')) ||
       (!strncmp(afl->fsrv.target_path, "/var/tmp/", 9) &&
-       !strchr(afl->fsrv.target_path + 9, '/')))
+       !strchr(afl->fsrv.target_path + 9, '/'))) {
+
     FATAL("Please don't keep binaries in /tmp or /var/tmp");
+
+  }
 
   fd = open(afl->fsrv.target_path, O_RDONLY);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", afl->fsrv.target_path);
+  if (fd < 0) { PFATAL("Unable to open '%s'", afl->fsrv.target_path); }
 
   f_data = mmap(0, f_len, PROT_READ, MAP_PRIVATE, fd, 0);
 
-  if (f_data == MAP_FAILED)
+  if (f_data == MAP_FAILED) {
+
     PFATAL("Unable to mmap file '%s'", afl->fsrv.target_path);
+
+  }
 
   close(fd);
 
@@ -1955,8 +2101,11 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
 #ifndef __APPLE__
 
-  if (f_data[0] != 0x7f || memcmp(f_data + 1, "ELF", 3))
+  if (f_data[0] != 0x7f || memcmp(f_data + 1, "ELF", 3)) {
+
     FATAL("Program '%s' is not an ELF binary", afl->fsrv.target_path);
+
+  }
 
 #else
 
@@ -2011,8 +2160,11 @@ void check_binary(afl_state_t *afl, u8 *fname) {
   }
 
   if (memmem(f_data, f_len, "__asan_init", 11) ||
-      memmem(f_data, f_len, "__msan_init", 11))
+      memmem(f_data, f_len, "__msan_init", 11)) {
+
     afl->fsrv.uses_asan = 1;
+
+  }
 
   /* Detect persistent & deferred init signatures in the binary. */
 
@@ -2040,7 +2192,7 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
   }
 
-  if (munmap(f_data, f_len)) PFATAL("unmap() failed");
+  if (munmap(f_data, f_len)) { PFATAL("unmap() failed"); }
 
 }
 
@@ -2057,10 +2209,15 @@ void fix_up_banner(afl_state_t *afl, u8 *name) {
     } else {
 
       u8 *trim = strrchr(name, '/');
-      if (!trim)
+      if (!trim) {
+
         afl->use_banner = name;
-      else
+
+      } else {
+
         afl->use_banner = trim + 1;
+
+      }
 
     }
 
@@ -2152,8 +2309,11 @@ void save_cmdline(afl_state_t *afl, u32 argc, char **argv) {
   u32 len = 1, i;
   u8 *buf;
 
-  for (i = 0; i < argc; ++i)
+  for (i = 0; i < argc; ++i) {
+
     len += strlen(argv[i]) + 1;
+
+  }
 
   buf = afl->orig_cmdline = ck_alloc(len);
 
@@ -2161,12 +2321,12 @@ void save_cmdline(afl_state_t *afl, u32 argc, char **argv) {
 
     u32 l = strlen(argv[i]);
 
-    if (!argv[i] || !buf) FATAL("null deref detected");
+    if (!argv[i] || !buf) { FATAL("null deref detected"); }
 
     memcpy(buf, argv[i], l);
     buf += l;
 
-    if (i != argc - 1) *(buf++) = ' ';
+    if (i != argc - 1) { *(buf++) = ' '; }
 
   }
 

--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -35,11 +35,14 @@ void setup_custom_mutator(afl_state_t *afl) {
 
   if (fn) {
 
-    if (afl->limit_time_sig)
+    if (afl->limit_time_sig) {
+
       FATAL(
           "MOpt and custom mutator are mutually exclusive. We accept pull "
           "requests that integrates MOpt with the optional mutators "
           "(custom/radamsa/redquenn/...).");
+
+    }
 
     load_custom_mutator(afl, fn);
 
@@ -53,11 +56,14 @@ void setup_custom_mutator(afl_state_t *afl) {
 
   if (module_name) {
 
-    if (afl->limit_time_sig)
+    if (afl->limit_time_sig) {
+
       FATAL(
           "MOpt and Python mutator are mutually exclusive. We accept pull "
           "requests that integrates MOpt with the optional mutators "
           "(custom/radamsa/redqueen/...).");
+
+    }
 
     load_custom_mutator_py(afl, module_name);
 
@@ -76,7 +82,7 @@ void destroy_custom_mutator(afl_state_t *afl) {
 
     afl->mutator->afl_custom_deinit(afl->mutator->data);
 
-    if (afl->mutator->dh) dlclose(afl->mutator->dh);
+    if (afl->mutator->dh) { dlclose(afl->mutator->dh); }
 
     if (afl->mutator->pre_save_buf) {
 
@@ -104,19 +110,25 @@ void load_custom_mutator(afl_state_t *afl, const char *fn) {
   ACTF("Loading custom mutator library from '%s'...", fn);
 
   dh = dlopen(fn, RTLD_NOW);
-  if (!dh) FATAL("%s", dlerror());
+  if (!dh) { FATAL("%s", dlerror()); }
   afl->mutator->dh = dh;
 
   /* Mutator */
   /* "afl_custom_init", required */
   afl->mutator->afl_custom_init = dlsym(dh, "afl_custom_init");
-  if (!afl->mutator->afl_custom_init)
+  if (!afl->mutator->afl_custom_init) {
+
     FATAL("Symbol 'afl_custom_init' not found.");
+
+  }
 
   /* "afl_custom_deinit", required */
   afl->mutator->afl_custom_deinit = dlsym(dh, "afl_custom_deinit");
-  if (!afl->mutator->afl_custom_deinit)
+  if (!afl->mutator->afl_custom_deinit) {
+
     FATAL("Symbol 'afl_custom_deinit' not found.");
+
+  }
 
   /* "afl_custom_fuzz" or "afl_custom_mutator", required */
   afl->mutator->afl_custom_fuzz = dlsym(dh, "afl_custom_fuzz");
@@ -126,31 +138,46 @@ void load_custom_mutator(afl_state_t *afl, const char *fn) {
     WARNF("Symbol 'afl_custom_fuzz' not found. Try 'afl_custom_mutator'.");
 
     afl->mutator->afl_custom_fuzz = dlsym(dh, "afl_custom_mutator");
-    if (!afl->mutator->afl_custom_fuzz)
+    if (!afl->mutator->afl_custom_fuzz) {
+
       FATAL("Symbol 'afl_custom_mutator' not found.");
+
+    }
 
   }
 
   /* "afl_custom_pre_save", optional */
   afl->mutator->afl_custom_pre_save = dlsym(dh, "afl_custom_pre_save");
-  if (!afl->mutator->afl_custom_pre_save)
+  if (!afl->mutator->afl_custom_pre_save) {
+
     WARNF("Symbol 'afl_custom_pre_save' not found.");
+
+  }
 
   u8 notrim = 0;
   /* "afl_custom_init_trim", optional */
   afl->mutator->afl_custom_init_trim = dlsym(dh, "afl_custom_init_trim");
-  if (!afl->mutator->afl_custom_init_trim)
+  if (!afl->mutator->afl_custom_init_trim) {
+
     WARNF("Symbol 'afl_custom_init_trim' not found.");
+
+  }
 
   /* "afl_custom_trim", optional */
   afl->mutator->afl_custom_trim = dlsym(dh, "afl_custom_trim");
-  if (!afl->mutator->afl_custom_trim)
+  if (!afl->mutator->afl_custom_trim) {
+
     WARNF("Symbol 'afl_custom_trim' not found.");
+
+  }
 
   /* "afl_custom_post_trim", optional */
   afl->mutator->afl_custom_post_trim = dlsym(dh, "afl_custom_post_trim");
-  if (!afl->mutator->afl_custom_post_trim)
+  if (!afl->mutator->afl_custom_post_trim) {
+
     WARNF("Symbol 'afl_custom_post_trim' not found.");
+
+  }
 
   if (notrim) {
 
@@ -166,32 +193,47 @@ void load_custom_mutator(afl_state_t *afl, const char *fn) {
   /* "afl_custom_havoc_mutation", optional */
   afl->mutator->afl_custom_havoc_mutation =
       dlsym(dh, "afl_custom_havoc_mutation");
-  if (!afl->mutator->afl_custom_havoc_mutation)
+  if (!afl->mutator->afl_custom_havoc_mutation) {
+
     WARNF("Symbol 'afl_custom_havoc_mutation' not found.");
+
+  }
 
   /* "afl_custom_havoc_mutation", optional */
   afl->mutator->afl_custom_havoc_mutation_probability =
       dlsym(dh, "afl_custom_havoc_mutation_probability");
-  if (!afl->mutator->afl_custom_havoc_mutation_probability)
+  if (!afl->mutator->afl_custom_havoc_mutation_probability) {
+
     WARNF("Symbol 'afl_custom_havoc_mutation_probability' not found.");
+
+  }
 
   /* "afl_custom_queue_get", optional */
   afl->mutator->afl_custom_queue_get = dlsym(dh, "afl_custom_queue_get");
-  if (!afl->mutator->afl_custom_queue_get)
+  if (!afl->mutator->afl_custom_queue_get) {
+
     WARNF("Symbol 'afl_custom_queue_get' not found.");
+
+  }
 
   /* "afl_custom_queue_new_entry", optional */
   afl->mutator->afl_custom_queue_new_entry =
       dlsym(dh, "afl_custom_queue_new_entry");
-  if (!afl->mutator->afl_custom_queue_new_entry)
+  if (!afl->mutator->afl_custom_queue_new_entry) {
+
     WARNF("Symbol 'afl_custom_queue_new_entry' not found");
+
+  }
 
   OKF("Custom mutator '%s' installed successfully.", fn);
 
   /* Initialize the custom mutator */
-  if (afl->mutator->afl_custom_init)
+  if (afl->mutator->afl_custom_init) {
+
     afl->mutator->data =
         afl->mutator->afl_custom_init(afl, rand_below(afl, 0xFFFFFFFF));
+
+  }
 
 }
 
@@ -210,11 +252,18 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
   afl->stage_cur = 0;
   afl->stage_max =
       afl->mutator->afl_custom_init_trim(afl->mutator->data, in_buf, q->len);
-  if (unlikely(afl->stage_max) < 0)
+  if (unlikely(afl->stage_max) < 0) {
+
     FATAL("custom_init_trim error ret: %d", afl->stage_max);
-  if (afl->not_on_tty && afl->debug)
+
+  }
+
+  if (afl->not_on_tty && afl->debug) {
+
     SAYF("[Custom Trimming] START: Max %d iterations, %u bytes", afl->stage_max,
          q->len);
+
+  }
 
   while (afl->stage_cur < afl->stage_max) {
 
@@ -227,12 +276,17 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
 
     size_t retlen = afl->mutator->afl_custom_trim(afl->mutator->data, &retbuf);
 
-    if (unlikely(!retbuf))
+    if (unlikely(!retbuf)) {
+
       FATAL("custom_trim failed (ret %zd)", retlen);
-    else if (unlikely(retlen > orig_len))
+
+    } else if (unlikely(retlen > orig_len)) {
+
       FATAL(
           "Trimmed data returned by custom mutator is larger than original "
           "data");
+
+    }
 
     write_to_testcase(afl, retbuf, retlen);
 
@@ -263,31 +317,44 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
       afl->stage_cur =
           afl->mutator->afl_custom_post_trim(afl->mutator->data, 1);
 
-      if (afl->not_on_tty && afl->debug)
+      if (afl->not_on_tty && afl->debug) {
+
         SAYF("[Custom Trimming] SUCCESS: %d/%d iterations (now at %u bytes)",
              afl->stage_cur, afl->stage_max, q->len);
+
+      }
 
     } else {
 
       /* Tell the custom mutator that the trimming was unsuccessful */
       afl->stage_cur =
           afl->mutator->afl_custom_post_trim(afl->mutator->data, 0);
-      if (unlikely(afl->stage_cur < 0))
+      if (unlikely(afl->stage_cur < 0)) {
+
         FATAL("Error ret in custom_post_trim: %d", afl->stage_cur);
-      if (afl->not_on_tty && afl->debug)
+
+      }
+
+      if (afl->not_on_tty && afl->debug) {
+
         SAYF("[Custom Trimming] FAILURE: %d/%d iterations", afl->stage_cur,
              afl->stage_max);
+
+      }
 
     }
 
     /* Since this can be slow, update the screen every now and then. */
 
-    if (!(trim_exec++ % afl->stats_update_freq)) show_stats(afl);
+    if (!(trim_exec++ % afl->stats_update_freq)) { show_stats(afl); }
 
   }
 
-  if (afl->not_on_tty && afl->debug)
+  if (afl->not_on_tty && afl->debug) {
+
     SAYF("[Custom Trimming] DONE: %u bytes -> %u bytes", orig_len, q->len);
+
+  }
 
   /* If we have made changes to in_buf, we also need to update the on-disk
      version of the test case. */
@@ -300,7 +367,7 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
 
     fd = open(q->fname, O_WRONLY | O_CREAT | O_EXCL, 0600);
 
-    if (fd < 0) PFATAL("Unable to create '%s'", q->fname);
+    if (fd < 0) { PFATAL("Unable to create '%s'", q->fname); }
 
     ck_write(fd, in_buf, q->len, q->fname);
     close(fd);

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -37,7 +37,7 @@ static int select_algorithm(afl_state_t *afl) {
 
     if (unlikely(i_puppet == 0)) {
 
-      if (sele < afl->probability_now[afl->swarm_now][i_puppet]) break;
+      if (sele < afl->probability_now[afl->swarm_now][i_puppet]) { break; }
 
     } else {
 
@@ -53,8 +53,12 @@ static int select_algorithm(afl_state_t *afl) {
   }
 
   if (j_puppet == 1 &&
-      sele < afl->probability_now[afl->swarm_now][i_puppet - 1])
+      sele < afl->probability_now[afl->swarm_now][i_puppet - 1]) {
+
     FATAL("error select_algorithm");
+
+  }
+
   return i_puppet;
 
 }
@@ -67,7 +71,7 @@ static u32 choose_block_len(afl_state_t *afl, u32 limit) {
   u32 min_value, max_value;
   u32 rlim = MIN(afl->queue_cycle, 3);
 
-  if (unlikely(!afl->run_over10m)) rlim = 1;
+  if (unlikely(!afl->run_over10m)) { rlim = 1; }
 
   switch (rand_below(afl, rlim)) {
 
@@ -97,7 +101,7 @@ static u32 choose_block_len(afl_state_t *afl, u32 limit) {
 
   }
 
-  if (min_value >= limit) min_value = 1;
+  if (min_value >= limit) { min_value = 1; }
 
   return min_value + rand_below(afl, MIN(max_value, limit) - min_value + 1);
 
@@ -114,7 +118,7 @@ static u8 could_be_bitflip(u32 xor_val) {
 
   u32 sh = 0;
 
-  if (!xor_val) return 1;
+  if (!xor_val) { return 1; }
 
   /* Shift left until first bit set. */
 
@@ -127,14 +131,18 @@ static u8 could_be_bitflip(u32 xor_val) {
 
   /* 1-, 2-, and 4-bit patterns are OK anywhere. */
 
-  if (xor_val == 1 || xor_val == 3 || xor_val == 15) return 1;
+  if (xor_val == 1 || xor_val == 3 || xor_val == 15) { return 1; }
 
   /* 8-, 16-, and 32-bit patterns are OK only if shift factor is
      divisible by 8, since that's the stepover for these ops. */
 
-  if (sh & 7) return 0;
+  if (sh & 7) { return 0; }
 
-  if (xor_val == 0xff || xor_val == 0xffff || xor_val == 0xffffffff) return 1;
+  if (xor_val == 0xff || xor_val == 0xffff || xor_val == 0xffffffff) {
+
+    return 1;
+
+  }
 
   return 0;
 
@@ -147,7 +155,7 @@ static u8 could_be_arith(u32 old_val, u32 new_val, u8 blen) {
 
   u32 i, ov = 0, nv = 0, diffs = 0;
 
-  if (old_val == new_val) return 1;
+  if (old_val == new_val) { return 1; }
 
   /* See if one-byte adjustments to any byte could produce this result. */
 
@@ -169,11 +177,11 @@ static u8 could_be_arith(u32 old_val, u32 new_val, u8 blen) {
 
   if (diffs == 1) {
 
-    if ((u8)(ov - nv) <= ARITH_MAX || (u8)(nv - ov) <= ARITH_MAX) return 1;
+    if ((u8)(ov - nv) <= ARITH_MAX || (u8)(nv - ov) <= ARITH_MAX) { return 1; }
 
   }
 
-  if (blen == 1) return 0;
+  if (blen == 1) { return 0; }
 
   /* See if two-byte adjustments to any byte would produce this result. */
 
@@ -197,12 +205,20 @@ static u8 could_be_arith(u32 old_val, u32 new_val, u8 blen) {
 
   if (diffs == 1) {
 
-    if ((u16)(ov - nv) <= ARITH_MAX || (u16)(nv - ov) <= ARITH_MAX) return 1;
+    if ((u16)(ov - nv) <= ARITH_MAX || (u16)(nv - ov) <= ARITH_MAX) {
+
+      return 1;
+
+    }
 
     ov = SWAP16(ov);
     nv = SWAP16(nv);
 
-    if ((u16)(ov - nv) <= ARITH_MAX || (u16)(nv - ov) <= ARITH_MAX) return 1;
+    if ((u16)(ov - nv) <= ARITH_MAX || (u16)(nv - ov) <= ARITH_MAX) {
+
+      return 1;
+
+    }
 
   }
 
@@ -211,15 +227,21 @@ static u8 could_be_arith(u32 old_val, u32 new_val, u8 blen) {
   if (blen == 4) {
 
     if ((u32)(old_val - new_val) <= ARITH_MAX ||
-        (u32)(new_val - old_val) <= ARITH_MAX)
+        (u32)(new_val - old_val) <= ARITH_MAX) {
+
       return 1;
+
+    }
 
     new_val = SWAP32(new_val);
     old_val = SWAP32(old_val);
 
     if ((u32)(old_val - new_val) <= ARITH_MAX ||
-        (u32)(new_val - old_val) <= ARITH_MAX)
+        (u32)(new_val - old_val) <= ARITH_MAX) {
+
       return 1;
+
+    }
 
   }
 
@@ -237,7 +259,7 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
 
   u32 i, j;
 
-  if (old_val == new_val) return 1;
+  if (old_val == new_val) { return 1; }
 
   /* See if one-byte insertions from interesting_8 over old_val could
      produce new_val. */
@@ -249,7 +271,7 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
       u32 tval =
           (old_val & ~(0xff << (i * 8))) | (((u8)interesting_8[j]) << (i * 8));
 
-      if (new_val == tval) return 1;
+      if (new_val == tval) { return 1; }
 
     }
 
@@ -258,7 +280,7 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
   /* Bail out unless we're also asked to examine two-byte LE insertions
      as a preparation for BE attempts. */
 
-  if (blen == 2 && !check_le) return 0;
+  if (blen == 2 && !check_le) { return 0; }
 
   /* See if two-byte insertions over old_val could give us new_val. */
 
@@ -269,7 +291,7 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
       u32 tval = (old_val & ~(0xffff << (i * 8))) |
                  (((u16)interesting_16[j]) << (i * 8));
 
-      if (new_val == tval) return 1;
+      if (new_val == tval) { return 1; }
 
       /* Continue here only if blen > 2. */
 
@@ -278,7 +300,7 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
         tval = (old_val & ~(0xffff << (i * 8))) |
                (SWAP16(interesting_16[j]) << (i * 8));
 
-        if (new_val == tval) return 1;
+        if (new_val == tval) { return 1; }
 
       }
 
@@ -291,8 +313,11 @@ static u8 could_be_interest(u32 old_val, u32 new_val, u8 blen, u8 check_le) {
     /* See if four-byte insertions could produce the same result
        (LE only). */
 
-    for (j = 0; j < sizeof(interesting_32) / 4; ++j)
-      if (new_val == (u32)interesting_32[j]) return 1;
+    for (j = 0; j < sizeof(interesting_32) / 4; ++j) {
+
+      if (new_val == (u32)interesting_32[j]) { return 1; }
+
+    }
 
   }
 
@@ -315,7 +340,7 @@ static void locate_diffs(u8 *ptr1, u8 *ptr2, u32 len, s32 *first, s32 *last) {
 
     if (*(ptr1++) != *(ptr2++)) {
 
-      if (f_loc == -1) f_loc = pos;
+      if (f_loc == -1) { f_loc = pos; }
       l_loc = pos;
 
     }
@@ -364,8 +389,11 @@ u8 fuzz_one_original(afl_state_t *afl) {
     /* The custom mutator will decide to skip this test case or not. */
 
     if (!afl->mutator->afl_custom_queue_get(afl->mutator->data,
-                                            afl->queue_cur->fname))
+                                            afl->queue_cur->fname)) {
+
       return 1;
+
+    }
 
   }
 
@@ -377,8 +405,11 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     if (((afl->queue_cur->was_fuzzed > 0 || afl->queue_cur->fuzz_level > 0) ||
          !afl->queue_cur->favored) &&
-        rand_below(afl, 100) < SKIP_TO_NEW_PROB)
+        rand_below(afl, 100) < SKIP_TO_NEW_PROB) {
+
       return 1;
+
+    }
 
   } else if (!afl->dumb_mode && !afl->queue_cur->favored &&
 
@@ -391,11 +422,11 @@ u8 fuzz_one_original(afl_state_t *afl) {
     if (afl->queue_cycle > 1 &&
         (afl->queue_cur->fuzz_level == 0 || afl->queue_cur->was_fuzzed)) {
 
-      if (rand_below(afl, 100) < SKIP_NFAV_NEW_PROB) return 1;
+      if (rand_below(afl, 100) < SKIP_NFAV_NEW_PROB) { return 1; }
 
     } else {
 
-      if (rand_below(afl, 100) < SKIP_NFAV_OLD_PROB) return 1;
+      if (rand_below(afl, 100) < SKIP_NFAV_OLD_PROB) { return 1; }
 
     }
 
@@ -415,14 +446,21 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
   fd = open(afl->queue_cur->fname, O_RDONLY);
 
-  if (unlikely(fd < 0)) PFATAL("Unable to open '%s'", afl->queue_cur->fname);
+  if (unlikely(fd < 0)) {
+
+    PFATAL("Unable to open '%s'", afl->queue_cur->fname);
+
+  }
 
   len = afl->queue_cur->len;
 
   orig_in = in_buf = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 
-  if (unlikely(orig_in == MAP_FAILED))
+  if (unlikely(orig_in == MAP_FAILED)) {
+
     PFATAL("Unable to mmap '%s' with len %d", afl->queue_cur->fname, len);
+
+  }
 
   close(fd);
 
@@ -449,8 +487,11 @@ u8 fuzz_one_original(afl_state_t *afl) {
       res =
           calibrate_case(afl, afl->queue_cur, in_buf, afl->queue_cycle - 1, 0);
 
-      if (unlikely(res == FSRV_RUN_ERROR))
+      if (unlikely(res == FSRV_RUN_ERROR)) {
+
         FATAL("Unable to execute target application");
+
+      }
 
     }
 
@@ -471,8 +512,11 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     u8 res = trim_case(afl, afl->queue_cur, in_buf);
 
-    if (unlikely(res == FSRV_RUN_ERROR))
+    if (unlikely(res == FSRV_RUN_ERROR)) {
+
       FATAL("Unable to execute target application");
+
+    }
 
     if (unlikely(afl->stop_soon)) {
 
@@ -497,15 +541,18 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
   orig_perf = perf_score = calculate_score(afl, afl->queue_cur);
 
-  if (unlikely(perf_score == 0)) goto abandon_entry;
+  if (unlikely(perf_score == 0)) { goto abandon_entry; }
 
-  if (unlikely(afl->use_radamsa > 1)) goto radamsa_stage;
+  if (unlikely(afl->use_radamsa > 1)) { goto radamsa_stage; }
 
   if (afl->shm.cmplog_mode && !afl->queue_cur->fully_colorized) {
 
     if (input_to_state_stage(afl, in_buf, out_buf, len,
-                             afl->queue_cur->exec_cksum))
+                             afl->queue_cur->exec_cksum)) {
+
       goto abandon_entry;
+
+    }
 
   }
 
@@ -568,7 +615,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     FLIP_BIT(out_buf, afl->stage_cur);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
 
@@ -608,20 +655,30 @@ u8 fuzz_one_original(afl_state_t *afl) {
         /* If at end of file and we are still collecting a string, grab the
            final character and force output. */
 
-        if (a_len < MAX_AUTO_EXTRA)
+        if (a_len < MAX_AUTO_EXTRA) {
+
           a_collect[a_len] = out_buf[afl->stage_cur >> 3];
+
+        }
+
         ++a_len;
 
-        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA)
+        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA) {
+
           maybe_add_auto((u8 *)afl, a_collect, a_len);
+
+        }
 
       } else if (cksum != prev_cksum) {
 
         /* Otherwise, if the checksum has changed, see if we have something
            worthwhile queued up, and collect that if the answer is yes. */
 
-        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA)
+        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA) {
+
           maybe_add_auto((u8 *)afl, a_collect, a_len);
+
+        }
 
         a_len = 0;
         prev_cksum = cksum;
@@ -633,8 +690,12 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
       if (cksum != afl->queue_cur->exec_cksum) {
 
-        if (a_len < MAX_AUTO_EXTRA)
+        if (a_len < MAX_AUTO_EXTRA) {
+
           a_collect[a_len] = out_buf[afl->stage_cur >> 3];
+
+        }
+
         ++a_len;
 
       }
@@ -663,7 +724,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
@@ -692,7 +753,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
     FLIP_BIT(out_buf, afl->stage_cur + 2);
     FLIP_BIT(out_buf, afl->stage_cur + 3);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
@@ -746,7 +807,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     out_buf[afl->stage_cur] ^= 0xFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     /* We also use this stage to pull off a simple trick: we identify
        bytes that seem to have no effect on the current execution path
@@ -760,10 +821,15 @@ u8 fuzz_one_original(afl_state_t *afl) {
       /* If in dumb mode or if the file is very short, just flag everything
          without wasting time on checksums. */
 
-      if (!afl->dumb_mode && len >= EFF_MIN_LEN)
+      if (!afl->dumb_mode && len >= EFF_MIN_LEN) {
+
         cksum = hash32(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
-      else
+
+      } else {
+
         cksum = ~afl->queue_cur->exec_cksum;
+
+      }
 
       if (cksum != afl->queue_cur->exec_cksum) {
 
@@ -804,7 +870,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
   /* Two walking bytes. */
 
-  if (len < 2) goto skip_bitflip;
+  if (len < 2) { goto skip_bitflip; }
 
   afl->stage_name = "bitflip 16/8";
   afl->stage_short = "flip16";
@@ -828,7 +894,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     *(u16 *)(out_buf + i) ^= 0xFFFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
     ++afl->stage_cur;
 
     *(u16 *)(out_buf + i) ^= 0xFFFF;
@@ -840,7 +906,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
   afl->stage_finds[STAGE_FLIP16] += new_hit_cnt - orig_hit_cnt;
   afl->stage_cycles[STAGE_FLIP16] += afl->stage_max;
 
-  if (len < 4) goto skip_bitflip;
+  if (len < 4) { goto skip_bitflip; }
 
   /* Four walking bytes. */
 
@@ -866,7 +932,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     *(u32 *)(out_buf + i) ^= 0xFFFFFFFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
     ++afl->stage_cur;
 
     *(u32 *)(out_buf + i) ^= 0xFFFFFFFF;
@@ -880,7 +946,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
 skip_bitflip:
 
-  if (afl->no_arith) goto skip_arith;
+  if (afl->no_arith) { goto skip_arith; }
 
   /**********************
    * ARITHMETIC INC/DEC *
@@ -924,12 +990,14 @@ skip_bitflip:
         afl->stage_cur_val = j;
         out_buf[i] = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       r = orig ^ (orig - j);
 
@@ -938,12 +1006,14 @@ skip_bitflip:
         afl->stage_cur_val = -j;
         out_buf[i] = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       out_buf[i] = orig;
 
@@ -958,7 +1028,7 @@ skip_bitflip:
 
   /* 16-bit arithmetics, both endians. */
 
-  if (len < 2) goto skip_arith;
+  if (len < 2) { goto skip_arith; }
 
   afl->stage_name = "arith 16/8";
   afl->stage_short = "arith16";
@@ -1000,24 +1070,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u16 *)(out_buf + i) = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig & 0xff) < j && !could_be_bitflip(r2)) {
 
         afl->stage_cur_val = -j;
         *(u16 *)(out_buf + i) = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       /* Big endian comes next. Same deal. */
 
@@ -1028,24 +1102,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u16 *)(out_buf + i) = SWAP16(SWAP16(orig) + j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig >> 8) < j && !could_be_bitflip(r4)) {
 
         afl->stage_cur_val = -j;
         *(u16 *)(out_buf + i) = SWAP16(SWAP16(orig) - j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       *(u16 *)(out_buf + i) = orig;
 
@@ -1060,7 +1138,7 @@ skip_bitflip:
 
   /* 32-bit arithmetics, both endians. */
 
-  if (len < 4) goto skip_arith;
+  if (len < 4) { goto skip_arith; }
 
   afl->stage_name = "arith 32/8";
   afl->stage_short = "arith32";
@@ -1101,24 +1179,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u32 *)(out_buf + i) = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig & 0xffff) < j && !could_be_bitflip(r2)) {
 
         afl->stage_cur_val = -j;
         *(u32 *)(out_buf + i) = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       /* Big endian next. */
 
@@ -1129,24 +1211,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u32 *)(out_buf + i) = SWAP32(SWAP32(orig) + j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((SWAP32(orig) & 0xffff) < j && !could_be_bitflip(r4)) {
 
         afl->stage_cur_val = -j;
         *(u32 *)(out_buf + i) = SWAP32(SWAP32(orig) - j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       *(u32 *)(out_buf + i) = orig;
 
@@ -1206,7 +1292,7 @@ skip_arith:
       afl->stage_cur_val = interesting_8[j];
       out_buf[i] = interesting_8[j];
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       out_buf[i] = orig;
       ++afl->stage_cur;
@@ -1222,7 +1308,7 @@ skip_arith:
 
   /* Setting 16-bit integers, both endians. */
 
-  if (afl->no_arith || len < 2) goto skip_interest;
+  if (afl->no_arith || len < 2) { goto skip_interest; }
 
   afl->stage_name = "interest 16/8";
   afl->stage_short = "int16";
@@ -1261,12 +1347,14 @@ skip_arith:
 
         *(u16 *)(out_buf + i) = interesting_16[j];
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((u16)interesting_16[j] != SWAP16(interesting_16[j]) &&
           !could_be_bitflip(orig ^ SWAP16(interesting_16[j])) &&
@@ -1276,12 +1364,14 @@ skip_arith:
         afl->stage_val_type = STAGE_VAL_BE;
 
         *(u16 *)(out_buf + i) = SWAP16(interesting_16[j]);
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
     }
 
@@ -1294,7 +1384,7 @@ skip_arith:
   afl->stage_finds[STAGE_INTEREST16] += new_hit_cnt - orig_hit_cnt;
   afl->stage_cycles[STAGE_INTEREST16] += afl->stage_max;
 
-  if (len < 4) goto skip_interest;
+  if (len < 4) { goto skip_interest; }
 
   /* Setting 32-bit integers, both endians. */
 
@@ -1336,12 +1426,14 @@ skip_arith:
 
         *(u32 *)(out_buf + i) = interesting_32[j];
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((u32)interesting_32[j] != SWAP32(interesting_32[j]) &&
           !could_be_bitflip(orig ^ SWAP32(interesting_32[j])) &&
@@ -1351,12 +1443,14 @@ skip_arith:
         afl->stage_val_type = STAGE_VAL_BE;
 
         *(u32 *)(out_buf + i) = SWAP32(interesting_32[j]);
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
     }
 
@@ -1375,7 +1469,7 @@ skip_interest:
    * DICTIONARY STUFF *
    ********************/
 
-  if (!afl->extras_cnt) goto skip_user_extras;
+  if (!afl->extras_cnt) { goto skip_user_extras; }
 
   /* Overwrite with user-supplied extras. */
 
@@ -1421,7 +1515,7 @@ skip_interest:
       last_len = afl->extras[j].len;
       memcpy(out_buf + i, afl->extras[j].data, last_len);
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       ++afl->stage_cur;
 
@@ -1489,7 +1583,7 @@ skip_interest:
 
 skip_user_extras:
 
-  if (!afl->a_extras_cnt) goto skip_extras;
+  if (!afl->a_extras_cnt) { goto skip_extras; }
 
   afl->stage_name = "auto extras (over)";
   afl->stage_short = "ext_AO";
@@ -1523,7 +1617,7 @@ skip_user_extras:
       last_len = afl->a_extras[j].len;
       memcpy(out_buf + i, afl->a_extras[j].data, last_len);
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       ++afl->stage_cur;
 
@@ -1545,22 +1639,22 @@ skip_extras:
      we're properly done with deterministic steps and can mark it as such
      in the .state/ directory. */
 
-  if (!afl->queue_cur->passed_det) mark_as_det_done(afl, afl->queue_cur);
+  if (!afl->queue_cur->passed_det) { mark_as_det_done(afl, afl->queue_cur); }
 
 custom_mutator_stage:
   /*******************
    * CUSTOM MUTATORS *
    *******************/
 
-  if (likely(!afl->mutator)) goto havoc_stage;
-  if (likely(!afl->mutator->afl_custom_fuzz)) goto havoc_stage;
+  if (likely(!afl->mutator)) { goto havoc_stage; }
+  if (likely(!afl->mutator->afl_custom_fuzz)) { goto havoc_stage; }
 
   afl->stage_name = "custom mutator";
   afl->stage_short = "custom";
   afl->stage_max = HAVOC_CYCLES * perf_score / afl->havoc_div / 100;
   afl->stage_val_type = STAGE_VAL_NONE;
 
-  if (afl->stage_max < HAVOC_MIN) afl->stage_max = HAVOC_MIN;
+  if (afl->stage_max < HAVOC_MIN) { afl->stage_max = HAVOC_MIN; }
 
   const u32 max_seed_size = MAX_FILE;
 
@@ -1589,8 +1683,11 @@ custom_mutator_stage:
 
     }
 
-    while (tid--)
+    while (tid--) {
+
       target = target->next;
+
+    }
 
     /* Make sure that the target has a reasonable length. */
 
@@ -1602,11 +1699,11 @@ custom_mutator_stage:
 
     }
 
-    if (!target) goto retry_external_pick;
+    if (!target) { goto retry_external_pick; }
 
     /* Read the additional testcase into a new buffer. */
     fd = open(target->fname, O_RDONLY);
-    if (unlikely(fd < 0)) PFATAL("Unable to open '%s'", target->fname);
+    if (unlikely(fd < 0)) { PFATAL("Unable to open '%s'", target->fname); }
 
     new_buf = ck_maybe_grow(BUF_PARAMS(out_scratch), target->len);
     ck_read(fd, new_buf, target->len, target->fname);
@@ -1618,8 +1715,11 @@ custom_mutator_stage:
         afl->mutator->data, out_buf, len, &mutated_buf, new_buf, target->len,
         max_seed_size);
 
-    if (unlikely(!mutated_buf))
+    if (unlikely(!mutated_buf)) {
+
       FATAL("Error in custom_fuzz. Size returned: %zd", mutated_size);
+
+    }
 
     if (mutated_size > 0) {
 
@@ -1695,7 +1795,7 @@ havoc_stage:
 
   }
 
-  if (afl->stage_max < HAVOC_MIN) afl->stage_max = HAVOC_MIN;
+  if (afl->stage_max < HAVOC_MIN) { afl->stage_max = HAVOC_MIN; }
 
   temp_len = len;
 
@@ -1710,10 +1810,13 @@ havoc_stage:
 
     stacked_custom_prob =
         afl->mutator->afl_custom_havoc_mutation_probability(afl->mutator->data);
-    if (stacked_custom_prob > 100)
+    if (stacked_custom_prob > 100) {
+
       FATAL(
           "The probability returned by afl_custom_havoc_mutation_propability "
           "has to be in the range 0-100.");
+
+    }
 
   }
 
@@ -1733,8 +1836,12 @@ havoc_stage:
         u8 *   custom_havoc_buf = NULL;
         size_t new_len = afl->mutator->afl_custom_havoc_mutation(
             afl->mutator->data, out_buf, temp_len, &custom_havoc_buf, MAX_FILE);
-        if (unlikely(!custom_havoc_buf))
+        if (unlikely(!custom_havoc_buf)) {
+
           FATAL("Error in custom_havoc (return %zd)", new_len);
+
+        }
+
         if (likely(new_len > 0 && custom_havoc_buf)) {
 
           temp_len = new_len;
@@ -1771,7 +1878,7 @@ havoc_stage:
 
           /* Set word to interesting value, randomly choosing endian. */
 
-          if (temp_len < 2) break;
+          if (temp_len < 2) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1791,7 +1898,7 @@ havoc_stage:
 
           /* Set dword to interesting value, randomly choosing endian. */
 
-          if (temp_len < 4) break;
+          if (temp_len < 4) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1825,7 +1932,7 @@ havoc_stage:
 
           /* Randomly subtract from word, random endian. */
 
-          if (temp_len < 2) break;
+          if (temp_len < 2) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1849,7 +1956,7 @@ havoc_stage:
 
           /* Randomly add to word, random endian. */
 
-          if (temp_len < 2) break;
+          if (temp_len < 2) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1873,7 +1980,7 @@ havoc_stage:
 
           /* Randomly subtract from dword, random endian. */
 
-          if (temp_len < 4) break;
+          if (temp_len < 4) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1897,7 +2004,7 @@ havoc_stage:
 
           /* Randomly add to dword, random endian. */
 
-          if (temp_len < 4) break;
+          if (temp_len < 4) { break; }
 
           if (rand_below(afl, 2)) {
 
@@ -1934,7 +2041,7 @@ havoc_stage:
 
           u32 del_from, del_len;
 
-          if (temp_len < 2) break;
+          if (temp_len < 2) { break; }
 
           /* Don't delete too much. */
 
@@ -1984,13 +2091,18 @@ havoc_stage:
 
             /* Inserted part */
 
-            if (actually_clone)
+            if (actually_clone) {
+
               memcpy(new_buf + clone_to, out_buf + clone_from, clone_len);
-            else
+
+            } else {
+
               memset(new_buf + clone_to,
                      rand_below(afl, 2) ? rand_below(afl, 256)
                                         : out_buf[rand_below(afl, temp_len)],
                      clone_len);
+
+            }
 
             /* Tail */
             memcpy(new_buf + clone_to + clone_len, out_buf + clone_to,
@@ -2012,7 +2124,7 @@ havoc_stage:
 
           u32 copy_from, copy_to, copy_len;
 
-          if (temp_len < 2) break;
+          if (temp_len < 2) { break; }
 
           copy_len = choose_block_len(afl, temp_len - 1);
 
@@ -2021,15 +2133,20 @@ havoc_stage:
 
           if (rand_below(afl, 4)) {
 
-            if (copy_from != copy_to)
+            if (copy_from != copy_to) {
+
               memmove(out_buf + copy_to, out_buf + copy_from, copy_len);
 
-          } else
+            }
+
+          } else {
 
             memset(out_buf + copy_to,
                    rand_below(afl, 2) ? rand_below(afl, 256)
                                       : out_buf[rand_below(afl, temp_len)],
                    copy_len);
+
+          }
 
           break;
 
@@ -2051,7 +2168,7 @@ havoc_stage:
             u32 extra_len = afl->a_extras[use_extra].len;
             u32 insert_at;
 
-            if (extra_len > temp_len) break;
+            if (extra_len > temp_len) { break; }
 
             insert_at = rand_below(afl, temp_len - extra_len + 1);
             memcpy(out_buf + insert_at, afl->a_extras[use_extra].data,
@@ -2065,7 +2182,7 @@ havoc_stage:
             u32 extra_len = afl->extras[use_extra].len;
             u32 insert_at;
 
-            if (extra_len > temp_len) break;
+            if (extra_len > temp_len) { break; }
 
             insert_at = rand_below(afl, temp_len - extra_len + 1);
             memcpy(out_buf + insert_at, afl->extras[use_extra].data, extra_len);
@@ -2089,7 +2206,7 @@ havoc_stage:
             use_extra = rand_below(afl, afl->a_extras_cnt);
             extra_len = afl->a_extras[use_extra].len;
 
-            if (temp_len + extra_len >= MAX_FILE) break;
+            if (temp_len + extra_len >= MAX_FILE) { break; }
 
             new_buf =
                 ck_maybe_grow(BUF_PARAMS(out_scratch), temp_len + extra_len);
@@ -2106,7 +2223,7 @@ havoc_stage:
             use_extra = rand_below(afl, afl->extras_cnt);
             extra_len = afl->extras[use_extra].len;
 
-            if (temp_len + extra_len >= MAX_FILE) break;
+            if (temp_len + extra_len >= MAX_FILE) { break; }
 
             new_buf =
                 ck_maybe_grow(BUF_PARAMS(out_scratch), temp_len + extra_len);
@@ -2136,7 +2253,7 @@ havoc_stage:
 
     }
 
-    if (common_fuzz_stuff(afl, out_buf, temp_len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, temp_len)) { goto abandon_entry; }
 
     /* out_buf might have been mangled a bit, so let's restore it to its
        original size and shape. */
@@ -2226,8 +2343,11 @@ retry_splicing:
 
     }
 
-    while (tid--)
+    while (tid--) {
+
       target = target->next;
+
+    }
 
     /* Make sure that the target has a reasonable length. */
 
@@ -2238,13 +2358,13 @@ retry_splicing:
 
     }
 
-    if (!target) goto retry_splicing;
+    if (!target) { goto retry_splicing; }
 
     /* Read the testcase into a new buffer. */
 
     fd = open(target->fname, O_RDONLY);
 
-    if (unlikely(fd < 0)) PFATAL("Unable to open '%s'", target->fname);
+    if (unlikely(fd < 0)) { PFATAL("Unable to open '%s'", target->fname); }
 
     new_buf = ck_maybe_grow(BUF_PARAMS(in_scratch), target->len);
 
@@ -2288,14 +2408,18 @@ retry_splicing:
 
 radamsa_stage:
 
-  if (likely(!afl->use_radamsa || !afl->radamsa_mutate_ptr)) goto abandon_entry;
+  if (likely(!afl->use_radamsa || !afl->radamsa_mutate_ptr)) {
+
+    goto abandon_entry;
+
+  }
 
   afl->stage_name = "radamsa";
   afl->stage_short = "radamsa";
   afl->stage_max = (HAVOC_CYCLES * perf_score / afl->havoc_div / 100)
                    << afl->use_radamsa;
 
-  if (afl->stage_max < HAVOC_MIN) afl->stage_max = HAVOC_MIN;
+  if (afl->stage_max < HAVOC_MIN) { afl->stage_max = HAVOC_MIN; }
 
   orig_hit_cnt = afl->queued_paths + afl->unique_crashes;
 
@@ -2351,7 +2475,7 @@ abandon_entry:
 
     --afl->pending_not_fuzzed;
     afl->queue_cur->was_fuzzed = 1;
-    if (afl->queue_cur->favored) --afl->pending_favored;
+    if (afl->queue_cur->favored) { --afl->pending_favored; }
 
   }
 
@@ -2405,8 +2529,11 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
        cases. */
 
     if ((afl->queue_cur->was_fuzzed || !afl->queue_cur->favored) &&
-        rand_below(afl, 100) < SKIP_TO_NEW_PROB)
+        rand_below(afl, 100) < SKIP_TO_NEW_PROB) {
+
       return 1;
+
+    }
 
   } else if (!afl->dumb_mode && !afl->queue_cur->favored &&
 
@@ -2418,11 +2545,11 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     if (afl->queue_cycle > 1 && !afl->queue_cur->was_fuzzed) {
 
-      if (rand_below(afl, 100) < SKIP_NFAV_NEW_PROB) return 1;
+      if (rand_below(afl, 100) < SKIP_NFAV_NEW_PROB) { return 1; }
 
     } else {
 
-      if (rand_below(afl, 100) < SKIP_NFAV_OLD_PROB) return 1;
+      if (rand_below(afl, 100) < SKIP_NFAV_OLD_PROB) { return 1; }
 
     }
 
@@ -2442,14 +2569,17 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
   fd = open(afl->queue_cur->fname, O_RDONLY);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", afl->queue_cur->fname);
+  if (fd < 0) { PFATAL("Unable to open '%s'", afl->queue_cur->fname); }
 
   len = afl->queue_cur->len;
 
   orig_in = in_buf = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 
-  if (orig_in == MAP_FAILED)
+  if (orig_in == MAP_FAILED) {
+
     PFATAL("Unable to mmap '%s'", afl->queue_cur->fname);
+
+  }
 
   close(fd);
 
@@ -2476,7 +2606,11 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
       res =
           calibrate_case(afl, afl->queue_cur, in_buf, afl->queue_cycle - 1, 0);
 
-      if (res == FSRV_RUN_ERROR) FATAL("Unable to execute target application");
+      if (res == FSRV_RUN_ERROR) {
+
+        FATAL("Unable to execute target application");
+
+      }
 
     }
 
@@ -2497,7 +2631,11 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     u8 res = trim_case(afl, afl->queue_cur, in_buf);
 
-    if (res == FSRV_RUN_ERROR) FATAL("Unable to execute target application");
+    if (res == FSRV_RUN_ERROR) {
+
+      FATAL("Unable to execute target application");
+
+    }
 
     if (afl->stop_soon) {
 
@@ -2525,8 +2663,11 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
   if (afl->shm.cmplog_mode && !afl->queue_cur->fully_colorized) {
 
     if (input_to_state_stage(afl, in_buf, out_buf, len,
-                             afl->queue_cur->exec_cksum))
+                             afl->queue_cur->exec_cksum)) {
+
       goto abandon_entry;
+
+    }
 
   }
 
@@ -2549,15 +2690,21 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
      testing in earlier, resumed runs (passed_det). */
 
   if (afl->skip_deterministic || afl->queue_cur->was_fuzzed ||
-      afl->queue_cur->passed_det)
+      afl->queue_cur->passed_det) {
+
     goto havoc_stage;
+
+  }
 
   /* Skip deterministic fuzzing if exec path checksum puts this out of scope
      for this master instance. */
 
   if (afl->master_max &&
-      (afl->queue_cur->exec_cksum % afl->master_max) != afl->master_id - 1)
+      (afl->queue_cur->exec_cksum % afl->master_max) != afl->master_id - 1) {
+
     goto havoc_stage;
+
+  }
 
   doing_det = 1;
 
@@ -2592,7 +2739,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     FLIP_BIT(out_buf, afl->stage_cur);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
 
@@ -2632,20 +2779,30 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
         /* If at end of file and we are still collecting a string, grab the
            final character and force output. */
 
-        if (a_len < MAX_AUTO_EXTRA)
+        if (a_len < MAX_AUTO_EXTRA) {
+
           a_collect[a_len] = out_buf[afl->stage_cur >> 3];
+
+        }
+
         ++a_len;
 
-        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA)
+        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA) {
+
           maybe_add_auto((u8 *)afl, a_collect, a_len);
+
+        }
 
       } else if (cksum != prev_cksum) {
 
         /* Otherwise, if the checksum has changed, see if we have something
            worthwhile queued up, and collect that if the answer is yes. */
 
-        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA)
+        if (a_len >= MIN_AUTO_EXTRA && a_len <= MAX_AUTO_EXTRA) {
+
           maybe_add_auto((u8 *)afl, a_collect, a_len);
+
+        }
 
         a_len = 0;
         prev_cksum = cksum;
@@ -2657,8 +2814,12 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
       if (cksum != afl->queue_cur->exec_cksum) {
 
-        if (a_len < MAX_AUTO_EXTRA)
+        if (a_len < MAX_AUTO_EXTRA) {
+
           a_collect[a_len] = out_buf[afl->stage_cur >> 3];
+
+        }
+
         ++a_len;
 
       }
@@ -2687,7 +2848,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
@@ -2716,7 +2877,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
     FLIP_BIT(out_buf, afl->stage_cur + 2);
     FLIP_BIT(out_buf, afl->stage_cur + 3);
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     FLIP_BIT(out_buf, afl->stage_cur);
     FLIP_BIT(out_buf, afl->stage_cur + 1);
@@ -2770,7 +2931,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     out_buf[afl->stage_cur] ^= 0xFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
     /* We also use this stage to pull off a simple trick: we identify
        bytes that seem to have no effect on the current execution path
@@ -2784,10 +2945,15 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
       /* If in dumb mode or if the file is very short, just flag everything
          without wasting time on checksums. */
 
-      if (!afl->dumb_mode && len >= EFF_MIN_LEN)
+      if (!afl->dumb_mode && len >= EFF_MIN_LEN) {
+
         cksum = hash32(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
-      else
+
+      } else {
+
         cksum = ~afl->queue_cur->exec_cksum;
+
+      }
 
       if (cksum != afl->queue_cur->exec_cksum) {
 
@@ -2828,7 +2994,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
   /* Two walking bytes. */
 
-  if (len < 2) goto skip_bitflip;
+  if (len < 2) { goto skip_bitflip; }
 
   afl->stage_name = "bitflip 16/8";
   afl->stage_short = "flip16";
@@ -2852,7 +3018,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     *(u16 *)(out_buf + i) ^= 0xFFFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
     ++afl->stage_cur;
 
     *(u16 *)(out_buf + i) ^= 0xFFFF;
@@ -2864,7 +3030,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
   afl->stage_finds[STAGE_FLIP16] += new_hit_cnt - orig_hit_cnt;
   afl->stage_cycles[STAGE_FLIP16] += afl->stage_max;
 
-  if (len < 4) goto skip_bitflip;
+  if (len < 4) { goto skip_bitflip; }
 
   /* Four walking bytes. */
 
@@ -2890,7 +3056,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
     *(u32 *)(out_buf + i) ^= 0xFFFFFFFF;
 
-    if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+    if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
     ++afl->stage_cur;
 
     *(u32 *)(out_buf + i) ^= 0xFFFFFFFF;
@@ -2904,7 +3070,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
 skip_bitflip:
 
-  if (afl->no_arith) goto skip_arith;
+  if (afl->no_arith) { goto skip_arith; }
 
   /**********************
    * ARITHMETIC INC/DEC *
@@ -2948,12 +3114,14 @@ skip_bitflip:
         afl->stage_cur_val = j;
         out_buf[i] = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       r = orig ^ (orig - j);
 
@@ -2962,12 +3130,14 @@ skip_bitflip:
         afl->stage_cur_val = -j;
         out_buf[i] = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       out_buf[i] = orig;
 
@@ -2982,7 +3152,7 @@ skip_bitflip:
 
   /* 16-bit arithmetics, both endians. */
 
-  if (len < 2) goto skip_arith;
+  if (len < 2) { goto skip_arith; }
 
   afl->stage_name = "arith 16/8";
   afl->stage_short = "arith16";
@@ -3024,24 +3194,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u16 *)(out_buf + i) = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig & 0xff) < j && !could_be_bitflip(r2)) {
 
         afl->stage_cur_val = -j;
         *(u16 *)(out_buf + i) = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       /* Big endian comes next. Same deal. */
 
@@ -3052,24 +3226,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u16 *)(out_buf + i) = SWAP16(SWAP16(orig) + j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig >> 8) < j && !could_be_bitflip(r4)) {
 
         afl->stage_cur_val = -j;
         *(u16 *)(out_buf + i) = SWAP16(SWAP16(orig) - j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       *(u16 *)(out_buf + i) = orig;
 
@@ -3084,7 +3262,7 @@ skip_bitflip:
 
   /* 32-bit arithmetics, both endians. */
 
-  if (len < 4) goto skip_arith;
+  if (len < 4) { goto skip_arith; }
 
   afl->stage_name = "arith 32/8";
   afl->stage_short = "arith32";
@@ -3125,24 +3303,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u32 *)(out_buf + i) = orig + j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((orig & 0xffff) < j && !could_be_bitflip(r2)) {
 
         afl->stage_cur_val = -j;
         *(u32 *)(out_buf + i) = orig - j;
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       /* Big endian next. */
 
@@ -3153,24 +3335,28 @@ skip_bitflip:
         afl->stage_cur_val = j;
         *(u32 *)(out_buf + i) = SWAP32(SWAP32(orig) + j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((SWAP32(orig) & 0xffff) < j && !could_be_bitflip(r4)) {
 
         afl->stage_cur_val = -j;
         *(u32 *)(out_buf + i) = SWAP32(SWAP32(orig) - j);
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       *(u32 *)(out_buf + i) = orig;
 
@@ -3230,7 +3416,7 @@ skip_arith:
       afl->stage_cur_val = interesting_8[j];
       out_buf[i] = interesting_8[j];
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       out_buf[i] = orig;
       ++afl->stage_cur;
@@ -3246,7 +3432,7 @@ skip_arith:
 
   /* Setting 16-bit integers, both endians. */
 
-  if (afl->no_arith || len < 2) goto skip_interest;
+  if (afl->no_arith || len < 2) { goto skip_interest; }
 
   afl->stage_name = "interest 16/8";
   afl->stage_short = "int16";
@@ -3285,12 +3471,14 @@ skip_arith:
 
         *(u16 *)(out_buf + i) = interesting_16[j];
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((u16)interesting_16[j] != SWAP16(interesting_16[j]) &&
           !could_be_bitflip(orig ^ SWAP16(interesting_16[j])) &&
@@ -3300,12 +3488,14 @@ skip_arith:
         afl->stage_val_type = STAGE_VAL_BE;
 
         *(u16 *)(out_buf + i) = SWAP16(interesting_16[j]);
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
     }
 
@@ -3318,7 +3508,7 @@ skip_arith:
   afl->stage_finds[STAGE_INTEREST16] += new_hit_cnt - orig_hit_cnt;
   afl->stage_cycles[STAGE_INTEREST16] += afl->stage_max;
 
-  if (len < 4) goto skip_interest;
+  if (len < 4) { goto skip_interest; }
 
   /* Setting 32-bit integers, both endians. */
 
@@ -3360,12 +3550,14 @@ skip_arith:
 
         *(u32 *)(out_buf + i) = interesting_32[j];
 
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
       if ((u32)interesting_32[j] != SWAP32(interesting_32[j]) &&
           !could_be_bitflip(orig ^ SWAP32(interesting_32[j])) &&
@@ -3375,12 +3567,14 @@ skip_arith:
         afl->stage_val_type = STAGE_VAL_BE;
 
         *(u32 *)(out_buf + i) = SWAP32(interesting_32[j]);
-        if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+        if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
         ++afl->stage_cur;
 
-      } else
+      } else {
 
         --afl->stage_max;
+
+      }
 
     }
 
@@ -3399,7 +3593,7 @@ skip_interest:
    * DICTIONARY STUFF *
    ********************/
 
-  if (!afl->extras_cnt) goto skip_user_extras;
+  if (!afl->extras_cnt) { goto skip_user_extras; }
 
   /* Overwrite with user-supplied extras. */
 
@@ -3445,7 +3639,7 @@ skip_interest:
       last_len = afl->extras[j].len;
       memcpy(out_buf + i, afl->extras[j].data, last_len);
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       ++afl->stage_cur;
 
@@ -3513,7 +3707,7 @@ skip_interest:
 
 skip_user_extras:
 
-  if (!afl->a_extras_cnt) goto skip_extras;
+  if (!afl->a_extras_cnt) { goto skip_extras; }
 
   afl->stage_name = "auto extras (over)";
   afl->stage_short = "ext_AO";
@@ -3547,7 +3741,7 @@ skip_user_extras:
       last_len = afl->a_extras[j].len;
       memcpy(out_buf + i, afl->a_extras[j].data, last_len);
 
-      if (common_fuzz_stuff(afl, out_buf, len)) goto abandon_entry;
+      if (common_fuzz_stuff(afl, out_buf, len)) { goto abandon_entry; }
 
       ++afl->stage_cur;
 
@@ -3569,7 +3763,7 @@ skip_extras:
      we're properly done with deterministic steps and can mark it as such
      in the .state/ directory. */
 
-  if (!afl->queue_cur->passed_det) mark_as_det_done(afl, afl->queue_cur);
+  if (!afl->queue_cur->passed_det) { mark_as_det_done(afl, afl->queue_cur); }
 
   /****************
    * RANDOM HAVOC *
@@ -3652,7 +3846,7 @@ pacemaker_fuzzing:
 
       }
 
-      if (afl->stage_max < HAVOC_MIN) afl->stage_max = HAVOC_MIN;
+      if (afl->stage_max < HAVOC_MIN) { afl->stage_max = HAVOC_MIN; }
 
       temp_len = len;
 
@@ -3684,7 +3878,7 @@ pacemaker_fuzzing:
               break;
 
             case 1:
-              if (temp_len < 2) break;
+              if (temp_len < 2) { break; }
               temp_len_puppet = rand_below(afl, (temp_len << 3) - 1);
               FLIP_BIT(out_buf, temp_len_puppet);
               FLIP_BIT(out_buf, temp_len_puppet + 1);
@@ -3692,7 +3886,7 @@ pacemaker_fuzzing:
               break;
 
             case 2:
-              if (temp_len < 2) break;
+              if (temp_len < 2) { break; }
               temp_len_puppet = rand_below(afl, (temp_len << 3) - 3);
               FLIP_BIT(out_buf, temp_len_puppet);
               FLIP_BIT(out_buf, temp_len_puppet + 1);
@@ -3702,19 +3896,19 @@ pacemaker_fuzzing:
               break;
 
             case 3:
-              if (temp_len < 4) break;
+              if (temp_len < 4) { break; }
               out_buf[rand_below(afl, temp_len)] ^= 0xFF;
               MOpt_globals.cycles_v2[STAGE_FLIP8] += 1;
               break;
 
             case 4:
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
               *(u16 *)(out_buf + rand_below(afl, temp_len - 1)) ^= 0xFFFF;
               MOpt_globals.cycles_v2[STAGE_FLIP16] += 1;
               break;
 
             case 5:
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
               *(u32 *)(out_buf + rand_below(afl, temp_len - 3)) ^= 0xFFFFFFFF;
               MOpt_globals.cycles_v2[STAGE_FLIP32] += 1;
               break;
@@ -3729,7 +3923,7 @@ pacemaker_fuzzing:
 
             case 7:
               /* Randomly subtract from word, random endian. */
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
               if (rand_below(afl, 2)) {
 
                 u32 pos = rand_below(afl, temp_len - 1);
@@ -3764,7 +3958,7 @@ pacemaker_fuzzing:
 
             case 8:
               /* Randomly subtract from dword, random endian. */
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
               if (rand_below(afl, 2)) {
 
                 u32 pos = rand_below(afl, temp_len - 3);
@@ -3800,7 +3994,7 @@ pacemaker_fuzzing:
 
             case 9:
               /* Set byte to interesting value. */
-              if (temp_len < 4) break;
+              if (temp_len < 4) { break; }
               out_buf[rand_below(afl, temp_len)] =
                   interesting_8[rand_below(afl, sizeof(interesting_8))];
               MOpt_globals.cycles_v2[STAGE_INTEREST8] += 1;
@@ -3808,7 +4002,7 @@ pacemaker_fuzzing:
 
             case 10:
               /* Set word to interesting value, randomly choosing endian. */
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
               if (rand_below(afl, 2)) {
 
                 *(u16 *)(out_buf + rand_below(afl, temp_len - 1)) =
@@ -3829,7 +4023,7 @@ pacemaker_fuzzing:
             case 11:
               /* Set dword to interesting value, randomly choosing endian. */
 
-              if (temp_len < 8) break;
+              if (temp_len < 8) { break; }
 
               if (rand_below(afl, 2)) {
 
@@ -3866,7 +4060,7 @@ pacemaker_fuzzing:
 
               u32 del_from, del_len;
 
-              if (temp_len < 2) break;
+              if (temp_len < 2) { break; }
 
               /* Don't delete too much. */
 
@@ -3917,14 +4111,19 @@ pacemaker_fuzzing:
 
                 /* Inserted part */
 
-                if (actually_clone)
+                if (actually_clone) {
+
                   memcpy(new_buf + clone_to, out_buf + clone_from, clone_len);
-                else
+
+                } else {
+
                   memset(new_buf + clone_to,
                          rand_below(afl, 2)
                              ? rand_below(afl, 256)
                              : out_buf[rand_below(afl, temp_len)],
                          clone_len);
+
+                }
 
                 /* Tail */
                 memcpy(new_buf + clone_to + clone_len, out_buf + clone_to,
@@ -3946,7 +4145,7 @@ pacemaker_fuzzing:
 
               u32 copy_from, copy_to, copy_len;
 
-              if (temp_len < 2) break;
+              if (temp_len < 2) { break; }
 
               copy_len = choose_block_len(afl, temp_len - 1);
 
@@ -3955,15 +4154,21 @@ pacemaker_fuzzing:
 
               if (rand_below(afl, 4)) {
 
-                if (copy_from != copy_to)
+                if (copy_from != copy_to) {
+
                   memmove(out_buf + copy_to, out_buf + copy_from, copy_len);
 
-              } else
+                }
+
+              } else {
 
                 memset(out_buf + copy_to,
                        rand_below(afl, 2) ? rand_below(afl, 256)
                                           : out_buf[rand_below(afl, temp_len)],
                        copy_len);
+
+              }
+
               MOpt_globals.cycles_v2[STAGE_OverWrite75] += 1;
               break;
 
@@ -3977,8 +4182,11 @@ pacemaker_fuzzing:
 
         u64 temp_total_found = afl->queued_paths + afl->unique_crashes;
 
-        if (common_fuzz_stuff(afl, out_buf, temp_len))
+        if (common_fuzz_stuff(afl, out_buf, temp_len)) {
+
           goto abandon_entry_puppet;
+
+        }
 
         /* out_buf might have been mangled a bit, so let's restore it to its
            original size and shape. */
@@ -4011,8 +4219,11 @@ pacemaker_fuzzing:
           afl->total_puppet_find = afl->total_puppet_find + temp_temp_puppet;
           for (i = 0; i < operator_num; ++i) {
 
-            if (MOpt_globals.cycles_v2[i] > MOpt_globals.cycles_v3[i])
+            if (MOpt_globals.cycles_v2[i] > MOpt_globals.cycles_v3[i]) {
+
               MOpt_globals.finds_v2[i] += temp_temp_puppet;
+
+            }
 
           }
 
@@ -4085,8 +4296,11 @@ pacemaker_fuzzing:
 
         }
 
-        while (tid--)
+        while (tid--) {
+
           target = target->next;
+
+        }
 
         /* Make sure that the target has a reasonable length. */
 
@@ -4097,13 +4311,13 @@ pacemaker_fuzzing:
 
         }
 
-        if (!target) goto retry_splicing_puppet;
+        if (!target) { goto retry_splicing_puppet; }
 
         /* Read the testcase into a new buffer. */
 
         fd = open(target->fname, O_RDONLY);
 
-        if (fd < 0) PFATAL("Unable to open '%s'", target->fname);
+        if (fd < 0) { PFATAL("Unable to open '%s'", target->fname); }
 
         new_buf = ck_maybe_grow(BUF_PARAMS(in_scratch), target->len);
 
@@ -4147,11 +4361,14 @@ pacemaker_fuzzing:
     abandon_entry:
     abandon_entry_puppet:
 
-      if (splice_cycle >= afl->SPLICE_CYCLES_puppet)
+      if (splice_cycle >= afl->SPLICE_CYCLES_puppet) {
+
         afl->SPLICE_CYCLES_puppet =
             (rand_below(
                  afl, SPLICE_CYCLES_puppet_up - SPLICE_CYCLES_puppet_low + 1) +
              SPLICE_CYCLES_puppet_low);
+
+      }
 
       afl->splicing_with = -1;
 
@@ -4205,10 +4422,13 @@ pacemaker_fuzzing:
 
             double temp_eff = 0.0;
 
-            if (MOpt_globals.cycles_v2[i] > MOpt_globals.cycles[i])
+            if (MOpt_globals.cycles_v2[i] > MOpt_globals.cycles[i]) {
+
               temp_eff =
                   (double)(MOpt_globals.finds_v2[i] - MOpt_globals.finds[i]) /
                   (double)(MOpt_globals.cycles_v2[i] - MOpt_globals.cycles[i]);
+
+            }
 
             if (afl->eff_best[afl->swarm_now][i] < temp_eff) {
 
@@ -4255,8 +4475,11 @@ pacemaker_fuzzing:
 
             }
 
-            if (afl->swarm_now < 0 || afl->swarm_now > swarm_num - 1)
+            if (afl->swarm_now < 0 || afl->swarm_now > swarm_num - 1) {
+
               PFATAL("swarm_now error number  %d", afl->swarm_now);
+
+            }
 
           }                               /* if afl->swarm_now == swarm_num */
 
@@ -4307,7 +4530,7 @@ u8 pilot_fuzzing(afl_state_t *afl) {
 void pso_updating(afl_state_t *afl) {
 
   afl->g_now += 1;
-  if (afl->g_now > afl->g_max) afl->g_now = 0;
+  if (afl->g_now > afl->g_max) { afl->g_now = 0; }
   afl->w_now =
       (afl->w_init - afl->w_end) * (afl->g_max - afl->g_now) / (afl->g_max) +
       afl->w_end;
@@ -4331,9 +4554,12 @@ void pso_updating(afl_state_t *afl) {
 
   for (i = 0; i < operator_num; ++i) {
 
-    if (afl->operator_finds_puppet[i])
+    if (afl->operator_finds_puppet[i]) {
+
       afl->G_best[i] = (double)((double)(afl->operator_finds_puppet[i]) /
                                 (double)(temp_operator_finds_puppet));
+
+    }
 
   }
 
@@ -4348,10 +4574,16 @@ void pso_updating(afl_state_t *afl) {
           RAND_C * (afl->L_best[tmp_swarm][i] - afl->x_now[tmp_swarm][i]) +
           RAND_C * (afl->G_best[i] - afl->x_now[tmp_swarm][i]);
       afl->x_now[tmp_swarm][i] += afl->v_now[tmp_swarm][i];
-      if (afl->x_now[tmp_swarm][i] > v_max)
+      if (afl->x_now[tmp_swarm][i] > v_max) {
+
         afl->x_now[tmp_swarm][i] = v_max;
-      else if (afl->x_now[tmp_swarm][i] < v_min)
+
+      } else if (afl->x_now[tmp_swarm][i] < v_min) {
+
         afl->x_now[tmp_swarm][i] = v_min;
+
+      }
+
       x_temp += afl->x_now[tmp_swarm][i];
 
     }
@@ -4359,17 +4591,25 @@ void pso_updating(afl_state_t *afl) {
     for (i = 0; i < operator_num; ++i) {
 
       afl->x_now[tmp_swarm][i] = afl->x_now[tmp_swarm][i] / x_temp;
-      if (likely(i != 0))
+      if (likely(i != 0)) {
+
         afl->probability_now[tmp_swarm][i] =
             afl->probability_now[tmp_swarm][i - 1] + afl->x_now[tmp_swarm][i];
-      else
+
+      } else {
+
         afl->probability_now[tmp_swarm][i] = afl->x_now[tmp_swarm][i];
+
+      }
 
     }
 
     if (afl->probability_now[tmp_swarm][operator_num - 1] < 0.99 ||
-        afl->probability_now[tmp_swarm][operator_num - 1] > 1.01)
+        afl->probability_now[tmp_swarm][operator_num - 1] > 1.01) {
+
       FATAL("ERROR probability");
+
+    }
 
   }
 
@@ -4410,12 +4650,19 @@ u8 fuzz_one(afl_state_t *afl) {
 
   if (afl->limit_time_sig != 0) {
 
-    if (afl->key_module == 0)
+    if (afl->key_module == 0) {
+
       key_val_lv_2 = pilot_fuzzing(afl);
-    else if (afl->key_module == 1)
+
+    } else if (afl->key_module == 1) {
+
       key_val_lv_2 = core_fuzzing(afl);
-    else if (afl->key_module == 2)
+
+    } else if (afl->key_module == 2) {
+
       pso_updating(afl);
+
+    }
 
   }
 

--- a/src/afl-fuzz-python.c
+++ b/src/afl-fuzz-python.c
@@ -111,10 +111,10 @@ static size_t fuzz_py(void *py_mutator, u8 *buf, size_t buf_size, u8 **out_buf,
 
 static py_mutator_t *init_py_module(afl_state_t *afl, u8 *module_name) {
 
-  if (!module_name) return NULL;
+  if (!module_name) { return NULL; }
 
   py_mutator_t *py = calloc(1, sizeof(py_mutator_t));
-  if (!py) PFATAL("Could not allocate memory for python mutator!");
+  if (!py) { PFATAL("Could not allocate memory for python mutator!"); }
 
   Py_Initialize();
 
@@ -160,12 +160,12 @@ static py_mutator_t *init_py_module(afl_state_t *afl, u8 *module_name) {
         if (py_idx == PY_FUNC_PRE_SAVE) {
 
           // Implenting the pre_save API is optional for now
-          if (PyErr_Occurred()) PyErr_Print();
+          if (PyErr_Occurred()) { PyErr_Print(); }
 
         } else if (py_idx >= PY_FUNC_INIT_TRIM && py_idx <= PY_FUNC_TRIM) {
 
           // Implementing the trim API is optional for now
-          if (PyErr_Occurred()) PyErr_Print();
+          if (PyErr_Occurred()) { PyErr_Print(); }
           py_notrim = 1;
 
         } else if ((py_idx >= PY_FUNC_HAVOC_MUTATION) &&
@@ -173,11 +173,11 @@ static py_mutator_t *init_py_module(afl_state_t *afl, u8 *module_name) {
                    (py_idx <= PY_FUNC_QUEUE_NEW_ENTRY)) {
 
           // Implenting the havoc and queue API is optional for now
-          if (PyErr_Occurred()) PyErr_Print();
+          if (PyErr_Occurred()) { PyErr_Print(); }
 
         } else {
 
-          if (PyErr_Occurred()) PyErr_Print();
+          if (PyErr_Occurred()) { PyErr_Print(); }
           fprintf(stderr,
                   "Cannot find/call function with index %d in external "
                   "Python module.\n",
@@ -222,8 +222,11 @@ void finalize_py_module(void *py_mutator) {
     deinit_py(py_mutator);
 
     u32 i;
-    for (i = 0; i < PY_FUNC_COUNT; ++i)
+    for (i = 0; i < PY_FUNC_COUNT; ++i) {
+
       Py_XDECREF(py->py_functions[i]);
+
+    }
 
     Py_DECREF(py->py_module);
 
@@ -308,37 +311,66 @@ void load_custom_mutator_py(afl_state_t *afl, char *module_name) {
 
   PyObject **py_functions = py_mutator->py_functions;
 
-  if (py_functions[PY_FUNC_INIT]) afl->mutator->afl_custom_init = unsupported;
+  if (py_functions[PY_FUNC_INIT]) {
 
-  if (py_functions[PY_FUNC_DEINIT]) afl->mutator->afl_custom_deinit = deinit_py;
+    afl->mutator->afl_custom_init = unsupported;
+
+  }
+
+  if (py_functions[PY_FUNC_DEINIT]) {
+
+    afl->mutator->afl_custom_deinit = deinit_py;
+
+  }
 
   /* "afl_custom_fuzz" should not be NULL, but the interface of Python mutator
      is quite different from the custom mutator. */
   afl->mutator->afl_custom_fuzz = fuzz_py;
 
-  if (py_functions[PY_FUNC_PRE_SAVE])
+  if (py_functions[PY_FUNC_PRE_SAVE]) {
+
     afl->mutator->afl_custom_pre_save = pre_save_py;
 
-  if (py_functions[PY_FUNC_INIT_TRIM])
+  }
+
+  if (py_functions[PY_FUNC_INIT_TRIM]) {
+
     afl->mutator->afl_custom_init_trim = init_trim_py;
 
-  if (py_functions[PY_FUNC_POST_TRIM])
+  }
+
+  if (py_functions[PY_FUNC_POST_TRIM]) {
+
     afl->mutator->afl_custom_post_trim = post_trim_py;
 
-  if (py_functions[PY_FUNC_TRIM]) afl->mutator->afl_custom_trim = trim_py;
+  }
 
-  if (py_functions[PY_FUNC_HAVOC_MUTATION])
+  if (py_functions[PY_FUNC_TRIM]) { afl->mutator->afl_custom_trim = trim_py; }
+
+  if (py_functions[PY_FUNC_HAVOC_MUTATION]) {
+
     afl->mutator->afl_custom_havoc_mutation = havoc_mutation_py;
 
-  if (py_functions[PY_FUNC_HAVOC_MUTATION_PROBABILITY])
+  }
+
+  if (py_functions[PY_FUNC_HAVOC_MUTATION_PROBABILITY]) {
+
     afl->mutator->afl_custom_havoc_mutation_probability =
         havoc_mutation_probability_py;
 
-  if (py_functions[PY_FUNC_QUEUE_GET])
+  }
+
+  if (py_functions[PY_FUNC_QUEUE_GET]) {
+
     afl->mutator->afl_custom_queue_get = queue_get_py;
 
-  if (py_functions[PY_FUNC_QUEUE_NEW_ENTRY])
+  }
+
+  if (py_functions[PY_FUNC_QUEUE_NEW_ENTRY]) {
+
     afl->mutator->afl_custom_queue_new_entry = queue_new_entry_py;
+
+  }
 
   OKF("Python mutator '%s' installed successfully.", module_name);
 

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -38,7 +38,7 @@ void mark_as_det_done(afl_state_t *afl, struct queue_entry *q) {
            strrchr(q->fname, '/') + 1);
 
   fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, 0600);
-  if (fd < 0) PFATAL("Unable to create '%s'", fn);
+  if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
   close(fd);
 
   q->passed_det = 1;
@@ -61,7 +61,7 @@ void mark_as_variable(afl_state_t *afl, struct queue_entry *q) {
   if (symlink(ldest, fn)) {
 
     s32 fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, 0600);
-    if (fd < 0) PFATAL("Unable to create '%s'", fn);
+    if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
     close(fd);
 
   }
@@ -77,7 +77,7 @@ void mark_as_redundant(afl_state_t *afl, struct queue_entry *q, u8 state) {
 
   u8 fn[PATH_MAX];
 
-  if (state == q->fs_redundant) return;
+  if (state == q->fs_redundant) { return; }
 
   q->fs_redundant = state;
 
@@ -89,12 +89,12 @@ void mark_as_redundant(afl_state_t *afl, struct queue_entry *q, u8 state) {
     s32 fd;
 
     fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, 0600);
-    if (fd < 0) PFATAL("Unable to create '%s'", fn);
+    if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
     close(fd);
 
   } else {
 
-    if (unlink(fn)) PFATAL("Unable to remove '%s'", fn);
+    if (unlink(fn)) { PFATAL("Unable to remove '%s'", fn); }
 
   }
 
@@ -113,16 +113,18 @@ void add_to_queue(afl_state_t *afl, u8 *fname, u32 len, u8 passed_det) {
   q->n_fuzz = 1;
   q->trace_mini = NULL;
 
-  if (q->depth > afl->max_depth) afl->max_depth = q->depth;
+  if (q->depth > afl->max_depth) { afl->max_depth = q->depth; }
 
   if (afl->queue_top) {
 
     afl->queue_top->next = q;
     afl->queue_top = q;
 
-  } else
+  } else {
 
     afl->q_prev100 = afl->queue = afl->queue_top = q;
+
+  }
 
   ++afl->queued_paths;
   ++afl->pending_not_fuzzed;
@@ -143,7 +145,7 @@ void add_to_queue(afl_state_t *afl, u8 *fname, u32 len, u8 passed_det) {
     u8 *fname_orig = NULL;
 
     /* At the initialization stage, queue_cur is NULL */
-    if (afl->queue_cur) fname_orig = afl->queue_cur->fname;
+    if (afl->queue_cur) { fname_orig = afl->queue_cur->fname; }
 
     afl->mutator->afl_custom_queue_new_entry(afl->mutator->data, fname,
                                              fname_orig);
@@ -188,14 +190,19 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
   u64 fuzz_p2 = next_pow2(q->n_fuzz);
 
   if (afl->schedule == MMOPT || afl->schedule == RARE ||
-      unlikely(afl->fixed_seed))
+      unlikely(afl->fixed_seed)) {
+
     fav_factor = q->len << 2;
-  else
+
+  } else {
+
     fav_factor = q->exec_us * q->len;
+
+  }
 
   /* For every byte set in afl->fsrv.trace_bits[], see if there is a previous
      winner, and how it compares to us. */
-  for (i = 0; i < afl->fsrv.map_size; ++i)
+  for (i = 0; i < afl->fsrv.map_size; ++i) {
 
     if (afl->fsrv.trace_bits[i]) {
 
@@ -206,26 +213,40 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
         u64 top_rated_fuzz_p2 = next_pow2(afl->top_rated[i]->n_fuzz);
 
         if (afl->schedule == MMOPT || afl->schedule == RARE ||
-            unlikely(afl->fixed_seed))
+            unlikely(afl->fixed_seed)) {
+
           top_rated_fav_factor = afl->top_rated[i]->len << 2;
-        else
+
+        } else {
+
           top_rated_fav_factor =
               afl->top_rated[i]->exec_us * afl->top_rated[i]->len;
 
-        if (fuzz_p2 > top_rated_fuzz_p2)
+        }
+
+        if (fuzz_p2 > top_rated_fuzz_p2) {
+
           continue;
-        else if (fuzz_p2 == top_rated_fuzz_p2)
-          if (fav_factor > top_rated_fav_factor) continue;
+
+        } else if (fuzz_p2 == top_rated_fuzz_p2) {
+
+          if (fav_factor > top_rated_fav_factor) { continue; }
+
+        }
 
         if (afl->schedule == MMOPT || afl->schedule == RARE ||
             unlikely(afl->fixed_seed)) {
 
-          if (fav_factor > afl->top_rated[i]->len << 2) continue;
+          if (fav_factor > afl->top_rated[i]->len << 2) { continue; }
 
         } else {
 
-          if (fav_factor > afl->top_rated[i]->exec_us * afl->top_rated[i]->len)
+          if (fav_factor >
+              afl->top_rated[i]->exec_us * afl->top_rated[i]->len) {
+
             continue;
+
+          }
 
         }
 
@@ -258,6 +279,8 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
 
     }
 
+  }
+
 }
 
 /* The second part of the mechanism discussed above is a routine that
@@ -273,7 +296,7 @@ void cull_queue(afl_state_t *afl) {
   u32                 i;
   u8 *                temp_v;
 
-  if (afl->dumb_mode || !afl->score_changed) return;
+  if (afl->dumb_mode || !afl->score_changed) { return; }
 
   temp_v = ck_alloc(afl->fsrv.map_size >> 3);
 
@@ -296,24 +319,37 @@ void cull_queue(afl_state_t *afl) {
   /* Let's see if anything in the bitmap isn't captured in temp_v.
      If yes, and if it has a afl->top_rated[] contender, let's use it. */
 
-  for (i = 0; i < afl->fsrv.map_size; ++i)
+  for (i = 0; i < afl->fsrv.map_size; ++i) {
+
     if (afl->top_rated[i] && (temp_v[i >> 3] & (1 << (i & 7)))) {
 
       u32 j = len;
 
       /* Remove all bits belonging to the current entry from temp_v. */
 
-      while (j--)
-        if (afl->top_rated[i]->trace_mini[j])
+      while (j--) {
+
+        if (afl->top_rated[i]->trace_mini[j]) {
+
           temp_v[j] &= ~afl->top_rated[i]->trace_mini[j];
+
+        }
+
+      }
 
       afl->top_rated[i]->favored = 1;
       ++afl->queued_favored;
 
-      if (afl->top_rated[i]->fuzz_level == 0 || !afl->top_rated[i]->was_fuzzed)
+      if (afl->top_rated[i]->fuzz_level == 0 ||
+          !afl->top_rated[i]->was_fuzzed) {
+
         ++afl->pending_favored;
 
+      }
+
     }
+
+  }
 
   q = afl->queue;
 
@@ -351,38 +387,66 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
   if (afl->schedule != MMOPT && afl->schedule != RARE &&
       likely(!afl->fixed_seed)) {
 
-    if (q->exec_us * 0.1 > avg_exec_us)
+    if (q->exec_us * 0.1 > avg_exec_us) {
+
       perf_score = 10;
-    else if (q->exec_us * 0.25 > avg_exec_us)
+
+    } else if (q->exec_us * 0.25 > avg_exec_us) {
+
       perf_score = 25;
-    else if (q->exec_us * 0.5 > avg_exec_us)
+
+    } else if (q->exec_us * 0.5 > avg_exec_us) {
+
       perf_score = 50;
-    else if (q->exec_us * 0.75 > avg_exec_us)
+
+    } else if (q->exec_us * 0.75 > avg_exec_us) {
+
       perf_score = 75;
-    else if (q->exec_us * 4 < avg_exec_us)
+
+    } else if (q->exec_us * 4 < avg_exec_us) {
+
       perf_score = 300;
-    else if (q->exec_us * 3 < avg_exec_us)
+
+    } else if (q->exec_us * 3 < avg_exec_us) {
+
       perf_score = 200;
-    else if (q->exec_us * 2 < avg_exec_us)
+
+    } else if (q->exec_us * 2 < avg_exec_us) {
+
       perf_score = 150;
+
+    }
 
   }
 
   /* Adjust score based on bitmap size. The working theory is that better
      coverage translates to better targets. Multiplier from 0.25x to 3x. */
 
-  if (q->bitmap_size * 0.3 > avg_bitmap_size)
+  if (q->bitmap_size * 0.3 > avg_bitmap_size) {
+
     perf_score *= 3;
-  else if (q->bitmap_size * 0.5 > avg_bitmap_size)
+
+  } else if (q->bitmap_size * 0.5 > avg_bitmap_size) {
+
     perf_score *= 2;
-  else if (q->bitmap_size * 0.75 > avg_bitmap_size)
+
+  } else if (q->bitmap_size * 0.75 > avg_bitmap_size) {
+
     perf_score *= 1.5;
-  else if (q->bitmap_size * 3 < avg_bitmap_size)
+
+  } else if (q->bitmap_size * 3 < avg_bitmap_size) {
+
     perf_score *= 0.25;
-  else if (q->bitmap_size * 2 < avg_bitmap_size)
+
+  } else if (q->bitmap_size * 2 < avg_bitmap_size) {
+
     perf_score *= 0.5;
-  else if (q->bitmap_size * 1.5 < avg_bitmap_size)
+
+  } else if (q->bitmap_size * 1.5 < avg_bitmap_size) {
+
     perf_score *= 0.75;
+
+  }
 
   /* Adjust score based on handicap. Handicap is proportional to how late
      in the game we learned about this path. Latecomers are allowed to run
@@ -406,11 +470,19 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
 
   switch (q->depth) {
 
-    case 0 ... 3: break;
-    case 4 ... 7: perf_score *= 2; break;
-    case 8 ... 13: perf_score *= 3; break;
-    case 14 ... 25: perf_score *= 4; break;
-    default: perf_score *= 5;
+    case 0 ... 3:
+      break;
+    case 4 ... 7:
+      perf_score *= 2;
+      break;
+    case 8 ... 13:
+      perf_score *= 3;
+      break;
+    case 14 ... 25:
+      perf_score *= 4;
+      break;
+    default:
+      perf_score *= 5;
 
   }
 
@@ -422,9 +494,12 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
 
   switch (afl->schedule) {
 
-    case EXPLORE: break;
+    case EXPLORE:
+      break;
 
-    case EXPLOIT: factor = MAX_FACTOR; break;
+    case EXPLOIT:
+      factor = MAX_FACTOR;
+      break;
 
     case COE:
       fuzz_total = 0;
@@ -439,15 +514,20 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
 
       }
 
-      if (unlikely(!n_paths)) FATAL("Queue state corrupt");
+      if (unlikely(!n_paths)) { FATAL("Queue state corrupt"); }
 
       fuzz_mu = fuzz_total / n_paths;
       if (fuzz <= fuzz_mu) {
 
-        if (q->fuzz_level < 16)
+        if (q->fuzz_level < 16) {
+
           factor = ((u32)(1 << q->fuzz_level));
-        else
+
+        } else {
+
           factor = MAX_FACTOR;
+
+        }
 
       } else {
 
@@ -458,13 +538,21 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
       break;
 
     case FAST:
-      if (q->fuzz_level < 16)
+      if (q->fuzz_level < 16) {
+
         factor = ((u32)(1 << q->fuzz_level)) / (fuzz == 0 ? 1 : fuzz);
-      else
+
+      } else {
+
         factor = MAX_FACTOR / (fuzz == 0 ? 1 : next_pow2(fuzz));
+
+      }
+
       break;
 
-    case LIN: factor = q->fuzz_level / (fuzz == 0 ? 1 : fuzz); break;
+    case LIN:
+      factor = q->fuzz_level / (fuzz == 0 ? 1 : fuzz);
+      break;
 
     case QUAD:
       factor = q->fuzz_level * q->fuzz_level / (fuzz == 0 ? 1 : fuzz);
@@ -481,7 +569,7 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
         (afl->max_depth - q->depth)) / 5));
       */
       // put focus on the last 5 entries
-      if (afl->max_depth - q->depth < 5) perf_score *= 2;
+      if (afl->max_depth - q->depth < 5) { perf_score *= 2; }
 
       break;
 
@@ -497,25 +585,34 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
 
       break;
 
-    default: PFATAL("Unknown Power Schedule");
+    default:
+      PFATAL("Unknown Power Schedule");
 
   }
 
-  if (factor > MAX_FACTOR) factor = MAX_FACTOR;
+  if (factor > MAX_FACTOR) { factor = MAX_FACTOR; }
 
   perf_score *= factor / POWER_BETA;
 
   // MOpt mode
-  if (afl->limit_time_sig != 0 && afl->max_depth - q->depth < 3)
+  if (afl->limit_time_sig != 0 && afl->max_depth - q->depth < 3) {
+
     perf_score *= 2;
-  else if (perf_score < 1)
+
+  } else if (perf_score < 1) {
+
     // Add a lower bound to AFLFast's energy assignment strategies
     perf_score = 1;
 
+  }
+
   /* Make sure that we don't go over limit. */
 
-  if (perf_score > afl->havoc_max_mult * 100)
+  if (perf_score > afl->havoc_max_mult * 100) {
+
     perf_score = afl->havoc_max_mult * 100;
+
+  }
 
   return perf_score;
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -73,10 +73,15 @@ static struct range *pop_biggest_range(struct range **ranges) {
 
   if (rmax) {
 
-    if (prev_rmax)
+    if (prev_rmax) {
+
       prev_rmax->next = rmax->next;
-    else
+
+    } else {
+
       *ranges = rmax->next;
+
+    }
 
   }
 
@@ -86,7 +91,7 @@ static struct range *pop_biggest_range(struct range **ranges) {
 
 static u8 get_exec_checksum(afl_state_t *afl, u8 *buf, u32 len, u32 *cksum) {
 
-  if (unlikely(common_fuzz_stuff(afl, buf, len))) return 1;
+  if (unlikely(common_fuzz_stuff(afl, buf, len))) { return 1; }
 
   *cksum = hash32(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
   return 0;
@@ -96,8 +101,11 @@ static u8 get_exec_checksum(afl_state_t *afl, u8 *buf, u32 len, u32 *cksum) {
 static void rand_replace(afl_state_t *afl, u8 *buf, u32 len) {
 
   u32 i;
-  for (i = 0; i < len; ++i)
+  for (i = 0; i < len; ++i) {
+
     buf[i] = rand_below(afl, 256);
+
+  }
 
 }
 
@@ -131,8 +139,11 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len, u32 exec_cksum) {
 
       u32 cksum;
       u64 start_us = get_cur_time_us();
-      if (unlikely(get_exec_checksum(afl, buf, len, &cksum)))
+      if (unlikely(get_exec_checksum(afl, buf, len, &cksum))) {
+
         goto checksum_fail;
+
+      }
 
       u64 stop_us = get_cur_time_us();
 
@@ -159,7 +170,7 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len, u32 exec_cksum) {
 
   }
 
-  if (afl->stage_cur < afl->stage_max) afl->queue_cur->fully_colorized = 1;
+  if (afl->stage_cur < afl->stage_max) { afl->queue_cur->fully_colorized = 1; }
 
   new_hit_cnt = afl->queued_paths + afl->unique_crashes;
   afl->stage_finds[STAGE_COLORIZATION] += new_hit_cnt - orig_hit_cnt;
@@ -192,7 +203,7 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len, u32 exec_cksum) {
 
     }
 
-    if (fd < 0) PFATAL("Unable to create '%s'", afl->queue_cur->fname);
+    if (fd < 0) { PFATAL("Unable to create '%s'", afl->queue_cur->fname); }
 
     ck_write(fd, buf, len, afl->queue_cur->fname);
     afl->queue_cur->len = len;  // no-op, just to be 100% safe
@@ -204,7 +215,7 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len, u32 exec_cksum) {
   return 0;
 
 checksum_fail:
-  if (rng) ck_free(rng);
+  if (rng) { ck_free(rng); }
   ck_free(backup);
 
   while (ranges) {
@@ -230,14 +241,19 @@ static u8 its_fuzz(afl_state_t *afl, u8 *buf, u32 len, u8 *status) {
 
   orig_hit_cnt = afl->queued_paths + afl->unique_crashes;
 
-  if (unlikely(common_fuzz_stuff(afl, buf, len))) return 1;
+  if (unlikely(common_fuzz_stuff(afl, buf, len))) { return 1; }
 
   new_hit_cnt = afl->queued_paths + afl->unique_crashes;
 
-  if (unlikely(new_hit_cnt != orig_hit_cnt))
+  if (unlikely(new_hit_cnt != orig_hit_cnt)) {
+
     *status = 1;
-  else
+
+  } else {
+
     *status = 2;
+
+  }
 
   return 0;
 
@@ -265,17 +281,23 @@ static u8 cmp_extend_encoding(afl_state_t *afl, struct cmp_header *h,
     if (its_len >= 8 && *buf_64 == pattern && *o_buf_64 == o_pattern) {
 
       *buf_64 = repl;
-      if (unlikely(its_fuzz(afl, buf, len, status))) return 1;
+      if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
       *buf_64 = pattern;
 
     }
 
     // reverse encoding
-    if (do_reverse)
+    if (do_reverse) {
+
       if (unlikely(cmp_extend_encoding(afl, h, SWAP64(pattern), SWAP64(repl),
                                        SWAP64(o_pattern), idx, orig_buf, buf,
-                                       len, 0, status)))
+                                       len, 0, status))) {
+
         return 1;
+
+      }
+
+    }
 
   }
 
@@ -285,17 +307,23 @@ static u8 cmp_extend_encoding(afl_state_t *afl, struct cmp_header *h,
         *o_buf_32 == (u32)o_pattern) {
 
       *buf_32 = (u32)repl;
-      if (unlikely(its_fuzz(afl, buf, len, status))) return 1;
+      if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
       *buf_32 = pattern;
 
     }
 
     // reverse encoding
-    if (do_reverse)
+    if (do_reverse) {
+
       if (unlikely(cmp_extend_encoding(afl, h, SWAP32(pattern), SWAP32(repl),
                                        SWAP32(o_pattern), idx, orig_buf, buf,
-                                       len, 0, status)))
+                                       len, 0, status))) {
+
         return 1;
+
+      }
+
+    }
 
   }
 
@@ -305,17 +333,23 @@ static u8 cmp_extend_encoding(afl_state_t *afl, struct cmp_header *h,
         *o_buf_16 == (u16)o_pattern) {
 
       *buf_16 = (u16)repl;
-      if (unlikely(its_fuzz(afl, buf, len, status))) return 1;
+      if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
       *buf_16 = (u16)pattern;
 
     }
 
     // reverse encoding
-    if (do_reverse)
+    if (do_reverse) {
+
       if (unlikely(cmp_extend_encoding(afl, h, SWAP16(pattern), SWAP16(repl),
                                        SWAP16(o_pattern), idx, orig_buf, buf,
-                                       len, 0, status)))
+                                       len, 0, status))) {
+
         return 1;
+
+      }
+
+    }
 
   }
 
@@ -324,7 +358,7 @@ static u8 cmp_extend_encoding(afl_state_t *afl, struct cmp_header *h,
     if (its_len >= 1 && *buf_8 == (u8)pattern && *o_buf_8 == (u8)o_pattern) {
 
       *buf_8 = (u8)repl;
-      if (unlikely(its_fuzz(afl, buf, len, status))) return 1;
+      if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
       *buf_8 = (u8)pattern;
 
     }
@@ -343,14 +377,21 @@ static void try_to_add_to_dict(afl_state_t *afl, u64 v, u8 shape) {
   u8  cons_ff = 0, cons_0 = 0;
   for (k = 0; k < shape; ++k) {
 
-    if (b[k] == 0)
+    if (b[k] == 0) {
+
       ++cons_0;
-    else if (b[k] == 0xff)
+
+    } else if (b[k] == 0xff) {
+
       ++cons_0;
-    else
+
+    } else {
+
       cons_0 = cons_ff = 0;
 
-    if (cons_0 > 1 || cons_ff > 1) return;
+    }
+
+    if (cons_0 > 1 || cons_ff > 1) { return; }
 
   }
 
@@ -359,7 +400,8 @@ static void try_to_add_to_dict(afl_state_t *afl, u64 v, u8 shape) {
   u64 rev;
   switch (shape) {
 
-    case 1: break;
+    case 1:
+      break;
     case 2:
       rev = SWAP16((u16)v);
       maybe_add_auto((u8 *)afl, (u8 *)&rev, shape);
@@ -383,7 +425,7 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
   u32                i, j, idx;
 
   u32 loggeds = h->hits;
-  if (h->hits > CMP_MAP_H) loggeds = CMP_MAP_H;
+  if (h->hits > CMP_MAP_H) { loggeds = CMP_MAP_H; }
 
   u8 status = 0;
   // opt not in the paper
@@ -410,12 +452,12 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
 
     } else {
 
-      if (s_v0 != o->v0) s_v0_fixed = 0;
-      if (s_v1 != o->v1) s_v1_fixed = 0;
-      if (s_v0 + 1 != o->v0) s_v0_inc = 0;
-      if (s_v1 + 1 != o->v1) s_v1_inc = 0;
-      if (s_v0 - 1 != o->v0) s_v0_dec = 0;
-      if (s_v1 - 1 != o->v1) s_v1_dec = 0;
+      if (s_v0 != o->v0) { s_v0_fixed = 0; }
+      if (s_v1 != o->v1) { s_v1_fixed = 0; }
+      if (s_v0 + 1 != o->v0) { s_v0_inc = 0; }
+      if (s_v1 + 1 != o->v1) { s_v1_inc = 0; }
+      if (s_v0 - 1 != o->v0) { s_v0_dec = 0; }
+      if (s_v1 - 1 != o->v1) { s_v1_dec = 0; }
       s_v0 = o->v0;
       s_v1 = o->v1;
 
@@ -424,32 +466,56 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
     struct cmp_operands *orig_o = &afl->orig_cmp_map->log[key][i];
 
     // opt not in the paper
-    for (j = 0; j < i; ++j)
+    for (j = 0; j < i; ++j) {
+
       if (afl->shm.cmp_map->log[key][j].v0 == o->v0 &&
-          afl->shm.cmp_map->log[key][i].v1 == o->v1)
+          afl->shm.cmp_map->log[key][i].v1 == o->v1) {
+
         goto cmp_fuzz_next_iter;
+
+      }
+
+    }
 
     for (idx = 0; idx < len && fails < 8; ++idx) {
 
       if (unlikely(cmp_extend_encoding(afl, h, o->v0, o->v1, orig_o->v0, idx,
-                                       orig_buf, buf, len, 1, &status)))
+                                       orig_buf, buf, len, 1, &status))) {
+
         return 1;
-      if (status == 2)
+
+      }
+
+      if (status == 2) {
+
         ++fails;
-      else if (status == 1)
+
+      } else if (status == 1) {
+
         break;
 
+      }
+
       if (unlikely(cmp_extend_encoding(afl, h, o->v1, o->v0, orig_o->v1, idx,
-                                       orig_buf, buf, len, 1, &status)))
+                                       orig_buf, buf, len, 1, &status))) {
+
         return 1;
-      if (status == 2)
+
+      }
+
+      if (status == 2) {
+
         ++fails;
-      else if (status == 1)
+
+      } else if (status == 1) {
+
         break;
+
+      }
 
     }
 
-    if (status == 1) found_one = 1;
+    if (status == 1) { found_one = 1; }
 
     // If failed, add to dictionary
     if (fails == 8) {
@@ -481,7 +547,7 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
 
   }
 
-  if (afl->pass_stats[key].total < 0xff) afl->pass_stats[key].total++;
+  if (afl->pass_stats[key].total < 0xff) { afl->pass_stats[key].total++; }
 
   return 0;
 
@@ -502,11 +568,14 @@ static u8 rtn_extend_encoding(afl_state_t *afl, struct cmp_header *h,
   for (i = 0; i < its_len; ++i) {
 
     if (pattern[idx + i] != buf[idx + i] ||
-        o_pattern[idx + i] != orig_buf[idx + i] || *status == 1)
+        o_pattern[idx + i] != orig_buf[idx + i] || *status == 1) {
+
       break;
 
+    }
+
     buf[idx + i] = repl[idx + i];
-    if (unlikely(its_fuzz(afl, buf, len, status))) return 1;
+    if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
 
   }
 
@@ -521,7 +590,7 @@ static u8 rtn_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
   u32                i, j, idx;
 
   u32 loggeds = h->hits;
-  if (h->hits > CMP_MAP_RTN_H) loggeds = CMP_MAP_RTN_H;
+  if (h->hits > CMP_MAP_RTN_H) { loggeds = CMP_MAP_RTN_H; }
 
   u8 status = 0;
   // opt not in the paper
@@ -539,32 +608,56 @@ static u8 rtn_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
         &((struct cmpfn_operands *)afl->orig_cmp_map->log[key])[i];
 
     // opt not in the paper
-    for (j = 0; j < i; ++j)
+    for (j = 0; j < i; ++j) {
+
       if (!memcmp(&((struct cmpfn_operands *)afl->shm.cmp_map->log[key])[j], o,
-                  sizeof(struct cmpfn_operands)))
+                  sizeof(struct cmpfn_operands))) {
+
         goto rtn_fuzz_next_iter;
+
+      }
+
+    }
 
     for (idx = 0; idx < len && fails < 8; ++idx) {
 
       if (unlikely(rtn_extend_encoding(afl, h, o->v0, o->v1, orig_o->v0, idx,
-                                       orig_buf, buf, len, &status)))
+                                       orig_buf, buf, len, &status))) {
+
         return 1;
-      if (status == 2)
+
+      }
+
+      if (status == 2) {
+
         ++fails;
-      else if (status == 1)
+
+      } else if (status == 1) {
+
         break;
 
+      }
+
       if (unlikely(rtn_extend_encoding(afl, h, o->v1, o->v0, orig_o->v1, idx,
-                                       orig_buf, buf, len, &status)))
+                                       orig_buf, buf, len, &status))) {
+
         return 1;
-      if (status == 2)
+
+      }
+
+      if (status == 2) {
+
         ++fails;
-      else if (status == 1)
+
+      } else if (status == 1) {
+
         break;
+
+      }
 
     }
 
-    if (status == 1) found_one = 1;
+    if (status == 1) { found_one = 1; }
 
     // If failed, add to dictionary
     if (fails == 8) {
@@ -589,7 +682,7 @@ static u8 rtn_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u32 len) {
 
   }
 
-  if (afl->pass_stats[key].total < 0xff) afl->pass_stats[key].total++;
+  if (afl->pass_stats[key].total < 0xff) { afl->pass_stats[key].total++; }
 
   return 0;
 
@@ -602,25 +695,31 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len,
                         u32 exec_cksum) {
 
   u8 r = 1;
-  if (afl->orig_cmp_map == NULL)
+  if (afl->orig_cmp_map == NULL) {
+
     afl->orig_cmp_map = ck_alloc_nozero(sizeof(struct cmp_map));
 
-  if (afl->pass_stats == NULL)
+  }
+
+  if (afl->pass_stats == NULL) {
+
     afl->pass_stats = ck_alloc(sizeof(struct afl_pass_stat) * CMP_MAP_W);
+
+  }
 
   // do it manually, forkserver clear only afl->fsrv.trace_bits
   memset(afl->shm.cmp_map->headers, 0, sizeof(afl->shm.cmp_map->headers));
 
-  if (unlikely(common_fuzz_cmplog_stuff(afl, buf, len))) return 1;
+  if (unlikely(common_fuzz_cmplog_stuff(afl, buf, len))) { return 1; }
 
   memcpy(afl->orig_cmp_map, afl->shm.cmp_map, sizeof(struct cmp_map));
 
-  if (unlikely(colorization(afl, buf, len, exec_cksum))) return 1;
+  if (unlikely(colorization(afl, buf, len, exec_cksum))) { return 1; }
 
   // do it manually, forkserver clear only afl->fsrv.trace_bits
   memset(afl->shm.cmp_map->headers, 0, sizeof(afl->shm.cmp_map->headers));
 
-  if (unlikely(common_fuzz_cmplog_stuff(afl, buf, len))) return 1;
+  if (unlikely(common_fuzz_cmplog_stuff(afl, buf, len))) { return 1; }
 
   u64 orig_hit_cnt, new_hit_cnt;
   u64 orig_execs = afl->fsrv.total_execs;
@@ -634,33 +733,41 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len,
   u32 k;
   for (k = 0; k < CMP_MAP_W; ++k) {
 
-    if (!afl->shm.cmp_map->headers[k].hits) continue;
+    if (!afl->shm.cmp_map->headers[k].hits) { continue; }
 
     if (afl->pass_stats[k].total &&
         (rand_below(afl, afl->pass_stats[k].total) >=
              afl->pass_stats[k].faileds ||
-         afl->pass_stats[k].total == 0xff))
+         afl->pass_stats[k].total == 0xff)) {
+
       afl->shm.cmp_map->headers[k].hits = 0;  // blacklist this cmp
 
-    if (afl->shm.cmp_map->headers[k].type == CMP_TYPE_INS)
+    }
+
+    if (afl->shm.cmp_map->headers[k].type == CMP_TYPE_INS) {
+
       afl->stage_max += MIN((u32)afl->shm.cmp_map->headers[k].hits, CMP_MAP_H);
-    else
+
+    } else {
+
       afl->stage_max +=
           MIN((u32)afl->shm.cmp_map->headers[k].hits, CMP_MAP_RTN_H);
+
+    }
 
   }
 
   for (k = 0; k < CMP_MAP_W; ++k) {
 
-    if (!afl->shm.cmp_map->headers[k].hits) continue;
+    if (!afl->shm.cmp_map->headers[k].hits) { continue; }
 
     if (afl->shm.cmp_map->headers[k].type == CMP_TYPE_INS) {
 
-      if (unlikely(cmp_fuzz(afl, k, orig_buf, buf, len))) goto exit_its;
+      if (unlikely(cmp_fuzz(afl, k, orig_buf, buf, len))) { goto exit_its; }
 
     } else {
 
-      if (unlikely(rtn_fuzz(afl, k, orig_buf, buf, len))) goto exit_its;
+      if (unlikely(rtn_fuzz(afl, k, orig_buf, buf, len))) { goto exit_its; }
 
     }
 

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -81,7 +81,7 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   and out_size are NULL/0 by default. */
   memset(afl, 0, sizeof(afl_state_t));
 
-  if (!map_size) afl->shm.map_size = MAP_SIZE;
+  if (!map_size) { afl->shm.map_size = MAP_SIZE; }
 
   afl->w_init = 0.9;
   afl->w_end = 0.3;
@@ -343,9 +343,11 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
           }
 
-        } else
+        } else {
 
           i++;
+
+        }
 
       }
 
@@ -360,7 +362,7 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
   }
 
-  if (found) sleep(2);
+  if (found) { sleep(2); }
 
 }
 
@@ -368,18 +370,18 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
 void afl_state_deinit(afl_state_t *afl) {
 
-  if (afl->post_deinit) afl->post_deinit(afl->post_data);
-  if (afl->in_place_resume) ck_free(afl->in_dir);
-  if (afl->sync_id) ck_free(afl->out_dir);
-  if (afl->pass_stats) ck_free(afl->pass_stats);
-  if (afl->orig_cmp_map) ck_free(afl->orig_cmp_map);
+  if (afl->post_deinit) { afl->post_deinit(afl->post_data); }
+  if (afl->in_place_resume) { ck_free(afl->in_dir); }
+  if (afl->sync_id) { ck_free(afl->out_dir); }
+  if (afl->pass_stats) { ck_free(afl->pass_stats); }
+  if (afl->orig_cmp_map) { ck_free(afl->orig_cmp_map); }
 
-  if (afl->out_buf) free(afl->out_buf);
-  if (afl->out_scratch_buf) free(afl->out_scratch_buf);
-  if (afl->eff_buf) free(afl->eff_buf);
-  if (afl->in_buf) free(afl->in_buf);
-  if (afl->in_scratch_buf) free(afl->in_scratch_buf);
-  if (afl->ex_buf) free(afl->ex_buf);
+  if (afl->out_buf) { free(afl->out_buf); }
+  if (afl->out_scratch_buf) { free(afl->out_scratch_buf); }
+  if (afl->eff_buf) { free(afl->eff_buf); }
+  if (afl->in_buf) { free(afl->in_buf); }
+  if (afl->in_scratch_buf) { free(afl->in_scratch_buf); }
+  if (afl->ex_buf) { free(afl->ex_buf); }
 
   ck_free(afl->virgin_bits);
   ck_free(afl->virgin_tmout);

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -43,11 +43,11 @@ void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
 
   fd = open(fn, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 
-  if (fd < 0) PFATAL("Unable to create '%s'", fn);
+  if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
 
   f = fdopen(fd, "w");
 
-  if (!f) PFATAL("fdopen() failed");
+  if (!f) { PFATAL("fdopen() failed"); }
 
   /* Keep last values in case we're called from another context
      where exec/sec stats and such are not readily available. */
@@ -65,7 +65,7 @@ void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
 
   }
 
-  if (getrusage(RUSAGE_CHILDREN, &rus)) rus.ru_maxrss = 0;
+  if (getrusage(RUSAGE_CHILDREN, &rus)) { rus.ru_maxrss = 0; }
 
   fprintf(
       f,
@@ -153,8 +153,11 @@ void maybe_update_plot_file(afl_state_t *afl, double bitmap_cvg, double eps) {
                afl->plot_prev_uc == afl->unique_crashes &&
                afl->plot_prev_uh == afl->unique_hangs &&
                afl->plot_prev_md == afl->max_depth) ||
-      unlikely(!afl->queue_cycle))
+      unlikely(!afl->queue_cycle)) {
+
     return;
+
+  }
 
   afl->plot_prev_qp = afl->queued_paths;
   afl->plot_prev_pf = afl->pending_favored;
@@ -190,10 +193,10 @@ static void check_term_size(afl_state_t *afl) {
 
   afl->term_too_small = 0;
 
-  if (ioctl(1, TIOCGWINSZ, &ws)) return;
+  if (ioctl(1, TIOCGWINSZ, &ws)) { return; }
 
-  if (ws.ws_row == 0 || ws.ws_col == 0) return;
-  if (ws.ws_row < 24 || ws.ws_col < 79) afl->term_too_small = 1;
+  if (ws.ws_row == 0 || ws.ws_col == 0) { return; }
+  if (ws.ws_row < 24 || ws.ws_col < 79) { afl->term_too_small = 1; }
 
 }
 
@@ -241,12 +244,15 @@ void show_stats(afl_state_t *afl) {
   /* If not enough time has passed since last UI update, bail out. */
 
   if (cur_ms - afl->stats_last_ms < 1000 / UI_TARGET_HZ &&
-      !afl->force_ui_update)
+      !afl->force_ui_update) {
+
     return;
+
+  }
 
   /* Check if we're past the 10 minute mark. */
 
-  if (cur_ms - afl->start_time > 10 * 60 * 1000) afl->run_over10m = 1;
+  if (cur_ms - afl->start_time > 10 * 60 * 1000) { afl->run_over10m = 1; }
 
   /* Calculate smoothed exec speed stats. */
 
@@ -263,8 +269,12 @@ void show_stats(afl_state_t *afl) {
     /* If there is a dramatic (5x+) jump in speed, reset the indicator
        more quickly. */
 
-    if (cur_avg * 5 < afl->stats_avg_exec || cur_avg / 5 > afl->stats_avg_exec)
+    if (cur_avg * 5 < afl->stats_avg_exec ||
+        cur_avg / 5 > afl->stats_avg_exec) {
+
       afl->stats_avg_exec = cur_avg;
+
+    }
 
     afl->stats_avg_exec = afl->stats_avg_exec * (1.0 - 1.0 / AVG_SMOOTHING) +
                           cur_avg * (1.0 / AVG_SMOOTHING);
@@ -277,17 +287,22 @@ void show_stats(afl_state_t *afl) {
   /* Tell the callers when to contact us (as measured in execs). */
 
   afl->stats_update_freq = afl->stats_avg_exec / (UI_TARGET_HZ * 10);
-  if (!afl->stats_update_freq) afl->stats_update_freq = 1;
+  if (!afl->stats_update_freq) { afl->stats_update_freq = 1; }
 
   /* Do some bitmap stats. */
 
   t_bytes = count_non_255_bytes(afl, afl->virgin_bits);
   t_byte_ratio = ((double)t_bytes * 100) / afl->fsrv.map_size;
 
-  if (likely(t_bytes) && unlikely(afl->var_byte_count))
+  if (likely(t_bytes) && unlikely(afl->var_byte_count)) {
+
     stab_ratio = 100 - (((double)afl->var_byte_count * 100) / t_bytes);
-  else
+
+  } else {
+
     stab_ratio = 100;
+
+  }
 
   /* Roughly every minute, update fuzzer stats and save auto tokens. */
 
@@ -312,19 +327,25 @@ void show_stats(afl_state_t *afl) {
   /* Honor AFL_EXIT_WHEN_DONE and AFL_BENCH_UNTIL_CRASH. */
 
   if (!afl->dumb_mode && afl->cycles_wo_finds > 100 &&
-      !afl->pending_not_fuzzed && afl->afl_env.afl_exit_when_done)
+      !afl->pending_not_fuzzed && afl->afl_env.afl_exit_when_done) {
+
     afl->stop_soon = 2;
 
-  if (afl->total_crashes && afl->afl_env.afl_bench_until_crash)
+  }
+
+  if (afl->total_crashes && afl->afl_env.afl_bench_until_crash) {
+
     afl->stop_soon = 2;
+
+  }
 
   /* If we're not on TTY, bail out. */
 
-  if (afl->not_on_tty) return;
+  if (afl->not_on_tty) { return; }
 
   /* If we haven't started doing things, bail out. */
 
-  if (!afl->queue_cur) return;
+  if (!afl->queue_cur) { return; }
 
   /* Compute some mildly useful bitmap stats. */
 
@@ -389,9 +410,9 @@ void show_stats(afl_state_t *afl) {
 
   /* Lord, forgive me this. */
 
-  SAYF(SET_G1 bSTG bLT bH bSTOP cCYA
+  SAYF(SET_G1 bSTG bLT bH bSTOP                         cCYA
        " process timing " bSTG bH30 bH5 bH bHB bH bSTOP cCYA
-       " overall results " bSTG bH2 bH2 bRT "\n");
+       " overall results " bSTG bH2 bH2                 bRT "\n");
 
   if (afl->dumb_mode) {
 
@@ -402,23 +423,32 @@ void show_stats(afl_state_t *afl) {
     u64 min_wo_finds = (cur_ms - afl->last_path_time) / 1000 / 60;
 
     /* First queue cycle: don't stop now! */
-    if (afl->queue_cycle == 1 || min_wo_finds < 15)
+    if (afl->queue_cycle == 1 || min_wo_finds < 15) {
+
       strcpy(tmp, cMGN);
-    else
+
+    } else
 
         /* Subsequent cycles, but we're still making finds. */
-        if (afl->cycles_wo_finds < 25 || min_wo_finds < 30)
+        if (afl->cycles_wo_finds < 25 || min_wo_finds < 30) {
+
       strcpy(tmp, cYEL);
-    else
+
+    } else
 
         /* No finds for a long time and no test cases to try. */
         if (afl->cycles_wo_finds > 100 && !afl->pending_not_fuzzed &&
-            min_wo_finds > 120)
+            min_wo_finds > 120) {
+
       strcpy(tmp, cLGN);
 
-    /* Default: cautiously OK to stop? */
-    else
+      /* Default: cautiously OK to stop? */
+
+    } else {
+
       strcpy(tmp, cLBL);
+
+    }
 
   }
 
@@ -439,15 +469,17 @@ void show_stats(afl_state_t *afl) {
 
   } else {
 
-    if (afl->dumb_mode)
+    if (afl->dumb_mode) {
 
       SAYF(bV bSTOP "   last new path : " cPIN "n/a" cRST
                     " (non-instrumented mode)       ");
 
-    else
+    } else {
 
       SAYF(bV bSTOP "   last new path : " cRST "none yet " cLRD
                     "(odd, check syntax!)     ");
+
+    }
 
   }
 
@@ -473,9 +505,9 @@ void show_stats(afl_state_t *afl) {
                 "   uniq hangs : " cRST "%-6s" bSTG         bV "\n",
        time_tmp, tmp);
 
-  SAYF(bVR bH bSTOP            cCYA
+  SAYF(bVR bH bSTOP                                          cCYA
        " cycle progress " bSTG bH10 bH5 bH2 bH2 bHB bH bSTOP cCYA
-       " map coverage " bSTG bH bHT bH20 bH2 bVL "\n");
+       " map coverage " bSTG bH bHT bH20 bH2                 bVL "\n");
 
   /* This gets funny because we want to print several variable-length variables
      together, but then cram them into a fixed-width field - so we need to
@@ -505,9 +537,9 @@ void show_stats(afl_state_t *afl) {
 
   SAYF(bSTOP " count coverage : " cRST "%-21s" bSTG bV "\n", tmp);
 
-  SAYF(bVR bH bSTOP            cCYA
+  SAYF(bVR bH bSTOP                                         cCYA
        " stage progress " bSTG bH10 bH5 bH2 bH2 bX bH bSTOP cCYA
-       " findings in depth " bSTG bH10 bH5 bH2 bH2 bVL "\n");
+       " findings in depth " bSTG bH10 bH5 bH2 bH2          bVL "\n");
 
   sprintf(tmp, "%s (%0.02f%%)", u_stringify_int(IB(0), afl->queued_favored),
           ((double)afl->queued_favored) * 100 / afl->queued_paths);
@@ -581,7 +613,7 @@ void show_stats(afl_state_t *afl) {
 
   /* Aaaalmost there... hold on! */
 
-  SAYF(bVR bH cCYA                      bSTOP
+  SAYF(bVR bH cCYA                                                     bSTOP
        " fuzzing strategy yields " bSTG bH10 bHT bH10 bH5 bHB bH bSTOP cCYA
        " path geometry " bSTG bH5 bH2 bVL "\n");
 
@@ -605,7 +637,8 @@ void show_stats(afl_state_t *afl) {
                 "    levels : " cRST "%-10s" bSTG       bV "\n",
        tmp, u_stringify_int(IB(0), afl->max_depth));
 
-  if (!afl->skip_deterministic)
+  if (!afl->skip_deterministic) {
+
     sprintf(tmp, "%s/%s, %s/%s, %s/%s",
             u_stringify_int(IB(0), afl->stage_finds[STAGE_FLIP8]),
             u_stringify_int(IB(1), afl->stage_cycles[STAGE_FLIP8]),
@@ -614,11 +647,14 @@ void show_stats(afl_state_t *afl) {
             u_stringify_int(IB(4), afl->stage_finds[STAGE_FLIP32]),
             u_stringify_int(IB(5), afl->stage_cycles[STAGE_FLIP32]));
 
+  }
+
   SAYF(bV bSTOP "  byte flips : " cRST "%-36s " bSTG bV bSTOP
                 "   pending : " cRST "%-10s" bSTG       bV "\n",
        tmp, u_stringify_int(IB(0), afl->pending_not_fuzzed));
 
-  if (!afl->skip_deterministic)
+  if (!afl->skip_deterministic) {
+
     sprintf(tmp, "%s/%s, %s/%s, %s/%s",
             u_stringify_int(IB(0), afl->stage_finds[STAGE_ARITH8]),
             u_stringify_int(IB(1), afl->stage_cycles[STAGE_ARITH8]),
@@ -627,11 +663,14 @@ void show_stats(afl_state_t *afl) {
             u_stringify_int(IB(4), afl->stage_finds[STAGE_ARITH32]),
             u_stringify_int(IB(5), afl->stage_cycles[STAGE_ARITH32]));
 
+  }
+
   SAYF(bV bSTOP " arithmetics : " cRST "%-36s " bSTG bV bSTOP
                 "  pend fav : " cRST "%-10s" bSTG       bV "\n",
        tmp, u_stringify_int(IB(0), afl->pending_favored));
 
-  if (!afl->skip_deterministic)
+  if (!afl->skip_deterministic) {
+
     sprintf(tmp, "%s/%s, %s/%s, %s/%s",
             u_stringify_int(IB(0), afl->stage_finds[STAGE_INTEREST8]),
             u_stringify_int(IB(1), afl->stage_cycles[STAGE_INTEREST8]),
@@ -640,11 +679,14 @@ void show_stats(afl_state_t *afl) {
             u_stringify_int(IB(4), afl->stage_finds[STAGE_INTEREST32]),
             u_stringify_int(IB(5), afl->stage_cycles[STAGE_INTEREST32]));
 
+  }
+
   SAYF(bV bSTOP "  known ints : " cRST "%-36s " bSTG bV bSTOP
                 " own finds : " cRST "%-10s" bSTG       bV "\n",
        tmp, u_stringify_int(IB(0), afl->queued_discovered));
 
-  if (!afl->skip_deterministic)
+  if (!afl->skip_deterministic) {
+
     sprintf(tmp, "%s/%s, %s/%s, %s/%s",
             u_stringify_int(IB(0), afl->stage_finds[STAGE_EXTRAS_UO]),
             u_stringify_int(IB(1), afl->stage_cycles[STAGE_EXTRAS_UO]),
@@ -652,6 +694,8 @@ void show_stats(afl_state_t *afl) {
             u_stringify_int(IB(3), afl->stage_cycles[STAGE_EXTRAS_UI]),
             u_stringify_int(IB(4), afl->stage_finds[STAGE_EXTRAS_AO]),
             u_stringify_int(IB(5), afl->stage_cycles[STAGE_EXTRAS_AO]));
+
+  }
 
   SAYF(bV bSTOP "  dictionary : " cRST "%-36s " bSTG bV bSTOP
                 "  imported : " cRST "%-10s" bSTG       bV "\n",
@@ -669,10 +713,15 @@ void show_stats(afl_state_t *afl) {
 
   SAYF(bV bSTOP "   havoc/rad : " cRST "%-36s " bSTG bV bSTOP, tmp);
 
-  if (t_bytes)
+  if (t_bytes) {
+
     sprintf(tmp, "%0.02f%%", stab_ratio);
-  else
+
+  } else {
+
     strcpy(tmp, "n/a");
+
+  }
 
   SAYF(" stability : %s%-10s" bSTG bV "\n",
        (stab_ratio < 85 && afl->var_byte_count > 40)
@@ -769,14 +818,17 @@ void show_stats(afl_state_t *afl) {
 
     /* If we could still run one or more processes, use green. */
 
-    if (afl->cpu_core_count > 1 && cur_runnable + 1 <= afl->cpu_core_count)
+    if (afl->cpu_core_count > 1 && cur_runnable + 1 <= afl->cpu_core_count) {
+
       cpu_color = cLGN;
+
+    }
 
     /* If we're clearly oversubscribed, use red. */
 
-    if (!afl->no_cpu_meter_red && cur_utilization >= 150) cpu_color = cLRD;
+    if (!afl->no_cpu_meter_red && cur_utilization >= 150) { cpu_color = cLRD; }
 
-    if (afl->fsrv.snapshot) spacing = snap;
+    if (afl->fsrv.snapshot) { spacing = snap; }
 
 #ifdef HAVE_AFFINITY
 
@@ -799,9 +851,11 @@ void show_stats(afl_state_t *afl) {
 
 #endif                                                    /* ^HAVE_AFFINITY */
 
-  } else
+  } else {
 
     SAYF("\r");
+
+  }
 
   /* Last line */
   SAYF(SET_G1 "\n" bSTG bLB bH30 bH20 bH2 bRB bSTOP cRST RESET_G1);
@@ -829,17 +883,21 @@ void show_init_stats(afl_state_t *afl) {
   u8 val_bufs[4][STRINGIFY_VAL_SIZE_MAX];
 #define IB(i) val_bufs[(i)], sizeof(val_bufs[(i)])
 
-  if (afl->total_cal_cycles) avg_us = afl->total_cal_us / afl->total_cal_cycles;
+  if (afl->total_cal_cycles) {
+
+    avg_us = afl->total_cal_us / afl->total_cal_cycles;
+
+  }
 
   while (q) {
 
-    if (!min_us || q->exec_us < min_us) min_us = q->exec_us;
-    if (q->exec_us > max_us) max_us = q->exec_us;
+    if (!min_us || q->exec_us < min_us) { min_us = q->exec_us; }
+    if (q->exec_us > max_us) { max_us = q->exec_us; }
 
-    if (!min_bits || q->bitmap_size < min_bits) min_bits = q->bitmap_size;
-    if (q->bitmap_size > max_bits) max_bits = q->bitmap_size;
+    if (!min_bits || q->bitmap_size < min_bits) { min_bits = q->bitmap_size; }
+    if (q->bitmap_size > max_bits) { max_bits = q->bitmap_size; }
 
-    if (q->len > max_len) max_len = q->len;
+    if (q->len > max_len) { max_len = q->len; }
 
     q = q->next;
 
@@ -847,37 +905,60 @@ void show_init_stats(afl_state_t *afl) {
 
   SAYF("\n");
 
-  if (avg_us > ((afl->fsrv.qemu_mode || afl->unicorn_mode) ? 50000 : 10000))
+  if (avg_us > ((afl->fsrv.qemu_mode || afl->unicorn_mode) ? 50000 : 10000)) {
+
     WARNF(cLRD "The target binary is pretty slow! See %s/perf_tips.md.",
           doc_path);
 
+  }
+
   /* Let's keep things moving with slow binaries. */
 
-  if (avg_us > 50000)
+  if (avg_us > 50000) {
+
     afl->havoc_div = 10;                                /* 0-19 execs/sec   */
-  else if (avg_us > 20000)
+
+  } else if (avg_us > 20000) {
+
     afl->havoc_div = 5;                                 /* 20-49 execs/sec  */
-  else if (avg_us > 10000)
+
+  } else if (avg_us > 10000) {
+
     afl->havoc_div = 2;                                 /* 50-100 execs/sec */
+
+  }
 
   if (!afl->resuming_fuzz) {
 
-    if (max_len > 50 * 1024)
+    if (max_len > 50 * 1024) {
+
       WARNF(cLRD "Some test cases are huge (%s) - see %s/perf_tips.md!",
             stringify_mem_size(IB(0), max_len), doc_path);
-    else if (max_len > 10 * 1024)
+
+    } else if (max_len > 10 * 1024) {
+
       WARNF("Some test cases are big (%s) - see %s/perf_tips.md.",
             stringify_mem_size(IB(0), max_len), doc_path);
 
-    if (afl->useless_at_start && !afl->in_bitmap)
+    }
+
+    if (afl->useless_at_start && !afl->in_bitmap) {
+
       WARNF(cLRD "Some test cases look useless. Consider using a smaller set.");
 
-    if (afl->queued_paths > 100)
+    }
+
+    if (afl->queued_paths > 100) {
+
       WARNF(cLRD
             "You probably have far too many input files! Consider trimming "
             "down.");
-    else if (afl->queued_paths > 20)
+
+    } else if (afl->queued_paths > 20) {
+
       WARNF("You have lots of input files; try starting small.");
+
+    }
 
   }
 
@@ -903,19 +984,29 @@ void show_init_stats(afl_state_t *afl) {
        random scheduler jitter is less likely to have any impact, and because
        our patience is wearing thin =) */
 
-    if (avg_us > 50000)
+    if (avg_us > 50000) {
+
       afl->fsrv.exec_tmout = avg_us * 2 / 1000;
-    else if (avg_us > 10000)
+
+    } else if (avg_us > 10000) {
+
       afl->fsrv.exec_tmout = avg_us * 3 / 1000;
-    else
+
+    } else {
+
       afl->fsrv.exec_tmout = avg_us * 5 / 1000;
+
+    }
 
     afl->fsrv.exec_tmout = MAX(afl->fsrv.exec_tmout, max_us / 1000);
     afl->fsrv.exec_tmout =
         (afl->fsrv.exec_tmout + EXEC_TM_ROUND) / EXEC_TM_ROUND * EXEC_TM_ROUND;
 
-    if (afl->fsrv.exec_tmout > EXEC_TIMEOUT)
+    if (afl->fsrv.exec_tmout > EXEC_TIMEOUT) {
+
       afl->fsrv.exec_tmout = EXEC_TIMEOUT;
+
+    }
 
     ACTF("No -t option specified, so I'll use exec timeout of %u ms.",
          afl->fsrv.exec_tmout);
@@ -932,8 +1023,11 @@ void show_init_stats(afl_state_t *afl) {
   /* In dumb mode, re-running every timing out test case with a generous time
      limit is very expensive, so let's select a more conservative default. */
 
-  if (afl->dumb_mode && !(afl->afl_env.afl_hang_tmout))
+  if (afl->dumb_mode && !(afl->afl_env.afl_hang_tmout)) {
+
     afl->hang_tmout = MIN(EXEC_TIMEOUT, afl->fsrv.exec_tmout * 2 + 100);
+
+  }
 
   OKF("All set and ready to roll!");
 #undef IB

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -36,7 +36,7 @@ static u8 *get_libradamsa_path(u8 *own_loc) {
 
     cp = alloc_printf("%s/libradamsa.so", tmp);
 
-    if (access(cp, X_OK)) FATAL("Unable to find '%s'", cp);
+    if (access(cp, X_OK)) { FATAL("Unable to find '%s'", cp); }
 
     return cp;
 
@@ -52,11 +52,13 @@ static u8 *get_libradamsa_path(u8 *own_loc) {
     cp = alloc_printf("%s/libradamsa.so", own_copy);
     ck_free(own_copy);
 
-    if (!access(cp, X_OK)) return cp;
+    if (!access(cp, X_OK)) { return cp; }
 
-  } else
+  } else {
 
     ck_free(own_copy);
+
+  }
 
   if (!access(AFL_PATH "/libradamsa.so", X_OK)) {
 
@@ -147,7 +149,8 @@ static void usage(afl_state_t *afl, u8 *argv0, int more_help) {
       "case\n\n",
       argv0, EXEC_TIMEOUT, MEM_LIMIT);
 
-  if (more_help > 1)
+  if (more_help > 1) {
+
     SAYF(
       "Environment variables used:\n"
       "LD_BIND_LAZY: do not set LD_BIND_NOW env var for target\n"
@@ -192,10 +195,14 @@ static void usage(afl_state_t *afl, u8 *argv0, int more_help) {
       //"AFL_DEFER_FORKSRV: not supported anymore -> no effect, just a warning\n"
       "\n"
     );
-  else
+
+  } else {
+
     SAYF(
         "To view also the supported environment variables of afl-fuzz please "
         "use \"-hh\".\n\n");
+
+  }
 
 #ifdef USE_PYTHON
   SAYF("Compiled with %s module support, see docs/custom_mutator.md\n",
@@ -215,13 +222,13 @@ static void usage(afl_state_t *afl, u8 *argv0, int more_help) {
 
 static int stricmp(char const *a, char const *b) {
 
-  if (!a || !b) FATAL("Null reference");
+  if (!a || !b) { FATAL("Null reference"); }
 
   for (;; ++a, ++b) {
 
     int d;
     d = tolower(*a) - tolower(*b);
-    if (d != 0 || !*a) return d;
+    if (d != 0 || !*a) { return d; }
 
   }
 
@@ -246,14 +253,14 @@ int main(int argc, char **argv_orig, char **envp) {
   afl_state_t *afl = calloc(1, sizeof(afl_state_t));
   if (!afl) { FATAL("Could not create afl state"); }
 
-  if (get_afl_env("AFL_DEBUG")) afl->debug = 1;
+  if (get_afl_env("AFL_DEBUG")) { afl->debug = 1; }
 
   map_size = get_map_size();
   afl_state_init(afl, map_size);
   afl_fsrv_init(&afl->fsrv);
 
   read_afl_environment(afl, envp);
-  if (afl->shm.map_size) afl->fsrv.map_size = afl->shm.map_size;
+  if (afl->shm.map_size) { afl->fsrv.map_size = afl->shm.map_size; }
   exit_1 = !!afl->afl_env.afl_bench_just_one;
 
   SAYF(cCYA "afl-fuzz" VERSION cRST
@@ -265,11 +272,14 @@ int main(int argc, char **argv_orig, char **envp) {
   afl->init_seed = tv.tv_sec ^ tv.tv_usec ^ getpid();
 
   while ((opt = getopt(argc, argv,
-                       "+c:i:I:o:f:m:t:T:dnCB:S:M:x:QNUWe:p:s:V:E:L:hRP:")) > 0)
+                       "+c:i:I:o:f:m:t:T:dnCB:S:M:x:QNUWe:p:s:V:E:L:hRP:")) >
+         0) {
 
     switch (opt) {
 
-      case 'I': afl->infoexec = optarg; break;
+      case 'I':
+        afl->infoexec = optarg;
+        break;
 
       case 'c': {
 
@@ -333,7 +343,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'e':
 
-        if (afl->file_extension) FATAL("Multiple -e options not supported");
+        if (afl->file_extension) { FATAL("Multiple -e options not supported"); }
 
         afl->file_extension = optarg;
 
@@ -341,16 +351,16 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'i':                                                /* input dir */
 
-        if (afl->in_dir) FATAL("Multiple -i options not supported");
+        if (afl->in_dir) { FATAL("Multiple -i options not supported"); }
         afl->in_dir = optarg;
 
-        if (!strcmp(afl->in_dir, "-")) afl->in_place_resume = 1;
+        if (!strcmp(afl->in_dir, "-")) { afl->in_place_resume = 1; }
 
         break;
 
       case 'o':                                               /* output dir */
 
-        if (afl->out_dir) FATAL("Multiple -o options not supported");
+        if (afl->out_dir) { FATAL("Multiple -o options not supported"); }
         afl->out_dir = optarg;
         break;
 
@@ -358,7 +368,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u8 *c;
 
-        if (afl->sync_id) FATAL("Multiple -S or -M options not supported");
+        if (afl->sync_id) { FATAL("Multiple -S or -M options not supported"); }
         afl->sync_id = ck_strdup(optarg);
 
         if ((c = strchr(afl->sync_id, ':'))) {
@@ -367,8 +377,11 @@ int main(int argc, char **argv_orig, char **envp) {
 
           if (sscanf(c + 1, "%u/%u", &afl->master_id, &afl->master_max) != 2 ||
               !afl->master_id || !afl->master_max ||
-              afl->master_id > afl->master_max || afl->master_max > 1000000)
+              afl->master_id > afl->master_max || afl->master_max > 1000000) {
+
             FATAL("Bogus master ID passed to -M");
+
+          }
 
         }
 
@@ -380,20 +393,20 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'S':
 
-        if (afl->sync_id) FATAL("Multiple -S or -M options not supported");
+        if (afl->sync_id) { FATAL("Multiple -S or -M options not supported"); }
         afl->sync_id = ck_strdup(optarg);
         break;
 
       case 'f':                                              /* target file */
 
-        if (afl->fsrv.out_file) FATAL("Multiple -f options not supported");
+        if (afl->fsrv.out_file) { FATAL("Multiple -f options not supported"); }
         afl->fsrv.out_file = ck_strdup(optarg);
         afl->fsrv.use_stdin = 0;
         break;
 
       case 'x':                                               /* dictionary */
 
-        if (extras_dir) FATAL("Multiple -x options not supported");
+        if (extras_dir) { FATAL("Multiple -x options not supported"); }
         extras_dir = optarg;
         break;
 
@@ -401,18 +414,26 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u8 suffix = 0;
 
-        if (afl->timeout_given) FATAL("Multiple -t options not supported");
+        if (afl->timeout_given) { FATAL("Multiple -t options not supported"); }
 
         if (sscanf(optarg, "%u%c", &afl->fsrv.exec_tmout, &suffix) < 1 ||
-            optarg[0] == '-')
+            optarg[0] == '-') {
+
           FATAL("Bad syntax used for -t");
 
-        if (afl->fsrv.exec_tmout < 5) FATAL("Dangerously low value of -t");
+        }
 
-        if (suffix == '+')
+        if (afl->fsrv.exec_tmout < 5) { FATAL("Dangerously low value of -t"); }
+
+        if (suffix == '+') {
+
           afl->timeout_given = 2;
-        else
+
+        } else {
+
           afl->timeout_given = 1;
+
+        }
 
         break;
 
@@ -422,10 +443,10 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u8 suffix = 'M';
 
-        if (mem_limit_given) FATAL("Multiple -m options not supported");
+        if (mem_limit_given) { FATAL("Multiple -m options not supported"); }
         mem_limit_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -m");
+        if (!optarg) { FATAL("Wrong usage of -m"); }
 
         if (!strcmp(optarg, "none")) {
 
@@ -435,24 +456,38 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         if (sscanf(optarg, "%llu%c", &afl->fsrv.mem_limit, &suffix) < 1 ||
-            optarg[0] == '-')
+            optarg[0] == '-') {
+
           FATAL("Bad syntax used for -m");
-
-        switch (suffix) {
-
-          case 'T': afl->fsrv.mem_limit *= 1024 * 1024; break;
-          case 'G': afl->fsrv.mem_limit *= 1024; break;
-          case 'k': afl->fsrv.mem_limit /= 1024; break;
-          case 'M': break;
-
-          default: FATAL("Unsupported suffix or bad syntax for -m");
 
         }
 
-        if (afl->fsrv.mem_limit < 5) FATAL("Dangerously low value of -m");
+        switch (suffix) {
 
-        if (sizeof(rlim_t) == 4 && afl->fsrv.mem_limit > 2000)
+          case 'T':
+            afl->fsrv.mem_limit *= 1024 * 1024;
+            break;
+          case 'G':
+            afl->fsrv.mem_limit *= 1024;
+            break;
+          case 'k':
+            afl->fsrv.mem_limit /= 1024;
+            break;
+          case 'M':
+            break;
+
+          default:
+            FATAL("Unsupported suffix or bad syntax for -m");
+
+        }
+
+        if (afl->fsrv.mem_limit < 5) { FATAL("Dangerously low value of -m"); }
+
+        if (sizeof(rlim_t) == 4 && afl->fsrv.mem_limit > 2000) {
+
           FATAL("Value of -m out of range on 32-bit systems");
+
+        }
 
       }
 
@@ -460,7 +495,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'd':                                       /* skip deterministic */
 
-        if (afl->skip_deterministic) FATAL("Multiple -d options not supported");
+        if (afl->skip_deterministic) {
+
+          FATAL("Multiple -d options not supported");
+
+        }
+
         afl->skip_deterministic = 1;
         afl->use_splicing = 1;
         break;
@@ -478,7 +518,7 @@ int main(int argc, char **argv_orig, char **envp) {
            I only used this once or twice to get variants of a particular
            file, so I'm not making this an official setting. */
 
-        if (afl->in_bitmap) FATAL("Multiple -B options not supported");
+        if (afl->in_bitmap) { FATAL("Multiple -B options not supported"); }
 
         afl->in_bitmap = optarg;
         read_bitmap(afl->in_bitmap, afl->virgin_bits, afl->fsrv.map_size);
@@ -486,84 +526,98 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'C':                                               /* crash mode */
 
-        if (afl->crash_mode) FATAL("Multiple -C options not supported");
+        if (afl->crash_mode) { FATAL("Multiple -C options not supported"); }
         afl->crash_mode = FSRV_RUN_CRASH;
         break;
 
       case 'n':                                                /* dumb mode */
 
-        if (afl->dumb_mode) FATAL("Multiple -n options not supported");
-        if (afl->afl_env.afl_dumb_forksrv)
+        if (afl->dumb_mode) { FATAL("Multiple -n options not supported"); }
+        if (afl->afl_env.afl_dumb_forksrv) {
+
           afl->dumb_mode = 2;
-        else
+
+        } else {
+
           afl->dumb_mode = 1;
+
+        }
 
         break;
 
       case 'T':                                                   /* banner */
 
-        if (afl->use_banner) FATAL("Multiple -T options not supported");
+        if (afl->use_banner) { FATAL("Multiple -T options not supported"); }
         afl->use_banner = optarg;
         break;
 
       case 'Q':                                                /* QEMU mode */
 
-        if (afl->fsrv.qemu_mode) FATAL("Multiple -Q options not supported");
+        if (afl->fsrv.qemu_mode) { FATAL("Multiple -Q options not supported"); }
         afl->fsrv.qemu_mode = 1;
 
-        if (!mem_limit_given) afl->fsrv.mem_limit = MEM_LIMIT_QEMU;
+        if (!mem_limit_given) { afl->fsrv.mem_limit = MEM_LIMIT_QEMU; }
 
         break;
 
       case 'N':                                             /* Unicorn mode */
 
-        if (afl->no_unlink) FATAL("Multiple -N options not supported");
+        if (afl->no_unlink) { FATAL("Multiple -N options not supported"); }
         afl->no_unlink = 1;
 
         break;
 
       case 'U':                                             /* Unicorn mode */
 
-        if (afl->unicorn_mode) FATAL("Multiple -U options not supported");
+        if (afl->unicorn_mode) { FATAL("Multiple -U options not supported"); }
         afl->unicorn_mode = 1;
 
-        if (!mem_limit_given) afl->fsrv.mem_limit = MEM_LIMIT_UNICORN;
+        if (!mem_limit_given) { afl->fsrv.mem_limit = MEM_LIMIT_UNICORN; }
 
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
 
-        if (afl->use_wine) FATAL("Multiple -W options not supported");
+        if (afl->use_wine) { FATAL("Multiple -W options not supported"); }
         afl->fsrv.qemu_mode = 1;
         afl->use_wine = 1;
 
-        if (!mem_limit_given) afl->fsrv.mem_limit = 0;
+        if (!mem_limit_given) { afl->fsrv.mem_limit = 0; }
 
         break;
 
       case 'V': {
 
         afl->most_time_key = 1;
-        if (sscanf(optarg, "%llu", &afl->most_time) < 1 || optarg[0] == '-')
+        if (sscanf(optarg, "%llu", &afl->most_time) < 1 || optarg[0] == '-') {
+
           FATAL("Bad syntax used for -V");
+
+        }
 
       } break;
 
       case 'E': {
 
         afl->most_execs_key = 1;
-        if (sscanf(optarg, "%llu", &afl->most_execs) < 1 || optarg[0] == '-')
+        if (sscanf(optarg, "%llu", &afl->most_execs) < 1 || optarg[0] == '-') {
+
           FATAL("Bad syntax used for -E");
+
+        }
 
       } break;
 
       case 'L': {                                              /* MOpt mode */
 
-        if (afl->limit_time_sig) FATAL("Multiple -L options not supported");
+        if (afl->limit_time_sig) { FATAL("Multiple -L options not supported"); }
         afl->havoc_max_mult = HAVOC_MAX_MULT_MOPT;
 
-        if (sscanf(optarg, "%d", &afl->limit_time_puppet) < 1)
+        if (sscanf(optarg, "%d", &afl->limit_time_puppet) < 1) {
+
           FATAL("Bad syntax used for -L");
+
+        }
 
         if (afl->limit_time_puppet == -1) {
 
@@ -582,19 +636,23 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u64 limit_time_puppet2 = afl->limit_time_puppet * 60 * 1000;
 
-        if (limit_time_puppet2 < afl->limit_time_puppet)
+        if (limit_time_puppet2 < afl->limit_time_puppet) {
+
           FATAL("limit_time overflow");
+
+        }
+
         afl->limit_time_puppet = limit_time_puppet2;
 
         SAYF("limit_time_puppet %d\n", afl->limit_time_puppet);
         afl->swarm_now = 0;
 
-        if (afl->limit_time_puppet == 0) afl->key_puppet = 1;
+        if (afl->limit_time_puppet == 0) { afl->key_puppet = 1; }
 
         int i;
         int tmp_swarm = 0;
 
-        if (afl->g_now > afl->g_max) afl->g_now = 0;
+        if (afl->g_now > afl->g_max) { afl->g_now = 0; }
         afl->w_now = (afl->w_init - afl->w_end) * (afl->g_max - afl->g_now) /
                          (afl->g_max) +
                      afl->w_end;
@@ -642,10 +700,15 @@ int main(int argc, char **argv_orig, char **envp) {
 
             afl->x_now[tmp_swarm][i] += afl->v_now[tmp_swarm][i];
 
-            if (afl->x_now[tmp_swarm][i] > v_max)
+            if (afl->x_now[tmp_swarm][i] > v_max) {
+
               afl->x_now[tmp_swarm][i] = v_max;
-            else if (afl->x_now[tmp_swarm][i] < v_min)
+
+            } else if (afl->x_now[tmp_swarm][i] < v_min) {
+
               afl->x_now[tmp_swarm][i] = v_min;
+
+            }
 
             x_temp += afl->x_now[tmp_swarm][i];
 
@@ -654,18 +717,26 @@ int main(int argc, char **argv_orig, char **envp) {
           for (i = 0; i < operator_num; ++i) {
 
             afl->x_now[tmp_swarm][i] = afl->x_now[tmp_swarm][i] / x_temp;
-            if (likely(i != 0))
+            if (likely(i != 0)) {
+
               afl->probability_now[tmp_swarm][i] =
                   afl->probability_now[tmp_swarm][i - 1] +
                   afl->x_now[tmp_swarm][i];
-            else
+
+            } else {
+
               afl->probability_now[tmp_swarm][i] = afl->x_now[tmp_swarm][i];
+
+            }
 
           }
 
           if (afl->probability_now[tmp_swarm][operator_num - 1] < 0.99 ||
-              afl->probability_now[tmp_swarm][operator_num - 1] > 1.01)
+              afl->probability_now[tmp_swarm][operator_num - 1] > 1.01) {
+
             FATAL("ERROR probability");
+
+          }
 
         }
 
@@ -681,24 +752,36 @@ int main(int argc, char **argv_orig, char **envp) {
 
       } break;
 
-      case 'h': show_help++; break;  // not needed
+      case 'h':
+        show_help++;
+        break;  // not needed
 
       case 'R':
 
-        if (afl->use_radamsa)
+        if (afl->use_radamsa) {
+
           afl->use_radamsa = 2;
-        else
+
+        } else {
+
           afl->use_radamsa = 1;
+
+        }
 
         break;
 
       default:
-        if (!show_help) show_help = 1;
+        if (!show_help) { show_help = 1; }
 
     }
 
-  if (optind == argc || !afl->in_dir || !afl->out_dir || show_help)
+  }
+
+  if (optind == argc || !afl->in_dir || !afl->out_dir || show_help) {
+
     usage(afl, argv[0], show_help);
+
+  }
 
   OKF("afl++ is maintained by Marc \"van Hauser\" Heuse, Heiko \"hexcoder\" "
       "Eißfeldt, Andrea Fioraldi and Dominik Maier");
@@ -710,25 +793,39 @@ int main(int argc, char **argv_orig, char **envp) {
   OKF("MOpt Mutator from github.com/puppet-meteor/MOpt-AFL");
 
   if (afl->sync_id && afl->force_deterministic &&
-      afl->afl_env.afl_custom_mutator_only)
+      afl->afl_env.afl_custom_mutator_only) {
+
     WARNF(
         "Using -M master with the AFL_CUSTOM_MUTATOR_ONLY mutator options will "
         "result in no deterministic mutations being done!");
 
-  if (afl->fixed_seed) OKF("Running with fixed seed: %u", (u32)afl->init_seed);
+  }
+
+  if (afl->fixed_seed) {
+
+    OKF("Running with fixed seed: %u", (u32)afl->init_seed);
+
+  }
+
   srandom((u32)afl->init_seed);
   srand((u32)afl->init_seed);  // in case it is a different implementation
 
   if (afl->use_radamsa) {
 
-    if (afl->limit_time_sig > 0)
+    if (afl->limit_time_sig > 0) {
+
       FATAL(
           "MOpt and Radamsa are mutually exclusive unless you specify -L -1. "
           "We accept pull requests that integrates MOpt with the optional "
           "mutators (custom/radamsa/redqueen/...).");
 
-    if (afl->limit_time_sig && afl->use_radamsa > 1)
+    }
+
+    if (afl->limit_time_sig && afl->use_radamsa > 1) {
+
       FATAL("Radamsa in radamsa-only mode can not run together with -L");
+
+    }
 
     OKF("Using Radamsa add-on");
 
@@ -736,13 +833,16 @@ int main(int argc, char **argv_orig, char **envp) {
     void *handle = dlopen(libradamsa_path, RTLD_NOW);
     ck_free(libradamsa_path);
 
-    if (!handle) FATAL("Failed to dlopen() libradamsa");
+    if (!handle) { FATAL("Failed to dlopen() libradamsa"); }
 
     void (*radamsa_init_ptr)(void) = dlsym(handle, "radamsa_init");
     afl->radamsa_mutate_ptr = dlsym(handle, "radamsa");
 
-    if (!radamsa_init_ptr || !afl->radamsa_mutate_ptr)
+    if (!radamsa_init_ptr || !afl->radamsa_mutate_ptr) {
+
       FATAL("Failed to dlsym() libradamsa");
+
+    }
 
     /* randamsa_init installs some signal hadlers, call it before
        setup_signal_handlers so that AFL++ can then replace those signal
@@ -766,79 +866,112 @@ int main(int argc, char **argv_orig, char **envp) {
 
   afl->power_name = power_names[afl->schedule];
 
-  if (afl->sync_id) fix_up_sync(afl);
+  if (afl->sync_id) { fix_up_sync(afl); }
 
-  if (!strcmp(afl->in_dir, afl->out_dir))
+  if (!strcmp(afl->in_dir, afl->out_dir)) {
+
     FATAL("Input and output directories can't be the same");
-
-  if (afl->dumb_mode) {
-
-    if (afl->crash_mode) FATAL("-C and -n are mutually exclusive");
-    if (afl->fsrv.qemu_mode) FATAL("-Q and -n are mutually exclusive");
-    if (afl->unicorn_mode) FATAL("-U and -n are mutually exclusive");
 
   }
 
-  if (get_afl_env("AFL_DISABLE_TRIM")) afl->disable_trim = 1;
+  if (afl->dumb_mode) {
 
-  if (getenv("AFL_NO_UI") && getenv("AFL_FORCE_UI"))
+    if (afl->crash_mode) { FATAL("-C and -n are mutually exclusive"); }
+    if (afl->fsrv.qemu_mode) { FATAL("-Q and -n are mutually exclusive"); }
+    if (afl->unicorn_mode) { FATAL("-U and -n are mutually exclusive"); }
+
+  }
+
+  if (get_afl_env("AFL_DISABLE_TRIM")) { afl->disable_trim = 1; }
+
+  if (getenv("AFL_NO_UI") && getenv("AFL_FORCE_UI")) {
+
     FATAL("AFL_NO_UI and AFL_FORCE_UI are mutually exclusive");
 
-  if (strchr(argv[optind], '/') == NULL && !afl->unicorn_mode)
+  }
+
+  if (strchr(argv[optind], '/') == NULL && !afl->unicorn_mode) {
+
     WARNF(cLRD
           "Target binary called without a prefixed path, make sure you are "
           "fuzzing the right binary: " cRST "%s",
           argv[optind]);
 
+  }
+
   ACTF("Getting to work...");
 
   switch (afl->schedule) {
 
-    case FAST: OKF("Using exponential power schedule (FAST)"); break;
-    case COE: OKF("Using cut-off exponential power schedule (COE)"); break;
+    case FAST:
+      OKF("Using exponential power schedule (FAST)");
+      break;
+    case COE:
+      OKF("Using cut-off exponential power schedule (COE)");
+      break;
     case EXPLOIT:
       OKF("Using exploitation-based constant power schedule (EXPLOIT)");
       break;
-    case LIN: OKF("Using linear power schedule (LIN)"); break;
-    case QUAD: OKF("Using quadratic power schedule (QUAD)"); break;
-    case MMOPT: OKF("Using modified MOpt power schedule (MMOPT)"); break;
-    case RARE: OKF("Using rare edge focus power schedule (RARE)"); break;
+    case LIN:
+      OKF("Using linear power schedule (LIN)");
+      break;
+    case QUAD:
+      OKF("Using quadratic power schedule (QUAD)");
+      break;
+    case MMOPT:
+      OKF("Using modified MOpt power schedule (MMOPT)");
+      break;
+    case RARE:
+      OKF("Using rare edge focus power schedule (RARE)");
+      break;
     case EXPLORE:
       OKF("Using exploration-based constant power schedule (EXPLORE, default)");
       break;
-    default: FATAL("Unknown power schedule"); break;
+    default:
+      FATAL("Unknown power schedule");
+      break;
 
   }
 
-  if (get_afl_env("AFL_NO_FORKSRV")) afl->no_forkserver = 1;
-  if (get_afl_env("AFL_NO_CPU_RED")) afl->no_cpu_meter_red = 1;
-  if (get_afl_env("AFL_NO_ARITH")) afl->no_arith = 1;
-  if (get_afl_env("AFL_SHUFFLE_QUEUE")) afl->shuffle_queue = 1;
-  if (get_afl_env("AFL_FAST_CAL")) afl->fast_cal = 1;
+  if (get_afl_env("AFL_NO_FORKSRV")) { afl->no_forkserver = 1; }
+  if (get_afl_env("AFL_NO_CPU_RED")) { afl->no_cpu_meter_red = 1; }
+  if (get_afl_env("AFL_NO_ARITH")) { afl->no_arith = 1; }
+  if (get_afl_env("AFL_SHUFFLE_QUEUE")) { afl->shuffle_queue = 1; }
+  if (get_afl_env("AFL_FAST_CAL")) { afl->fast_cal = 1; }
 
   if (afl->afl_env.afl_autoresume) {
 
     afl->autoresume = 1;
-    if (afl->in_place_resume) SAYF("AFL_AUTORESUME has no effect for '-i -'");
+    if (afl->in_place_resume) {
+
+      SAYF("AFL_AUTORESUME has no effect for '-i -'");
+
+    }
 
   }
 
   if (afl->afl_env.afl_hang_tmout) {
 
     afl->hang_tmout = atoi(afl->afl_env.afl_hang_tmout);
-    if (!afl->hang_tmout) FATAL("Invalid value of AFL_HANG_TMOUT");
+    if (!afl->hang_tmout) { FATAL("Invalid value of AFL_HANG_TMOUT"); }
 
   }
 
-  if (afl->dumb_mode == 2 && afl->no_forkserver)
+  if (afl->dumb_mode == 2 && afl->no_forkserver) {
+
     FATAL("AFL_DUMB_FORKSRV and AFL_NO_FORKSRV are mutually exclusive");
+
+  }
 
   afl->fsrv.use_fauxsrv = afl->dumb_mode == 1 || afl->no_forkserver;
 
-  if (getenv("LD_PRELOAD"))
+  if (getenv("LD_PRELOAD")) {
+
     WARNF(
         "LD_PRELOAD is set, are you sure that is what to you want to do "
         "instead of using AFL_PRELOAD?");
+
+  }
 
   if (afl->afl_env.afl_preload) {
 
@@ -851,19 +984,27 @@ int main(int argc, char **argv_orig, char **envp) {
       s32 i, afl_preload_size = strlen(afl_preload);
       for (i = 0; i < afl_preload_size; ++i) {
 
-        if (afl_preload[i] == ',')
+        if (afl_preload[i] == ',') {
+
           PFATAL(
               "Comma (',') is not allowed in AFL_PRELOAD when -Q is "
               "specified!");
 
+        }
+
       }
 
-      if (qemu_preload)
+      if (qemu_preload) {
+
         buf = alloc_printf("%s,LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            qemu_preload, afl_preload, afl_preload);
-      else
+
+      } else {
+
         buf = alloc_printf("LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            afl_preload, afl_preload);
+
+      }
 
       setenv("QEMU_SET_ENV", buf, 1);
 
@@ -878,15 +1019,18 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
-  if (getenv("AFL_LD_PRELOAD"))
+  if (getenv("AFL_LD_PRELOAD")) {
+
     FATAL("Use AFL_PRELOAD instead of AFL_LD_PRELOAD");
+
+  }
 
   save_cmdline(afl, argc, argv);
 
   fix_up_banner(afl, argv[optind]);
 
   check_if_tty(afl);
-  if (afl->afl_env.afl_force_ui) afl->not_on_tty = 0;
+  if (afl->afl_env.afl_force_ui) { afl->not_on_tty = 0; }
 
   if (afl->afl_env.afl_cal_fast) {
 
@@ -920,7 +1064,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   setup_post(afl);
 
-  if (!afl->in_bitmap) memset(afl->virgin_bits, 255, afl->fsrv.map_size);
+  if (!afl->in_bitmap) { memset(afl->virgin_bits, 255, afl->fsrv.map_size); }
   memset(afl->virgin_tmout, 255, afl->fsrv.map_size);
   memset(afl->virgin_crash, 255, afl->fsrv.map_size);
 
@@ -937,9 +1081,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
   pivot_inputs(afl);
 
-  if (extras_dir) load_extras(afl, extras_dir);
+  if (extras_dir) { load_extras(afl, extras_dir); }
 
-  if (!afl->timeout_given) find_timeout(afl);
+  if (!afl->timeout_given) { find_timeout(afl); }
 
   if ((afl->tmp_dir = afl->afl_env.afl_tmpdir) != NULL &&
       !afl->in_place_resume) {
@@ -958,15 +1102,20 @@ int main(int argc, char **argv_orig, char **envp) {
     }
 
     /* there is still a race condition here, but well ... */
-    if (access(tmpfile, F_OK) != -1)
+    if (access(tmpfile, F_OK) != -1) {
+
       FATAL(
           "AFL_TMPDIR already has an existing temporary input file: %s - if "
           "this is not from another instance, then just remove the file.",
           tmpfile);
 
-  } else
+    }
+
+  } else {
 
     afl->tmp_dir = afl->out_dir;
+
+  }
 
   /* If we don't have a file name chosen yet, use a safe default. */
 
@@ -1004,13 +1153,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
-  if (!afl->fsrv.out_file) setup_stdio_file(afl);
+  if (!afl->fsrv.out_file) { setup_stdio_file(afl); }
 
   if (afl->cmplog_binary) {
 
-    if (afl->unicorn_mode)
+    if (afl->unicorn_mode) {
+
       FATAL("CmpLog and Unicorn mode are not compatible at the moment, sorry");
-    if (!afl->fsrv.qemu_mode) check_binary(afl, afl->cmplog_binary);
+
+    }
+
+    if (!afl->fsrv.qemu_mode) { check_binary(afl, afl->cmplog_binary); }
 
   }
 
@@ -1020,12 +1173,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (afl->fsrv.qemu_mode) {
 
-    if (afl->use_wine)
+    if (afl->use_wine) {
+
       use_argv = get_wine_argv(argv[0], &afl->fsrv.target_path, argc - optind,
                                argv + optind);
-    else
+
+    } else {
+
       use_argv = get_qemu_argv(argv[0], &afl->fsrv.target_path, argc - optind,
                                argv + optind);
+
+    }
 
   } else {
 
@@ -1061,7 +1219,7 @@ int main(int argc, char **argv_orig, char **envp) {
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);
 
-  if (afl->stop_soon) goto stop_fuzzing;
+  if (afl->stop_soon) { goto stop_fuzzing; }
 
   /* Woop woop woop */
 
@@ -1069,7 +1227,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
     sleep(4);
     afl->start_time += 4000;
-    if (afl->stop_soon) goto stop_fuzzing;
+    if (afl->stop_soon) { goto stop_fuzzing; }
 
   }
 
@@ -1111,20 +1269,30 @@ int main(int argc, char **argv_orig, char **envp) {
 
       if (afl->queued_paths == prev_queued) {
 
-        if (afl->use_splicing)
+        if (afl->use_splicing) {
+
           ++afl->cycles_wo_finds;
-        else
+
+        } else {
+
           afl->use_splicing = 1;
 
-      } else
+        }
+
+      } else {
 
         afl->cycles_wo_finds = 0;
+
+      }
 
       prev_queued = afl->queued_paths;
 
       if (afl->sync_id && afl->queue_cycle == 1 &&
-          afl->afl_env.afl_import_first)
+          afl->afl_env.afl_import_first) {
+
         sync_fuzzers(afl);
+
+      }
 
     }
 
@@ -1132,13 +1300,13 @@ int main(int argc, char **argv_orig, char **envp) {
 
     if (!skipped_fuzz && !afl->stop_soon && afl->sync_id) {
 
-      if (!(sync_interval_cnt++ % SYNC_INTERVAL)) sync_fuzzers(afl);
+      if (!(sync_interval_cnt++ % SYNC_INTERVAL)) { sync_fuzzers(afl); }
 
     }
 
-    if (!afl->stop_soon && exit_1) afl->stop_soon = 2;
+    if (!afl->stop_soon && exit_1) { afl->stop_soon = 2; }
 
-    if (afl->stop_soon) break;
+    if (afl->stop_soon) { break; }
 
     afl->queue_cur = afl->queue_cur->next;
     ++afl->current_entry;
@@ -1158,10 +1326,17 @@ stop_fuzzing:
   SAYF(CURSOR_SHOW cLRD "\n\n+++ Testing aborted %s +++\n" cRST,
        afl->stop_soon == 2 ? "programmatically" : "by user");
 
-  if (afl->most_time_key == 2)
+  if (afl->most_time_key == 2) {
+
     SAYF(cYEL "[!] " cRST "Time limit was reached\n");
-  if (afl->most_execs_key == 2)
+
+  }
+
+  if (afl->most_execs_key == 2) {
+
     SAYF(cYEL "[!] " cRST "Execution limit was reached\n");
+
+  }
 
   /* Running for more than 30 minutes but still doing first cycle? */
 
@@ -1181,7 +1356,7 @@ stop_fuzzing:
   destroy_custom_mutator(afl);
   afl_shm_deinit(&afl->shm);
   afl_fsrv_deinit(&afl->fsrv);
-  if (afl->orig_cmdline) ck_free(afl->orig_cmdline);
+  if (afl->orig_cmdline) { ck_free(afl->orig_cmdline); }
   ck_free(afl->fsrv.target_path);
   ck_free(afl->fsrv.out_file);
   ck_free(afl->sync_id);

--- a/src/afl-gcc.c
+++ b/src/afl-gcc.c
@@ -128,10 +128,15 @@ static void edit_params(u32 argc, char **argv) {
   cc_params = ck_alloc((argc + 128) * sizeof(u8 *));
 
   name = strrchr(argv[0], '/');
-  if (!name)
+  if (!name) {
+
     name = argv[0];
-  else
+
+  } else {
+
     ++name;
+
+  }
 
   if (!strncmp(name, "afl-clang", 9)) {
 
@@ -211,7 +216,7 @@ static void edit_params(u32 argc, char **argv) {
 
     if (!strncmp(cur, "-B", 2)) {
 
-      if (!be_quiet) WARNF("-B is already set, overriding");
+      if (!be_quiet) { WARNF("-B is already set, overriding"); }
 
       if (!cur[2] && argc > 1) {
 
@@ -224,18 +229,22 @@ static void edit_params(u32 argc, char **argv) {
 
     }
 
-    if (!strcmp(cur, "-integrated-as")) continue;
+    if (!strcmp(cur, "-integrated-as")) { continue; }
 
-    if (!strcmp(cur, "-pipe")) continue;
+    if (!strcmp(cur, "-pipe")) { continue; }
 
 #if defined(__FreeBSD__) && defined(WORD_SIZE_64)
     if (!strcmp(cur, "-m32")) m32_set = 1;
 #endif
 
-    if (!strcmp(cur, "-fsanitize=address") || !strcmp(cur, "-fsanitize=memory"))
+    if (!strcmp(cur, "-fsanitize=address") ||
+        !strcmp(cur, "-fsanitize=memory")) {
+
       asan_set = 1;
 
-    if (strstr(cur, "FORTIFY_SOURCE")) fortify_set = 1;
+    }
+
+    if (strstr(cur, "FORTIFY_SOURCE")) { fortify_set = 1; }
 
     cc_params[cc_par_cnt++] = cur;
 
@@ -244,13 +253,13 @@ static void edit_params(u32 argc, char **argv) {
   cc_params[cc_par_cnt++] = "-B";
   cc_params[cc_par_cnt++] = as_path;
 
-  if (clang_mode) cc_params[cc_par_cnt++] = "-no-integrated-as";
+  if (clang_mode) { cc_params[cc_par_cnt++] = "-no-integrated-as"; }
 
   if (getenv("AFL_HARDEN")) {
 
     cc_params[cc_par_cnt++] = "-fstack-protector-all";
 
-    if (!fortify_set) cc_params[cc_par_cnt++] = "-D_FORTIFY_SOURCE=2";
+    if (!fortify_set) { cc_params[cc_par_cnt++] = "-D_FORTIFY_SOURCE=2"; }
 
   }
 
@@ -262,20 +271,34 @@ static void edit_params(u32 argc, char **argv) {
 
   } else if (getenv("AFL_USE_ASAN")) {
 
-    if (getenv("AFL_USE_MSAN")) FATAL("ASAN and MSAN are mutually exclusive");
+    if (getenv("AFL_USE_MSAN")) {
 
-    if (getenv("AFL_HARDEN"))
+      FATAL("ASAN and MSAN are mutually exclusive");
+
+    }
+
+    if (getenv("AFL_HARDEN")) {
+
       FATAL("ASAN and AFL_HARDEN are mutually exclusive");
+
+    }
 
     cc_params[cc_par_cnt++] = "-U_FORTIFY_SOURCE";
     cc_params[cc_par_cnt++] = "-fsanitize=address";
 
   } else if (getenv("AFL_USE_MSAN")) {
 
-    if (getenv("AFL_USE_ASAN")) FATAL("ASAN and MSAN are mutually exclusive");
+    if (getenv("AFL_USE_ASAN")) {
 
-    if (getenv("AFL_HARDEN"))
+      FATAL("ASAN and MSAN are mutually exclusive");
+
+    }
+
+    if (getenv("AFL_HARDEN")) {
+
       FATAL("MSAN and AFL_HARDEN are mutually exclusive");
+
+    }
 
     cc_params[cc_par_cnt++] = "-U_FORTIFY_SOURCE";
     cc_params[cc_par_cnt++] = "-fsanitize=memory";
@@ -386,9 +409,11 @@ int main(int argc, char **argv) {
               "afl-gcc is deprecated, llvm_mode is much faster and has more "
               "options\n");
 
-  } else
+  } else {
 
     be_quiet = 1;
+
+  }
 
   if (argc < 2) {
 
@@ -416,7 +441,11 @@ int main(int argc, char **argv) {
       ((ptr = getenv("AFL_MAP_SIZE")) || (ptr = getenv("AFL_MAPSIZE")))) {
 
     u32 map_size = atoi(ptr);
-    if (map_size != MAP_SIZE) FATAL("AFL_MAP_SIZE is not supported by afl-gcc");
+    if (map_size != MAP_SIZE) {
+
+      FATAL("AFL_MAP_SIZE is not supported by afl-gcc");
+
+    }
 
   }
 

--- a/src/afl-gotcpu.c
+++ b/src/afl-gotcpu.c
@@ -102,8 +102,12 @@ repeat_loop:
 
   v1 = CTEST_BUSY_CYCLES;
 
-  while (v1--)
+  while (v1--) {
+
     v2++;
+
+  }
+
   sched_yield();
 
   en_t = get_cur_time_us();
@@ -154,7 +158,7 @@ int main(int argc, char **argv) {
 
     s32 fr = fork();
 
-    if (fr < 0) PFATAL("fork failed");
+    if (fr < 0) { PFATAL("fork failed"); }
 
     if (!fr) {
 
@@ -192,8 +196,12 @@ int main(int argc, char **argv) {
 #endif
 
 #if defined(__linux__)
-      if (sched_setaffinity(0, sizeof(c), &c))
+      if (sched_setaffinity(0, sizeof(c), &c)) {
+
         PFATAL("sched_setaffinity failed for cpu %d", i);
+
+      }
+
 #endif
 
       util_perc = measure_preemption(CTEST_CORE_TRG_MS);
@@ -221,10 +229,10 @@ int main(int argc, char **argv) {
   for (i = 0; i < cpu_cnt; i++) {
 
     int ret;
-    if (waitpid(-1, &ret, 0) < 0) PFATAL("waitpid failed");
+    if (waitpid(-1, &ret, 0) < 0) { PFATAL("waitpid failed"); }
 
-    if (WEXITSTATUS(ret) == 0) idle_cpus++;
-    if (WEXITSTATUS(ret) <= 1) maybe_cpus++;
+    if (WEXITSTATUS(ret) == 0) { idle_cpus++; }
+    if (WEXITSTATUS(ret) <= 1) { maybe_cpus++; }
 
   }
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -86,7 +86,7 @@ void afl_shm_deinit(sharedmem_t *shm) {
 
 #else
   shmctl(shm->shm_id, IPC_RMID, NULL);
-  if (shm->cmplog_mode) shmctl(shm->cmplog_shm_id, IPC_RMID, NULL);
+  if (shm->cmplog_mode) { shmctl(shm->cmplog_shm_id, IPC_RMID, NULL); }
 #endif
 
   shm->map = NULL;
@@ -152,14 +152,14 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size, unsigned char dumb_mode) {
 
   shm->shm_id = shmget(IPC_PRIVATE, map_size, IPC_CREAT | IPC_EXCL | 0600);
 
-  if (shm->shm_id < 0) PFATAL("shmget() failed");
+  if (shm->shm_id < 0) { PFATAL("shmget() failed"); }
 
   if (shm->cmplog_mode) {
 
     shm->cmplog_shm_id = shmget(IPC_PRIVATE, sizeof(struct cmp_map),
                                 IPC_CREAT | IPC_EXCL | 0600);
 
-    if (shm->cmplog_shm_id < 0) PFATAL("shmget() failed");
+    if (shm->cmplog_shm_id < 0) { PFATAL("shmget() failed"); }
 
   }
 
@@ -170,7 +170,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size, unsigned char dumb_mode) {
      fork server commands. This should be replaced with better auto-detection
      later on, perhaps? */
 
-  if (!dumb_mode) setenv(SHM_ENV_VAR, shm_str, 1);
+  if (!dumb_mode) { setenv(SHM_ENV_VAR, shm_str, 1); }
 
   ck_free(shm_str);
 
@@ -178,7 +178,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size, unsigned char dumb_mode) {
 
     shm_str = alloc_printf("%d", shm->cmplog_shm_id);
 
-    if (!dumb_mode) setenv(CMPLOG_SHM_ENV_VAR, shm_str, 1);
+    if (!dumb_mode) { setenv(CMPLOG_SHM_ENV_VAR, shm_str, 1); }
 
     ck_free(shm_str);
 
@@ -186,13 +186,17 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size, unsigned char dumb_mode) {
 
   shm->map = shmat(shm->shm_id, NULL, 0);
 
-  if (shm->map == (void *)-1 || !shm->map) PFATAL("shmat() failed");
+  if (shm->map == (void *)-1 || !shm->map) { PFATAL("shmat() failed"); }
 
   if (shm->cmplog_mode) {
 
     shm->cmp_map = shmat(shm->cmplog_shm_id, NULL, 0);
 
-    if (shm->cmp_map == (void *)-1 || !shm->cmp_map) PFATAL("shmat() failed");
+    if (shm->cmp_map == (void *)-1 || !shm->cmp_map) {
+
+      PFATAL("shmat() failed");
+
+    }
 
   }
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -120,7 +120,7 @@ static void classify_counts(afl_forkserver_t *fsrv) {
 
     while (i--) {
 
-      if (*mem) *mem = 1;
+      if (*mem) { *mem = 1; }
       mem++;
 
     }
@@ -142,7 +142,7 @@ static void classify_counts(afl_forkserver_t *fsrv) {
 
 static void at_exit_handler(void) {
 
-  if (stdin_file) unlink(stdin_file);
+  if (stdin_file) { unlink(stdin_file); }
 
 }
 
@@ -160,25 +160,28 @@ static u32 write_results_to_file(afl_forkserver_t *fsrv, u8 *outfile) {
 
     fd = open(outfile, O_WRONLY);
 
-    if (fd < 0) PFATAL("Unable to open '%s'", out_file);
+    if (fd < 0) { PFATAL("Unable to open '%s'", out_file); }
 
   } else if (!strcmp(outfile, "-")) {
 
     fd = dup(1);
-    if (fd < 0) PFATAL("Unable to open stdout");
+    if (fd < 0) { PFATAL("Unable to open stdout"); }
 
   } else {
 
     unlink(outfile);                                       /* Ignore errors */
     fd = open(outfile, O_WRONLY | O_CREAT | O_EXCL, 0600);
-    if (fd < 0) PFATAL("Unable to create '%s'", outfile);
+    if (fd < 0) { PFATAL("Unable to create '%s'", outfile); }
 
   }
 
   if (binary_mode) {
 
-    for (i = 0; i < map_size; i++)
-      if (fsrv->trace_bits[i]) ret++;
+    for (i = 0; i < map_size; i++) {
+
+      if (fsrv->trace_bits[i]) { ret++; }
+
+    }
 
     ck_write(fd, fsrv->trace_bits, map_size, outfile);
     close(fd);
@@ -187,26 +190,28 @@ static u32 write_results_to_file(afl_forkserver_t *fsrv, u8 *outfile) {
 
     FILE *f = fdopen(fd, "w");
 
-    if (!f) PFATAL("fdopen() failed");
+    if (!f) { PFATAL("fdopen() failed"); }
 
     for (i = 0; i < map_size; i++) {
 
-      if (!fsrv->trace_bits[i]) continue;
+      if (!fsrv->trace_bits[i]) { continue; }
       ret++;
 
       total += fsrv->trace_bits[i];
-      if (highest < fsrv->trace_bits[i]) highest = fsrv->trace_bits[i];
+      if (highest < fsrv->trace_bits[i]) { highest = fsrv->trace_bits[i]; }
 
       if (cmin_mode) {
 
-        if (fsrv->last_run_timed_out) break;
-        if (!caa && child_crashed != cco) break;
+        if (fsrv->last_run_timed_out) { break; }
+        if (!caa && child_crashed != cco) { break; }
 
         fprintf(f, "%u%u\n", fsrv->trace_bits[i], i);
 
-      } else
+      } else {
 
         fprintf(f, "%06u:%u\n", i, fsrv->trace_bits[i]);
+
+      }
 
     }
 
@@ -250,10 +255,13 @@ static u32 read_file(u8 *in_file) {
   struct stat st;
   s32         fd = open(in_file, O_RDONLY);
 
-  if (fd < 0) WARNF("Unable to open '%s'", in_file);
+  if (fd < 0) { WARNF("Unable to open '%s'", in_file); }
 
-  if (fstat(fd, &st) || !st.st_size)
+  if (fstat(fd, &st) || !st.st_size) {
+
     WARNF("Zero-sized input file '%s'.", in_file);
+
+  }
 
   in_len = st.st_size;
   in_data = ck_alloc_nozero(in_len);
@@ -275,13 +283,13 @@ static void showmap_run_target(afl_forkserver_t *fsrv, char **argv) {
   static struct itimerval it;
   int                     status = 0;
 
-  if (!quiet_mode) SAYF("-- Program output begins --\n" cRST);
+  if (!quiet_mode) { SAYF("-- Program output begins --\n" cRST); }
 
   MEM_BARRIER();
 
   fsrv->child_pid = fork();
 
-  if (fsrv->child_pid < 0) PFATAL("fork() failed");
+  if (fsrv->child_pid < 0) { PFATAL("fork() failed"); }
 
   if (!fsrv->child_pid) {
 
@@ -318,14 +326,19 @@ static void showmap_run_target(afl_forkserver_t *fsrv, char **argv) {
 
     }
 
-    if (!keep_cores)
+    if (!keep_cores) {
+
       r.rlim_max = r.rlim_cur = 0;
-    else
+
+    } else {
+
       r.rlim_max = r.rlim_cur = RLIM_INFINITY;
+
+    }
 
     setrlimit(RLIMIT_CORE, &r);                            /* Ignore errors */
 
-    if (!getenv("LD_BIND_LAZY")) setenv("LD_BIND_NOW", "1", 0);
+    if (!getenv("LD_BIND_LAZY")) { setenv("LD_BIND_NOW", "1", 0); }
 
     setsid();
 
@@ -348,7 +361,7 @@ static void showmap_run_target(afl_forkserver_t *fsrv, char **argv) {
 
   setitimer(ITIMER_REAL, &it, NULL);
 
-  if (waitpid(fsrv->child_pid, &status, 0) <= 0) FATAL("waitpid() failed");
+  if (waitpid(fsrv->child_pid, &status, 0) <= 0) { FATAL("waitpid() failed"); }
 
   fsrv->child_pid = 0;
   it.it_value.tv_sec = 0;
@@ -359,25 +372,38 @@ static void showmap_run_target(afl_forkserver_t *fsrv, char **argv) {
 
   /* Clean up bitmap, analyze exit condition, etc. */
 
-  if (*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG)
+  if (*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG) {
+
     FATAL("Unable to execute '%s'", argv[0]);
+
+  }
 
   classify_counts(fsrv);
 
-  if (!quiet_mode) SAYF(cRST "-- Program output ends --\n");
+  if (!quiet_mode) { SAYF(cRST "-- Program output ends --\n"); }
 
-  if (!fsrv->last_run_timed_out && !stop_soon && WIFSIGNALED(status))
+  if (!fsrv->last_run_timed_out && !stop_soon && WIFSIGNALED(status)) {
+
     child_crashed = 1;
+
+  }
 
   if (!quiet_mode) {
 
-    if (fsrv->last_run_timed_out)
+    if (fsrv->last_run_timed_out) {
+
       SAYF(cLRD "\n+++ Program timed off +++\n" cRST);
-    else if (stop_soon)
+
+    } else if (stop_soon) {
+
       SAYF(cLRD "\n+++ Program aborted by user +++\n" cRST);
-    else if (child_crashed)
+
+    } else if (child_crashed) {
+
       SAYF(cLRD "\n+++ Program killed by signal %u +++\n" cRST,
            WTERMSIG(status));
+
+    }
 
   }
 
@@ -420,19 +446,27 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
       s32 i, afl_preload_size = strlen(afl_preload);
       for (i = 0; i < afl_preload_size; ++i) {
 
-        if (afl_preload[i] == ',')
+        if (afl_preload[i] == ',') {
+
           PFATAL(
               "Comma (',') is not allowed in AFL_PRELOAD when -Q is "
               "specified!");
 
+        }
+
       }
 
-      if (qemu_preload)
+      if (qemu_preload) {
+
         buf = alloc_printf("%s,LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            qemu_preload, afl_preload, afl_preload);
-      else
+
+      } else {
+
         buf = alloc_printf("LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            afl_preload, afl_preload);
+
+      }
 
       setenv("QEMU_SET_ENV", buf, 1);
 
@@ -548,20 +582,20 @@ int main(int argc, char **argv_orig, char **envp) {
 
   doc_path = access(DOC_PATH, F_OK) ? "docs" : DOC_PATH;
 
-  if (getenv("AFL_QUIET") != NULL) be_quiet = 1;
+  if (getenv("AFL_QUIET") != NULL) { be_quiet = 1; }
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:A:eqZQUWbcrh")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:A:eqZQUWbcrh")) > 0) {
 
     switch (opt) {
 
       case 'i':
-        if (in_dir) FATAL("Multiple -i options not supported");
+        if (in_dir) { FATAL("Multiple -i options not supported"); }
         in_dir = optarg;
         break;
 
       case 'o':
 
-        if (out_file) FATAL("Multiple -o options not supported");
+        if (out_file) { FATAL("Multiple -o options not supported"); }
         out_file = optarg;
         break;
 
@@ -569,10 +603,10 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u8 suffix = 'M';
 
-        if (mem_limit_given) FATAL("Multiple -m options not supported");
+        if (mem_limit_given) { FATAL("Multiple -m options not supported"); }
         mem_limit_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -m");
+        if (!optarg) { FATAL("Wrong usage of -m"); }
 
         if (!strcmp(optarg, "none")) {
 
@@ -582,24 +616,38 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         if (sscanf(optarg, "%llu%c", &fsrv->mem_limit, &suffix) < 1 ||
-            optarg[0] == '-')
+            optarg[0] == '-') {
+
           FATAL("Bad syntax used for -m");
-
-        switch (suffix) {
-
-          case 'T': fsrv->mem_limit *= 1024 * 1024; break;
-          case 'G': fsrv->mem_limit *= 1024; break;
-          case 'k': fsrv->mem_limit /= 1024; break;
-          case 'M': break;
-
-          default: FATAL("Unsupported suffix or bad syntax for -m");
 
         }
 
-        if (fsrv->mem_limit < 5) FATAL("Dangerously low value of -m");
+        switch (suffix) {
 
-        if (sizeof(rlim_t) == 4 && fsrv->mem_limit > 2000)
+          case 'T':
+            fsrv->mem_limit *= 1024 * 1024;
+            break;
+          case 'G':
+            fsrv->mem_limit *= 1024;
+            break;
+          case 'k':
+            fsrv->mem_limit /= 1024;
+            break;
+          case 'M':
+            break;
+
+          default:
+            FATAL("Unsupported suffix or bad syntax for -m");
+
+        }
+
+        if (fsrv->mem_limit < 5) { FATAL("Dangerously low value of -m"); }
+
+        if (sizeof(rlim_t) == 4 && fsrv->mem_limit > 2000) {
+
           FATAL("Value of -m out of range on 32-bit systems");
+
+        }
 
       }
 
@@ -614,17 +662,20 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 't':
 
-        if (timeout_given) FATAL("Multiple -t options not supported");
+        if (timeout_given) { FATAL("Multiple -t options not supported"); }
         timeout_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -t");
+        if (!optarg) { FATAL("Wrong usage of -t"); }
 
         if (strcmp(optarg, "none")) {
 
           fsrv->exec_tmout = atoi(optarg);
 
-          if (fsrv->exec_tmout < 20 || optarg[0] == '-')
+          if (fsrv->exec_tmout < 20 || optarg[0] == '-') {
+
             FATAL("Dangerously low value of -t");
+
+          }
 
         }
 
@@ -632,14 +683,14 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'e':
 
-        if (edges_only) FATAL("Multiple -e options not supported");
-        if (raw_instr_output) FATAL("-e and -r are mutually exclusive");
+        if (edges_only) { FATAL("Multiple -e options not supported"); }
+        if (raw_instr_output) { FATAL("-e and -r are mutually exclusive"); }
         edges_only = 1;
         break;
 
       case 'q':
 
-        if (quiet_mode) FATAL("Multiple -q options not supported");
+        if (quiet_mode) { FATAL("Multiple -q options not supported"); }
         quiet_mode = 1;
         break;
 
@@ -659,27 +710,27 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'Q':
 
-        if (fsrv->qemu_mode) FATAL("Multiple -Q options not supported");
-        if (!mem_limit_given) fsrv->mem_limit = MEM_LIMIT_QEMU;
+        if (fsrv->qemu_mode) { FATAL("Multiple -Q options not supported"); }
+        if (!mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_QEMU; }
 
         fsrv->qemu_mode = 1;
         break;
 
       case 'U':
 
-        if (unicorn_mode) FATAL("Multiple -U options not supported");
-        if (!mem_limit_given) fsrv->mem_limit = MEM_LIMIT_UNICORN;
+        if (unicorn_mode) { FATAL("Multiple -U options not supported"); }
+        if (!mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
 
         unicorn_mode = 1;
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
 
-        if (use_wine) FATAL("Multiple -W options not supported");
+        if (use_wine) { FATAL("Multiple -W options not supported"); }
         fsrv->qemu_mode = 1;
         use_wine = 1;
 
-        if (!mem_limit_given) fsrv->mem_limit = 0;
+        if (!mem_limit_given) { fsrv->mem_limit = 0; }
 
         break;
 
@@ -693,14 +744,14 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'c':
 
-        if (keep_cores) FATAL("Multiple -c options not supported");
+        if (keep_cores) { FATAL("Multiple -c options not supported"); }
         keep_cores = 1;
         break;
 
       case 'r':
 
-        if (raw_instr_output) FATAL("Multiple -r options not supported");
-        if (edges_only) FATAL("-e and -r are mutually exclusive");
+        if (raw_instr_output) { FATAL("Multiple -r options not supported"); }
+        if (edges_only) { FATAL("-e and -r are mutually exclusive"); }
         raw_instr_output = 1;
         break;
 
@@ -709,11 +760,14 @@ int main(int argc, char **argv_orig, char **envp) {
         return -1;
         break;
 
-      default: usage(argv[0]);
+      default:
+        usage(argv[0]);
 
     }
 
-  if (optind == argc || !out_file) usage(argv[0]);
+  }
+
+  if (optind == argc || !out_file) { usage(argv[0]); }
 
   check_environment_vars(envp);
 
@@ -734,7 +788,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (in_dir) {
 
-    if (at_file) PFATAL("Options -A and -i are mutually exclusive");
+    if (at_file) { PFATAL("Options -A and -i are mutually exclusive"); }
     detect_file_args(argv + optind, "", &fsrv->use_stdin);
 
   } else {
@@ -743,21 +797,31 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
-  for (i = optind; i < argc; i++)
-    if (strcmp(argv[i], "@@") == 0) arg_offset = i;
+  for (i = optind; i < argc; i++) {
+
+    if (strcmp(argv[i], "@@") == 0) { arg_offset = i; }
+
+  }
 
   if (fsrv->qemu_mode) {
 
-    if (use_wine)
+    if (use_wine) {
+
       use_argv = get_wine_argv(argv[0], &fsrv->target_path, argc - optind,
                                argv + optind);
-    else
+
+    } else {
+
       use_argv = get_qemu_argv(argv[0], &fsrv->target_path, argc - optind,
                                argv + optind);
 
-  } else
+    }
+
+  } else {
 
     use_argv = argv + optind;
+
+  }
 
   if (in_dir) {
 
@@ -770,20 +834,30 @@ int main(int argc, char **argv_orig, char **envp) {
 #endif
 
     fsrv->dev_null_fd = open("/dev/null", O_RDWR);
-    if (fsrv->dev_null_fd < 0) PFATAL("Unable to open /dev/null");
+    if (fsrv->dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
-    if (!(dir_in = opendir(in_dir))) PFATAL("cannot open directory %s", in_dir);
+    if (!(dir_in = opendir(in_dir))) {
 
-    if (!(dir_out = opendir(out_file)))
-      if (mkdir(out_file, 0700))
+      PFATAL("cannot open directory %s", in_dir);
+
+    }
+
+    if (!(dir_out = opendir(out_file))) {
+
+      if (mkdir(out_file, 0700)) {
+
         PFATAL("cannot create output directory %s", out_file);
+
+      }
+
+    }
 
     u8 *use_dir = ".";
 
     if (access(use_dir, R_OK | W_OK | X_OK)) {
 
       use_dir = get_afl_env("TMPDIR");
-      if (!use_dir) use_dir = "/tmp";
+      if (!use_dir) { use_dir = "/tmp"; }
 
     }
 
@@ -791,7 +865,7 @@ int main(int argc, char **argv_orig, char **envp) {
     unlink(stdin_file);
     atexit(at_exit_handler);
     fsrv->out_fd = open(stdin_file, O_RDWR | O_CREAT | O_EXCL, 0600);
-    if (fsrv->out_fd < 0) PFATAL("Unable to create '%s'", out_file);
+    if (fsrv->out_fd < 0) { PFATAL("Unable to create '%s'", out_file); }
 
     if (arg_offset && argv[arg_offset] != stdin_file) {
 
@@ -804,8 +878,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
       int i = optind;
       SAYF(cMGN "[D]" cRST " %s:", fsrv->target_path);
-      while (argv[i] != NULL)
+      while (argv[i] != NULL) {
+
         SAYF(" \"%s\"", argv[i++]);
+
+      }
+
       SAYF("\n");
       SAYF(cMGN "[D]" cRST " %d - %d = %d, %s\n", arg_offset, optind,
            arg_offset - optind, infile);
@@ -817,11 +895,19 @@ int main(int argc, char **argv_orig, char **envp) {
 
     while (done == 0 && (dir_ent = readdir(dir_in))) {
 
-      if (dir_ent->d_name[0] == '.')
+      if (dir_ent->d_name[0] == '.') {
+
         continue;  // skip anything that starts with '.'
 
+      }
+
 #if defined(DT_REG)      /* Posix and Solaris do not know d_type and DT_REG */
-      if (dir_ent->d_type != DT_REG) continue;  // only regular files
+      if (dir_ent->d_type != DT_REG) {
+
+        continue;  // only regular files
+
+      }
+
 #endif
 
       snprintf(infile, sizeof(infile), "%s/%s", in_dir, dir_ent->d_name);
@@ -842,10 +928,10 @@ int main(int argc, char **argv_orig, char **envp) {
 
     }
 
-    if (!quiet_mode) OKF("Processed %llu input files.", fsrv->total_execs);
+    if (!quiet_mode) { OKF("Processed %llu input files.", fsrv->total_execs); }
 
     closedir(dir_in);
-    if (dir_out) closedir(dir_out);
+    if (dir_out) { closedir(dir_out); }
 
   } else {
 
@@ -856,7 +942,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (!quiet_mode) {
 
-    if (!tcnt) FATAL("No instrumentation detected" cRST);
+    if (!tcnt) { FATAL("No instrumentation detected" cRST); }
     OKF("Captured %u tuples (highest value %u, total values %u) in '%s'." cRST,
         tcnt, highest, total, out_file);
 
@@ -874,13 +960,13 @@ int main(int argc, char **argv_orig, char **envp) {
 
   u32 ret = child_crashed * 2 + fsrv->last_run_timed_out;
 
-  if (fsrv->target_path) ck_free(fsrv->target_path);
+  if (fsrv->target_path) { ck_free(fsrv->target_path); }
 
   afl_fsrv_deinit(fsrv);
-  if (stdin_file) ck_free(stdin_file);
+  if (stdin_file) { ck_free(stdin_file); }
 
   argv_cpy_free(argv);
-  if (fsrv->qemu_mode) free(use_argv[2]);
+  if (fsrv->qemu_mode) { free(use_argv[2]); }
 
   exit(ret);
 

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -108,7 +108,7 @@ static void apply_mask(u32 *mem, u32 *mask) {
 
   u32 i = (map_size >> 2);
 
-  if (!mask) return;
+  if (!mask) { return; }
 
   while (i--) {
 
@@ -129,7 +129,7 @@ static void classify_counts(afl_forkserver_t *fsrv) {
 
     while (i--) {
 
-      if (*mem) *mem = 1;
+      if (*mem) { *mem = 1; }
       mem++;
 
     }
@@ -154,8 +154,11 @@ static inline u8 anything_set(afl_forkserver_t *fsrv) {
   u32 *ptr = (u32 *)fsrv->trace_bits;
   u32  i = (map_size >> 2);
 
-  while (i--)
-    if (*(ptr++)) return 1;
+  while (i--) {
+
+    if (*(ptr++)) { return 1; }
+
+  }
 
   return 0;
 
@@ -174,12 +177,15 @@ static void read_initial_file(void) {
   struct stat st;
   s32         fd = open(in_file, O_RDONLY);
 
-  if (fd < 0) PFATAL("Unable to open '%s'", in_file);
+  if (fd < 0) { PFATAL("Unable to open '%s'", in_file); }
 
-  if (fstat(fd, &st) || !st.st_size) FATAL("Zero-sized input file.");
+  if (fstat(fd, &st) || !st.st_size) { FATAL("Zero-sized input file."); }
 
-  if (st.st_size >= TMIN_MAX_FILE)
+  if (st.st_size >= TMIN_MAX_FILE) {
+
     FATAL("Input file is too large (%u MB max)", TMIN_MAX_FILE / 1024 / 1024);
+
+  }
 
   in_len = st.st_size;
   in_data = ck_alloc_nozero(in_len);
@@ -202,7 +208,7 @@ static s32 write_to_file(u8 *path, u8 *mem, u32 len) {
 
   ret = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
 
-  if (ret < 0) PFATAL("Unable to create '%s'", path);
+  if (ret < 0) { PFATAL("Unable to create '%s'", path); }
 
   ck_write(ret, mem, len, path);
 
@@ -223,7 +229,7 @@ static u8 tmin_run_target(afl_forkserver_t *fsrv, char **argv, u8 *mem, u32 len,
   fsrv_run_result_t ret =
       afl_fsrv_run_target(fsrv, fsrv->exec_tmout, &stop_soon);
 
-  if (ret == FSRV_RUN_ERROR) FATAL("Couldn't run child");
+  if (ret == FSRV_RUN_ERROR) { FATAL("Couldn't run child"); }
 
   if (stop_soon) {
 
@@ -239,9 +245,14 @@ static u8 tmin_run_target(afl_forkserver_t *fsrv, char **argv, u8 *mem, u32 len,
 
     switch (ret) {
 
-      case FSRV_RUN_TMOUT: return 1;
-      case FSRV_RUN_CRASH: missed_crashes++; return 0;
-      default: missed_hangs++; return 0;
+      case FSRV_RUN_TMOUT:
+        return 1;
+      case FSRV_RUN_CRASH:
+        missed_crashes++;
+        return 0;
+      default:
+        missed_hangs++;
+        return 0;
 
     }
 
@@ -261,11 +272,11 @@ static u8 tmin_run_target(afl_forkserver_t *fsrv, char **argv, u8 *mem, u32 len,
 
   if (ret == FSRV_RUN_CRASH) {
 
-    if (first_run) crash_mode = 1;
+    if (first_run) { crash_mode = 1; }
 
     if (crash_mode) {
 
-      if (!exact_mode) return 1;
+      if (!exact_mode) { return 1; }
 
     } else {
 
@@ -287,13 +298,13 @@ static u8 tmin_run_target(afl_forkserver_t *fsrv, char **argv, u8 *mem, u32 len,
 
   }
 
-  if (ret == FSRV_RUN_NOINST) FATAL("Binary not instrumented?");
+  if (ret == FSRV_RUN_NOINST) { FATAL("Binary not instrumented?"); }
 
   u32 cksum = hash32(fsrv->trace_bits, fsrv->map_size, HASH_CONST);
 
-  if (first_run) orig_cksum = cksum;
+  if (first_run) { orig_cksum = cksum; }
 
-  if (orig_cksum == cksum) return 1;
+  if (orig_cksum == cksum) { return 1; }
 
   missed_paths++;
   return 0;
@@ -320,7 +331,7 @@ static void minimize(afl_forkserver_t *fsrv, char **argv) {
   set_len = next_pow2(in_len / TMIN_SET_STEPS);
   set_pos = 0;
 
-  if (set_len < TMIN_SET_MIN_SIZE) set_len = TMIN_SET_MIN_SIZE;
+  if (set_len < TMIN_SET_MIN_SIZE) { set_len = TMIN_SET_MIN_SIZE; }
 
   ACTF(cBRI "Stage #0: " cRST "One-time block normalization...");
 
@@ -328,8 +339,11 @@ static void minimize(afl_forkserver_t *fsrv, char **argv) {
 
     u32 use_len = MIN(set_len, in_len - set_pos);
 
-    for (i = 0; i < use_len; i++)
-      if (in_data[set_pos + i] != '0') break;
+    for (i = 0; i < use_len; i++) {
+
+      if (in_data[set_pos + i] != '0') { break; }
+
+    }
 
     if (i != use_len) {
 
@@ -374,7 +388,7 @@ next_pass:
 
 next_del_blksize:
 
-  if (!del_len) del_len = 1;
+  if (!del_len) { del_len = 1; }
   del_pos = 0;
   prev_del = 1;
 
@@ -387,7 +401,7 @@ next_del_blksize:
     s32 tail_len;
 
     tail_len = in_len - del_pos - del_len;
-    if (tail_len < 0) tail_len = 0;
+    if (tail_len < 0) { tail_len = 0; }
 
     /* If we have processed at least one full block (initially, prev_del == 1),
        and we did so without deleting the previous one, and we aren't at the
@@ -420,9 +434,11 @@ next_del_blksize:
 
       changed_any = 1;
 
-    } else
+    } else {
 
       del_pos += del_len;
+
+    }
 
   }
 
@@ -435,11 +451,14 @@ next_del_blksize:
 
   OKF("Block removal complete, %u bytes deleted.", stage_o_len - in_len);
 
-  if (!in_len && changed_any)
+  if (!in_len && changed_any) {
+
     WARNF(cLRD
           "Down to zero bytes - check the command line and mem limit!" cRST);
 
-  if (cur_pass > 1 && !changed_any) goto finalize_all;
+  }
+
+  if (cur_pass > 1 && !changed_any) { goto finalize_all; }
 
   /*************************
    * ALPHABET MINIMIZATION *
@@ -453,7 +472,7 @@ next_del_blksize:
 
   for (i = 0; i < in_len; i++) {
 
-    if (!alpha_map[in_data[i]]) alpha_size++;
+    if (!alpha_map[in_data[i]]) { alpha_size++; }
     alpha_map[in_data[i]]++;
 
   }
@@ -466,12 +485,15 @@ next_del_blksize:
     u32 r;
     u8  res;
 
-    if (i == '0' || !alpha_map[i]) continue;
+    if (i == '0' || !alpha_map[i]) { continue; }
 
     memcpy(tmp_buf, in_data, in_len);
 
-    for (r = 0; r < in_len; r++)
-      if (tmp_buf[r] == i) tmp_buf[r] = '0';
+    for (r = 0; r < in_len; r++) {
+
+      if (tmp_buf[r] == i) { tmp_buf[r] = '0'; }
+
+    }
 
     res = tmin_run_target(fsrv, argv, tmp_buf, in_len, 0);
 
@@ -506,7 +528,7 @@ next_del_blksize:
 
     u8 res, orig = tmp_buf[i];
 
-    if (orig == '0') continue;
+    if (orig == '0') { continue; }
     tmp_buf[i] = '0';
 
     res = tmin_run_target(fsrv, argv, tmp_buf, in_len, 0);
@@ -517,9 +539,11 @@ next_del_blksize:
       alpha_del2++;
       changed_any = 1;
 
-    } else
+    } else {
 
       tmp_buf[i] = orig;
+
+    }
 
   }
 
@@ -528,11 +552,11 @@ next_del_blksize:
   OKF("Character minimization done, %u byte%s replaced.", alpha_del2,
       alpha_del2 == 1 ? "" : "s");
 
-  if (changed_any) goto next_pass;
+  if (changed_any) { goto next_pass; }
 
 finalize_all:
 
-  if (tmp_buf) ck_free(tmp_buf);
+  if (tmp_buf) { ck_free(tmp_buf); }
 
   if (hang_mode) {
 
@@ -558,8 +582,11 @@ finalize_all:
        missed_hangs ? cLRD : "", missed_hangs);
 
   if (fsrv->total_execs > 50 && missed_hangs * 10 > fsrv->total_execs &&
-      !hang_mode)
+      !hang_mode) {
+
     WARNF(cLRD "Frequent timeouts - results may be skewed." cRST);
+
+  }
 
 }
 
@@ -579,7 +606,7 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
   u8 *x;
 
   fsrv->dev_null_fd = open("/dev/null", O_RDWR);
-  if (fsrv->dev_null_fd < 0) PFATAL("Unable to open /dev/null");
+  if (fsrv->dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
   if (!out_file) {
 
@@ -588,7 +615,7 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
     if (access(use_dir, R_OK | W_OK | X_OK)) {
 
       use_dir = get_afl_env("TMPDIR");
-      if (!use_dir) use_dir = "/tmp";
+      if (!use_dir) { use_dir = "/tmp"; }
 
     }
 
@@ -600,7 +627,7 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
 
   fsrv->out_fd = open(out_file, O_RDWR | O_CREAT | O_EXCL, 0600);
 
-  if (fsrv->out_fd < 0) PFATAL("Unable to create '%s'", out_file);
+  if (fsrv->out_fd < 0) { PFATAL("Unable to create '%s'", out_file); }
 
   /* Set sane defaults... */
 
@@ -608,11 +635,17 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
 
   if (x) {
 
-    if (!strstr(x, "abort_on_error=1"))
+    if (!strstr(x, "abort_on_error=1")) {
+
       FATAL("Custom ASAN_OPTIONS set without abort_on_error=1 - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom ASAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -620,12 +653,18 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
 
   if (x) {
 
-    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR)))
+    if (!strstr(x, "exit_code=" STRINGIFY(MSAN_ERROR))) {
+
       FATAL("Custom MSAN_OPTIONS set without exit_code=" STRINGIFY(
           MSAN_ERROR) " - please fix!");
 
-    if (!strstr(x, "symbolize=0"))
+    }
+
+    if (!strstr(x, "symbolize=0")) {
+
       FATAL("Custom MSAN_OPTIONS set without symbolize=0 - please fix!");
+
+    }
 
   }
 
@@ -653,19 +692,27 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
       s32 i, afl_preload_size = strlen(afl_preload);
       for (i = 0; i < afl_preload_size; ++i) {
 
-        if (afl_preload[i] == ',')
+        if (afl_preload[i] == ',') {
+
           PFATAL(
               "Comma (',') is not allowed in AFL_PRELOAD when -Q is "
               "specified!");
 
+        }
+
       }
 
-      if (qemu_preload)
+      if (qemu_preload) {
+
         buf = alloc_printf("%s,LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            qemu_preload, afl_preload, afl_preload);
-      else
+
+      } else {
+
         buf = alloc_printf("LD_PRELOAD=%s,DYLD_INSERT_LIBRARIES=%s",
                            afl_preload, afl_preload);
+
+      }
 
       setenv("QEMU_SET_ENV", buf, 1);
 
@@ -772,40 +819,44 @@ int main(int argc, char **argv_orig, char **envp) {
 
   SAYF(cCYA "afl-tmin" VERSION cRST " by Michal Zalewski\n");
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:B:xeQUWHh")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:B:xeQUWHh")) > 0) {
 
     switch (opt) {
 
       case 'i':
 
-        if (in_file) FATAL("Multiple -i options not supported");
+        if (in_file) { FATAL("Multiple -i options not supported"); }
         in_file = optarg;
         break;
 
       case 'o':
 
-        if (output_file) FATAL("Multiple -o options not supported");
+        if (output_file) { FATAL("Multiple -o options not supported"); }
         output_file = optarg;
         break;
 
       case 'f':
 
-        if (out_file) FATAL("Multiple -f options not supported");
+        if (out_file) { FATAL("Multiple -f options not supported"); }
         fsrv->use_stdin = 0;
         out_file = optarg;
         break;
 
       case 'e':
 
-        if (edges_only) FATAL("Multiple -e options not supported");
-        if (hang_mode)
+        if (edges_only) { FATAL("Multiple -e options not supported"); }
+        if (hang_mode) {
+
           FATAL("Edges only and hang mode are mutually exclusive.");
+
+        }
+
         edges_only = 1;
         break;
 
       case 'x':
 
-        if (exit_crash) FATAL("Multiple -x options not supported");
+        if (exit_crash) { FATAL("Multiple -x options not supported"); }
         exit_crash = 1;
         break;
 
@@ -813,10 +864,10 @@ int main(int argc, char **argv_orig, char **envp) {
 
         u8 suffix = 'M';
 
-        if (mem_limit_given) FATAL("Multiple -m options not supported");
+        if (mem_limit_given) { FATAL("Multiple -m options not supported"); }
         mem_limit_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -m");
+        if (!optarg) { FATAL("Wrong usage of -m"); }
 
         if (!strcmp(optarg, "none")) {
 
@@ -826,24 +877,38 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         if (sscanf(optarg, "%llu%c", &fsrv->mem_limit, &suffix) < 1 ||
-            optarg[0] == '-')
+            optarg[0] == '-') {
+
           FATAL("Bad syntax used for -m");
-
-        switch (suffix) {
-
-          case 'T': fsrv->mem_limit *= 1024 * 1024; break;
-          case 'G': fsrv->mem_limit *= 1024; break;
-          case 'k': fsrv->mem_limit /= 1024; break;
-          case 'M': break;
-
-          default: FATAL("Unsupported suffix or bad syntax for -m");
 
         }
 
-        if (fsrv->mem_limit < 5) FATAL("Dangerously low value of -m");
+        switch (suffix) {
 
-        if (sizeof(rlim_t) == 4 && fsrv->mem_limit > 2000)
+          case 'T':
+            fsrv->mem_limit *= 1024 * 1024;
+            break;
+          case 'G':
+            fsrv->mem_limit *= 1024;
+            break;
+          case 'k':
+            fsrv->mem_limit /= 1024;
+            break;
+          case 'M':
+            break;
+
+          default:
+            FATAL("Unsupported suffix or bad syntax for -m");
+
+        }
+
+        if (fsrv->mem_limit < 5) { FATAL("Dangerously low value of -m"); }
+
+        if (sizeof(rlim_t) == 4 && fsrv->mem_limit > 2000) {
+
           FATAL("Value of -m out of range on 32-bit systems");
+
+        }
 
       }
 
@@ -851,41 +916,44 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 't':
 
-        if (timeout_given) FATAL("Multiple -t options not supported");
+        if (timeout_given) { FATAL("Multiple -t options not supported"); }
         timeout_given = 1;
 
-        if (!optarg) FATAL("Wrong usage of -t");
+        if (!optarg) { FATAL("Wrong usage of -t"); }
 
         fsrv->exec_tmout = atoi(optarg);
 
-        if (fsrv->exec_tmout < 10 || optarg[0] == '-')
+        if (fsrv->exec_tmout < 10 || optarg[0] == '-') {
+
           FATAL("Dangerously low value of -t");
+
+        }
 
         break;
 
       case 'Q':
 
-        if (fsrv->qemu_mode) FATAL("Multiple -Q options not supported");
-        if (!mem_limit_given) fsrv->mem_limit = MEM_LIMIT_QEMU;
+        if (fsrv->qemu_mode) { FATAL("Multiple -Q options not supported"); }
+        if (!mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_QEMU; }
 
         fsrv->qemu_mode = 1;
         break;
 
       case 'U':
 
-        if (unicorn_mode) FATAL("Multiple -Q options not supported");
-        if (!mem_limit_given) fsrv->mem_limit = MEM_LIMIT_UNICORN;
+        if (unicorn_mode) { FATAL("Multiple -Q options not supported"); }
+        if (!mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
 
         unicorn_mode = 1;
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
 
-        if (use_wine) FATAL("Multiple -W options not supported");
+        if (use_wine) { FATAL("Multiple -W options not supported"); }
         fsrv->qemu_mode = 1;
         use_wine = 1;
 
-        if (!mem_limit_given) fsrv->mem_limit = 0;
+        if (!mem_limit_given) { fsrv->mem_limit = 0; }
 
         break;
 
@@ -893,9 +961,13 @@ int main(int argc, char **argv_orig, char **envp) {
 
         /* Minimizes a testcase to the minimum that still times out */
 
-        if (hang_mode) FATAL("Multipe -H options not supported");
-        if (edges_only)
+        if (hang_mode) { FATAL("Multipe -H options not supported"); }
+        if (edges_only) {
+
           FATAL("Edges only and hang mode are mutually exclusive.");
+
+        }
+
         hang_mode = 1;
         break;
 
@@ -914,7 +986,7 @@ int main(int argc, char **argv_orig, char **envp) {
            The option may be extended and made more official if it proves
            to be useful. */
 
-        if (mask_bitmap) FATAL("Multiple -B options not supported");
+        if (mask_bitmap) { FATAL("Multiple -B options not supported"); }
         mask_bitmap = ck_alloc(map_size);
         read_bitmap(optarg, mask_bitmap, map_size);
         break;
@@ -924,11 +996,14 @@ int main(int argc, char **argv_orig, char **envp) {
         return -1;
         break;
 
-      default: usage(argv[0]);
+      default:
+        usage(argv[0]);
 
     }
 
-  if (optind == argc || !in_file || !output_file) usage(argv[0]);
+  }
+
+  if (optind == argc || !in_file || !output_file) { usage(argv[0]); }
 
   check_environment_vars(envp);
 
@@ -945,16 +1020,23 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (fsrv->qemu_mode) {
 
-    if (use_wine)
+    if (use_wine) {
+
       use_argv = get_wine_argv(argv[0], &fsrv->target_path, argc - optind,
                                argv + optind);
-    else
+
+    } else {
+
       use_argv = get_qemu_argv(argv[0], &fsrv->target_path, argc - optind,
                                argv + optind);
 
-  } else
+    }
+
+  } else {
 
     use_argv = argv + optind;
+
+  }
 
   exact_mode = !!get_afl_env("AFL_TMIN_EXACT");
 
@@ -977,16 +1059,22 @@ int main(int argc, char **argv_orig, char **envp) {
 
   tmin_run_target(fsrv, use_argv, in_data, in_len, 1);
 
-  if (hang_mode && !fsrv->last_run_timed_out)
+  if (hang_mode && !fsrv->last_run_timed_out) {
+
     FATAL(
         "Target binary did not time out but hang minimization mode "
         "(-H) was set (-t %u).",
         fsrv->exec_tmout);
 
-  if (fsrv->last_run_timed_out && !hang_mode)
+  }
+
+  if (fsrv->last_run_timed_out && !hang_mode) {
+
     FATAL(
         "Target binary times out (adjusting -t may help). Use -H to minimize a "
         "hang.");
+
+  }
 
   if (hang_mode) {
 
@@ -997,7 +1085,7 @@ int main(int argc, char **argv_orig, char **envp) {
     OKF("Program terminates normally, minimizing in " cCYA "instrumented" cRST
         " mode.");
 
-    if (!anything_set(fsrv)) FATAL("No instrumentation detected.");
+    if (!anything_set(fsrv)) { FATAL("No instrumentation detected."); }
 
   } else {
 
@@ -1012,7 +1100,7 @@ int main(int argc, char **argv_orig, char **envp) {
   ACTF("Writing output to '%s'...", output_file);
 
   unlink(out_file);
-  if (out_file) ck_free(out_file);
+  if (out_file) { ck_free(out_file); }
   out_file = NULL;
 
   close(write_to_file(output_file, in_data, in_len));
@@ -1021,9 +1109,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
   afl_shm_deinit(&shm);
   afl_fsrv_deinit(fsrv);
-  if (fsrv->target_path) ck_free(fsrv->target_path);
-  if (mask_bitmap) ck_free(mask_bitmap);
-  if (in_data) ck_free(in_data);
+  if (fsrv->target_path) { ck_free(fsrv->target_path); }
+  if (mask_bitmap) { ck_free(mask_bitmap); }
+  if (in_data) { ck_free(in_data); }
 
   argv_cpy_free(argv);
 


### PR DESCRIPTION
This PR adds, what clang-tidy calls `readability braces`.
Basically it changes
```c
if (test == 1)

    do_fun();

else 

  something_else();

or_not();
```
to 
```c
if (test == 1) {

  do_fun();

} else { 

  something_else();

}

or_not();
```
(and 
`if(var) ck_free(var);` to `if(var) { ck_free(var); }`)

Of course, code style is highly personal and everybody has their own opinion, hence this PR.
I am greatly in favor of brackets, I feel like they do make it easier to understand what's going on.
Not having them can lead to hard-to-find bugs.
See Apple's `goto fail;` bug as example:
https://dwheeler.com/essays/apple-goto-fail.html