### PR TITLE
llvm mode shared segment fix for FreeBSD.

### DIFF
--- a/llvm_mode/afl-llvm-rt.o.c
+++ b/llvm_mode/afl-llvm-rt.o.c
@@ -53,7 +53,11 @@
 #define CONST_PRIO 5
 
 #ifndef MAP_FIXED_NOREPLACE
-  #define MAP_FIXED_NOREPLACE MAP_FIXED
+# ifdef MAP_EXCL
+   #define MAP_FIXED_NOREPLACE MAP_EXCL|MAP_FIXED
+#else
+   #define MAP_FIXED_NOREPLACE MAP_FIXED
+# endif
 #endif
 
 #include <sys/mman.h>


### PR DESCRIPTION
MAP_EXCL|MAP_FIXED is a (genuine) equivalent to Linux's MAP_FIXED_NOREPLACE.