### PR TITLE
afl-gcc and afl-clang: fail when binary name can't be used to determine build mode

### DIFF
--- a/gcc_plugin/afl-gcc-fast.c
+++ b/gcc_plugin/afl-gcc-fast.c
@@ -123,10 +123,16 @@ static void edit_params(u32 argc, char **argv) {
     u8 *alt_cxx = getenv("AFL_CXX");
     cc_params[0] = alt_cxx && *alt_cxx ? alt_cxx : (u8 *)AFL_GCC_CXX;
 
-  } else {
+  } else if (!strcmp(name, "afl-gcc-fast")) {
 
     u8 *alt_cc = getenv("AFL_CC");
     cc_params[0] = alt_cc && *alt_cc ? alt_cc : (u8 *)AFL_GCC_CC;
+
+  } else {
+
+    fprintf(stderr, "Name of the binary: %s\n", argv[0]);
+    FATAL(
+        "Name of the binary is not a known name, expected afl-(gcc|g++)-fast");
 
   }
 

--- a/src/afl-gcc.c
+++ b/src/afl-gcc.c
@@ -149,10 +149,16 @@ static void edit_params(u32 argc, char **argv) {
       u8 *alt_cxx = getenv("AFL_CXX");
       cc_params[0] = alt_cxx && *alt_cxx ? alt_cxx : (u8 *)"clang++";
 
-    } else {
+    } else if (!strcmp(name, "afl-clang")) {
 
       u8 *alt_cc = getenv("AFL_CC");
       cc_params[0] = alt_cc && *alt_cc ? alt_cc : (u8 *)"clang";
+
+    } else {
+
+      fprintf(stderr, "Name of the binary: %s\n", argv[0]);
+      FATAL(
+        "Name of the binary is not a known name, expected afl-clang(++)");
 
     }
 
@@ -166,12 +172,17 @@ static void edit_params(u32 argc, char **argv) {
 
 #ifdef __APPLE__
 
-    if (!strcmp(name, "afl-g++"))
+    if (!strcmp(name, "afl-g++")) {
       cc_params[0] = getenv("AFL_CXX");
-    else if (!strcmp(name, "afl-gcj"))
+    } else if (!strcmp(name, "afl-gcj")) {
       cc_params[0] = getenv("AFL_GCJ");
-    else
+    } else if (!strcmp(name, "afl-gcc")) {
       cc_params[0] = getenv("AFL_CC");
+    } else {
+      fprintf(stderr, "Name of the binary: %s\n", argv[0]);
+      FATAL(
+        "Name of the binary is not a known name, expected afl-gcc/g++/gcj");
+    }
 
     if (!cc_params[0]) {
 
@@ -199,10 +210,16 @@ static void edit_params(u32 argc, char **argv) {
       u8 *alt_cc = getenv("AFL_GCJ");
       cc_params[0] = alt_cc && *alt_cc ? alt_cc : (u8 *)"gcj";
 
-    } else {
+    } else if (!strcmp(name, "afl-gcc")) {
 
       u8 *alt_cc = getenv("AFL_CC");
       cc_params[0] = alt_cc && *alt_cc ? alt_cc : (u8 *)"gcc";
+
+    } else {
+
+      fprintf(stderr, "Name of the binary: %s\n", argv[0]);
+      FATAL(
+        "Name of the binary is not a known name, expected afl-gcc/g++/gcj");
 
     }
 


### PR DESCRIPTION
This is a continuation of PR #318.
The goal is to prevent issues where binaries with the wrong name will
silently pass control to the C compiler instead of failing.
This makes it more explicit that aflplusplus relies on the name of the
binary for correct compiler execution.