### PR TITLE
`fault == afl->crash_mode` should be likely

### DIFF
--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -570,7 +570,7 @@ u8 save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
   }
 
-  if (unlikely(fault == afl->crash_mode)) {
+  if (likely(fault == afl->crash_mode)) {
 
     /* Keep only if there are new bits in the map, add to queue for
        future fuzzing, etc. */


### PR DESCRIPTION
Since during normal fuzzing, `crash_mode` is `FSRV_RUN_OK`, and `fault` is also usually `FSRV_RUN_OK` since most executions are valid executions, thus it should be `likely` instead of `unlikely`