### PR TITLE
Integer-Swapping Havoc Mutator

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -107,6 +107,15 @@ typedef int64_t s64;
                                                                                \
   })
 
+  #define SWAPQ(_x, _y) \
+  (                     \
+      {                 \
+          u64 _t = _x;  \
+          _x     = _y;  \
+          _y     = _t;  \
+      }                 \
+  ) 
+
 #ifdef AFL_LLVM_PASS
 #if defined(__linux__)
 #define AFL_SR(s) (srandom(s))

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -1750,7 +1750,7 @@ havoc_stage:
       }
 
       switch (rand_below(
-          afl, 15 + ((afl->extras_cnt + afl->a_extras_cnt) ? 2 : 0))) {
+          afl, 16 + ((afl->extras_cnt + afl->a_extras_cnt) ? 2 : 0))) {
 
         case 0:
 
@@ -2034,11 +2034,22 @@ havoc_stage:
           break;
 
         }
+            
+        case 15 : {
+          /* Swap QWORDS */
+          if(temp_len <= 8) break;
+
+          u32 offset_1 = rand_below(afl, temp_len-8);
+          u32 offset_2 = rand_below(afl, temp_len-8);
+
+          SWAPQ((*(u64 *)(out_buf + offset_1)), (*(u64 *)(out_buf + offset_2)));     
+          break;
+        }
 
           /* Values 15 and 16 can be selected only if there are any extras
              present in the dictionaries. */
 
-        case 15: {
+        case 16: {
 
           /* Overwrite bytes with an extra. */
 
@@ -2076,7 +2087,7 @@ havoc_stage:
 
         }
 
-        case 16: {
+        case 17: {
 
           u32 use_extra, extra_len, insert_at = rand_below(afl, temp_len + 1);
           u8 *new_buf;


### PR DESCRIPTION
Some changes were made in src/afl-fuzz-one.c and types.h . A primary report on fuzzer  performance, before and after patching is given below.

| Details   |                                                    |
|-------------|-------------------------------------------|
| OS          | Ubuntu Bionic |
| System   | Google Compute N1 custom (10 vCPUs, 9 GB memory) [ Free Tier ] |
| Test Lib   |   Binutils-2.30 |


The binaries were compiled using afl-clang-fast.

The command line argument used is ::
`` $ afl-fuzz -i afl_in -o afl_o_# -d -V 43200 # $ @@ ``

Each binutil was fuzzed only once using patched and unpatched afl-fuzz-one.c .
* where # stands for the following binutils used
* where $ stands for the arguments used along with them


|    #    |    $    |
|---------|---------|
| readelf |   -a    |
| strings |         |
| nm      |   -C    |
| objdump |   -d    |
| size    |         |


The coverage data was collected using afl-cov. 


|    binutil    |  patched?  |  lines  |  functions  |
|---------------|------------|---------|-------------|
|    readelf    |     No     |   6.7%  |    4.7%     |
|    strings    |     No     |   2.1%  |    2.6%     |
|    nm         |     No     |   3.4%  |    3.8%     |
|    objdump    |     No     |   5.4%  |    5.0%     |
|    size       |     No     |   0.1%  |    0.1%     |
|    readelf    |    Yes     |   6.7%  |    4.7%     |
|    strings    |    Yes     |   7.5%  |   11.6%     |
|    nm         |    Yes     |  12.3%  |   15.1%     |
|    objdump    |    Yes     |   7.3%  |    7.7%     |
|    size       |    Yes     |   4.9%  |    4.8%     |


In case of readelf, the patched version has slightly more code coverage 
   *  Unpatched -> 9466/142239 lines, 253/5350 functions
   *  Patched   -> 9501/142239 lines, 253/5350 functions

In the above cases, patched afl-fuzz-one.c resulted in improved code coverage. 

I'll run the fuzzers again to confirm the observation. For the testcases and the output, I can mail them to any member. There are some crash reports in them.