### PR TITLE
OpenBSD build update and llvm mode fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -100,7 +100,7 @@ ifeq "$(shell uname -s)" "DragonFly"
 endif
 
 ifeq "$(shell uname -s)" "OpenBSD"
-  override CFLAGS  += -I /usr/local/include/
+  override CFLAGS  += -I /usr/local/include/ -mno-retpoline
   LDFLAGS += -Wl,-z,notext -L /usr/local/lib/
 endif
 

--- a/llvm_mode/GNUmakefile
+++ b/llvm_mode/GNUmakefile
@@ -226,6 +226,10 @@ endif
 
 ifeq "$(shell uname)" "OpenBSD"
   CLANG_LFL += `$(LLVM_CONFIG) --libdir`/libLLVM.so
+  CLANG_CFL += -mno-retpoline
+  CFLAGS += -mno-retpoline
+  # Needed for unwind symbols
+  LDFLAGS += -lc++abi
 endif
 
 ifeq "$(shell echo '$(HASH)include <sys/ipc.h>@$(HASH)include <sys/shm.h>@int main() { int _id = shmget(IPC_PRIVATE, 65536, IPC_CREAT | IPC_EXCL | 0600); shmctl(_id, IPC_RMID, 0); return 0;}' | tr @ '\n' | $(CC) -x c - -o .test2 2>/dev/null && echo 1 || echo 0 ; rm -f .test2 )" "1"


### PR DESCRIPTION
Unlike upstream version, LLVM in OpenBSD enable by default anti ROP gadget
 leading to bigger binaries and lower performances.
On OpenBSD, it needs to link to c++ abi for th unwind symbols.