### PR TITLE
Fix when env. PATH contains spaces

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -86,7 +86,7 @@ export AFL_LLVM_INSTRUMENT=AFL
 
 # on OpenBSD we need to work with llvm from /usr/local/bin
 test -e /usr/local/bin/opt && {
-  export PATH=/usr/local/bin:${PATH}
+  export PATH="/usr/local/bin:${PATH}"
 }
 # on MacOS X we prefer afl-clang over afl-gcc, because
 # afl-gcc does not work there
@@ -108,7 +108,7 @@ RESET="\\033[0m"
 
 MEM_LIMIT=none
 
-export PATH=$PATH:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+export PATH="${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
 $ECHO "${RESET}${GREY}[*] starting afl++ test framework ..."
 


### PR DESCRIPTION
I don't advocate having spaces in a directory name, but this change should fix test/test.sh in that case.

By the way, is the travis CI status visible somewhere? afl-fuzz -R (radamsa) somehow stopped working on my machine, and it would be useful to know whether it's a local issue or if something might've broken in the code tree.