### PR TITLE
Fix Unicorn support build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ qemu_mode/libcompcov/compcovtest
 as
 ld
 qemu_mode/qemu-*
-unicorn_mode/samples/*/\.test-*
+unicorn_mode/samples/*/test-*
 unicorn_mode/samples/*/output/
 core\.*
 test/unittests/unit_maybe_alloc

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ qemu_mode/libcompcov/compcovtest
 as
 ld
 qemu_mode/qemu-*
-unicorn_mode/samples/*/test-*
+unicorn_mode/samples/*/\.test-*
 unicorn_mode/samples/*/output/
 core\.*
 test/unittests/unit_maybe_alloc

--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -209,9 +209,9 @@ cd ../samples/simple || exit 1
 
 # Run afl-showmap on the sample application. If anything comes out then it must have worked!
 unset AFL_INST_RATIO
-echo 0 | ../../../afl-showmap -U -m none -t 2000 -q -o .test-instr0 -- $PYTHONBIN simple_test_harness.py ./sample_inputs/sample1.bin || exit 1
+echo 0 | ../../../afl-showmap -U -m none -t 2000 -q -o ./test-instr0 -- $PYTHONBIN ./simple_test_harness.py ./sample_inputs/sample1.bin || exit 1
 
-if [ -s .test-instr0 ]
+if [ -s ./test-instr0 ]
 then
 
   echo "[+] Instrumentation tests passed. "

--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -209,9 +209,9 @@ cd ../samples/simple || exit 1
 
 # Run afl-showmap on the sample application. If anything comes out then it must have worked!
 unset AFL_INST_RATIO
-echo 0 | ../../../afl-showmap -U -m none -t 2000 -q -o ./test-instr0 -- $PYTHONBIN ./simple_test_harness.py ./sample_inputs/sample1.bin || exit 1
+echo 0 | ../../../afl-showmap -U -m none -t 2000 -q -o ./.test-instr0 -- $PYTHONBIN ./simple_test_harness.py ./sample_inputs/sample1.bin || exit 1
 
-if [ -s ./test-instr0 ]
+if [ -s ./.test-instr0 ]
 then
 
   echo "[+] Instrumentation tests passed. "
@@ -227,6 +227,6 @@ else
 
 fi
 
-rm -f .test-instr0
+rm -f ./.test-instr0
 
 exit $RETVAL


### PR DESCRIPTION
Hi, I recently tried to build Unicorn mode support for AFL++ from my WSL distribution (Ubuntu-18.04). Unfortunately, the Unicorn build script repeatedly failed because it couldn't generate the test harness, but after applying the suggested changes it managed to compile and run successfully. Hope that helps 😅 