### PR TITLE
add flex to apt install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ afl++ has many build options.
 The easiest is to build and install everything:
 
 ```shell
-$ sudo apt install build-essential libtool-bin python3 automake bison libglib2.0-dev libpixman-1-dev clang python-setuptools llvm
+$ sudo apt install build-essential libtool-bin python3 automake flex bison libglib2.0-dev libpixman-1-dev clang python-setuptools llvm
 $ make distrib
 $ sudo make install
 ```


### PR DESCRIPTION
Building `make distrib` on a clean Ubuntu install, after installing dependencies `sudo apt install build-essential libtool-bin python3 automake bison libglib2.0-dev libpixman-1-dev clang python-setuptools llvm`, yielded the following error during build:
```
cd qemu_mode && sh ./build_qemu_support.sh
=================================================
AFL binary-only instrumentation QEMU build script
=================================================

[*] Performing basic sanity checks...
[-] Error: 'flex' not found, please install first.
GNUmakefile:467: recipe for target 'distrib' failed
make: *** [distrib] Error 1
```

`sudo apt install flex` resolved this build issue. Therefore, this PR adds flex to the build instructions.