### PR TITLE
Fixed missing cast in afl-clang-fast.c, which results in a compilation error when using __AFL_FUZZ_TESTCASE_BUF in a C++ target

### DIFF
--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -500,7 +500,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
       "unsigned char *__afl_fuzz_alt_ptr;";
   cc_params[cc_par_cnt++] =
       "-D__AFL_FUZZ_TESTCASE_BUF=(__afl_fuzz_ptr ? __afl_fuzz_ptr : "
-      "(__afl_fuzz_alt_ptr = malloc(1 * 1024 * 1024)))";
+      "(__afl_fuzz_alt_ptr = (unsigned char *) malloc(1 * 1024 * 1024)))";
   cc_params[cc_par_cnt++] =
       "-D__AFL_FUZZ_TESTCASE_LEN=(__afl_fuzz_ptr ? *__afl_fuzz_len : read(0, "
       "__afl_fuzz_alt_ptr, 1 * 1024 * 1024))";


### PR DESCRIPTION
When compiling the following minimal C++ fuzzing target test.cpp for LLVM's Persistent Mode
```
#include <stdlib.h>

__AFL_FUZZ_INIT();

int main(int argc, char **argv) {
    unsigned char *buffer = __AFL_FUZZ_TESTCASE_BUF;
}
```
with afl-clang-fast++, the compilation will fail with this error:
```
afl-clang-fast++2.65d by <lszekeres@google.com> in PCGUARD mode
test.cpp:6:29: error: assigning to 'unsigned char *' from incompatible type 'void *'
    unsigned char *buffer = __AFL_FUZZ_TESTCASE_BUF;
                            ^~~~~~~~~~~~~~~~~~~~~~~
<command line>:5:90: note: expanded from here
#define __AFL_FUZZ_TESTCASE_BUF (__afl_fuzz_ptr ? __afl_fuzz_ptr : (__afl_fuzz_alt_ptr = malloc(1 * 1024 * 1024)))
                                                                                         ^~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
The problem seems to be the decleration of `__afl_fuzz_alt_ptr` in Line 500:
https://github.com/AFLplusplus/AFLplusplus/blob/12bdefe00e38cdc3dd8cb028eeac325ab2e94e16/llvm_mode/afl-clang-fast.c#L498-L503
The pointer returned by malloc is not casted, which is fine for C but C++ does not seem to like it. Adding a cast to `unsigned char *` allows usage of `__AFL_FUZZ_TESTCASE_BUF` in a C++ target without a compilation error.