### PR TITLE
Dont always use march=native

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,8 +56,10 @@ endif
 
 ifneq "$(shell uname)" "Darwin"
  ifeq "$(shell echo 'int main() {return 0; }' | $(CC) $(CFLAGS) -Werror -x c - -march=native -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
+  ifndef SOURCE_DATE_EPOCH
  	#CFLAGS_OPT += -march=native
  	SPECIAL_PERFORMANCE += -march=native
+  endif
  endif
  # OS X does not like _FORTIFY_SOURCE=2
  CFLAGS_OPT += -D_FORTIFY_SOURCE=2


### PR DESCRIPTION
When a reproducible distribution build is wanted,
it is not good to make build results depend on the build machine's CPU

There might be other good ways to fix this?

See https://reproducible-builds.org/ for why this matters.

This PR was done while working on reproducible builds for openSUSE.