### PR TITLE
llvm_mode compare-transform-pass: add handling of sized comparisons with non-const size

### DIFF
--- a/test/test-compcov.c
+++ b/test/test-compcov.c
@@ -20,9 +20,19 @@ int main(int argc, char **argv) {
   }
 
   if (strcmp(input, "LIBTOKENCAP") == 0)
-    printf("your string was libtokencap\n");
+    printf("your string was LIBTOKENCAP\n");
   else if (strcmp(input, "BUGMENOT") == 0)
-    printf("your string was bugmenot\n");
+    printf("your string was BUGMENOT\n");
+  else if (strncmp(input, "BANANA", 3) == 0)
+    printf("your string started with BAN\n");
+  else if (strcmp(input, "APRI\0COT") == 0)
+    printf("your string was APRI\n");
+  else if (strcasecmp(input, "Kiwi") == 0)
+    printf("your string was Kiwi\n");
+  else if (strncasecmp(input, "avocado", 9) == 0)
+    printf("your string was avocado\n");
+  else if (strncasecmp(input, "Grapes", argc > 2 ? atoi(argv[2]) : 3) == 0)
+    printf("your string was a prefix of Grapes\n");
   else if (strcmp(input, "BUFFEROVERFLOW") == 0) {
 
     buf = (char *)malloc(16);

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,6 +22,20 @@ else
   GREPAOPTION=
 fi
 
+test_compcov_binary_functionality() {
+  RUN="../afl-showmap -o /dev/null -- $1"
+  $RUN 'LIBTOKENCAP' | grep 'your string was LIBTOKENCAP' \
+    && $RUN 'BUGMENOT' | grep 'your string was BUGMENOT' \
+    && $RUN 'BANANA' | grep 'your string started with BAN' \
+    && $RUN 'APRI' | grep 'your string was APRI' \
+    && $RUN 'kiWI' | grep 'your string was Kiwi' \
+    && $RUN 'Avocado' | grep 'your string was avocado' \
+    && $RUN 'GRAX' 3 | grep 'your string was a prefix of Grapes' \
+    && $RUN 'LOCALVARIABLE' | grep 'local var memcmp works!' \
+    && $RUN 'abc' | grep 'short local var memcmp works!' \
+    && $RUN 'GLOBALVARIABLE' | grep 'global var memcmp works!'
+} > /dev/null
+
 ECHO="printf %b\\n"
 $ECHO \\101 2>&1 | grep -qE '^A' || {
   ECHO=
@@ -259,7 +273,7 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
     $ECHO "$RED[!] llvm_mode failed"
     CODE=1
   }
-  test -e test-compcov.harden && {
+  test -e test-compcov.harden && test_compcov_binary_functionality ./test-compcov.harden && {
     grep -Eq$GREPAOPTION 'stack_chk_fail|fstack-protector-all|fortified' test-compcov.harden > /dev/null 2>&1 && {
       $ECHO "$GREEN[+] llvm_mode hardened mode succeeded and is working"
     } || {
@@ -360,8 +374,8 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
   }
   AFL_LLVM_INSTRUMENT=AFL
   AFL_DEBUG=1 AFL_LLVM_LAF_SPLIT_SWITCHES=1 AFL_LLVM_LAF_TRANSFORM_COMPARES=1 AFL_LLVM_LAF_SPLIT_COMPARES=1 ../afl-clang-fast -o test-compcov.compcov test-compcov.c > test.out 2>&1
-  test -e test-compcov.compcov && {
-    grep --binary-files=text -Eq " [ 12][0-9][0-9] location| [3-9][0-9] location" test.out && {
+  test -e test-compcov.compcov && test_compcov_binary_functionality ./test-compcov.compcov && {
+    grep --binary-files=text -Eq " [ 123][0-9][0-9] location| [3-9][0-9] location" test.out && {
       $ECHO "$GREEN[+] llvm_mode laf-intel/compcov feature works correctly"
     } || {
       $ECHO "$RED[!] llvm_mode laf-intel/compcov feature failed"
@@ -374,7 +388,7 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
   rm -f test-compcov.compcov test.out
   echo foobar.c > whitelist.txt
   AFL_DEBUG=1 AFL_LLVM_WHITELIST=whitelist.txt ../afl-clang-fast -o test-compcov test-compcov.c > test.out 2>&1
-  test -e test-compcov && {
+  test -e test-compcov && test_compcov_binary_functionality ./test-compcov && {
     grep -q "No instrumentation targets found" test.out && {
       $ECHO "$GREEN[+] llvm_mode whitelist feature works correctly"
     } || {
@@ -513,7 +527,7 @@ test -e ../afl-gcc-fast -a -e ../afl-gcc-rt.o && {
     CODE=1
   }
 
-  test -e test-compcov.harden.gccpi && {
+  test -e test-compcov.harden.gccpi && test_compcov_binary_functionality ./test-compcov.harden.gccpi && {
     grep -Eq$GREPAOPTION 'stack_chk_fail|fstack-protector-all|fortified' test-compcov.harden.gccpi > /dev/null 2>&1 && {
       $ECHO "$GREEN[+] gcc_plugin hardened mode succeeded and is working"
     } || {
@@ -558,7 +572,7 @@ test -e ../afl-gcc-fast -a -e ../afl-gcc-rt.o && {
   # now for the special gcc_plugin things
   echo foobar.c > whitelist.txt
   AFL_GCC_WHITELIST=whitelist.txt ../afl-gcc-fast -o test-compcov test-compcov.c > /dev/null 2>&1
-  test -e test-compcov && {
+  test -e test-compcov && test_compcov_binary_functionality ./test-compcov && {
     echo 1 | ../afl-showmap -m ${MEM_LIMIT} -o - -r -- ./test-compcov 2>&1 | grep -q "Captured 1 tuples" && {
       $ECHO "$GREEN[+] gcc_plugin whitelist feature works correctly"
     } || {


### PR DESCRIPTION
Don't know if this is of any use to you, but I've been using this modification with some success.

Some targets use sized comparisons with non-const `n` values (in cases I've seen this is usually the length of the variable-string's buffer). These can be handled by insertion of a "length check" bb for each unrolled character, branching to the phi node with a zero return value if the n argument equals each character's position index.

To make this easier to tackle I did a bit of refactoring of the length determination and renaming of variables.

And to give myself more confidence that I'm not breaking any of this existing logic I added some extra cases to `test-compcov.c` and extra steps to `test.sh` that actually test the correctness of the resulting binary's behaviour, also adding calls to these checks in other places the file is compiled to what should be a functioning binary. Excuse my horrible bash.

Oh, and I also added handling of a corner case where the const string has embedded null characters. In such a case, the `str*` functions should end comparison after the first-encountered null, not continue comparing to the end of the const.