### PR TITLE
illumos littlefixes: little typo for cpu binding and

### DIFF
--- a/gcc_plugin/GNUmakefile
+++ b/gcc_plugin/GNUmakefile
@@ -70,8 +70,13 @@ ifeq "$(TEST_MMAP)" "1"
 endif
 
 ifneq "$(shell uname -s)" "Haiku"
-	LDFLAGS += -lrt
+  LDFLAGS += -lrt
 endif
+
+ifeq "$(shell uname -s)" "SunOS"
+  PLUGIN_FLAGS += -I/usr/include/gmp
+endif
+
 
 PROGS        = ../afl-gcc-fast ../afl-gcc-pass.so ../afl-gcc-rt.o
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -398,7 +398,7 @@ if (pset_bind(c, P_PID, getpid(), NULL)) {
 
   if (cpu_start == afl->cpu_core_count)
     PFATAL("pset_bind failed for cpu %d, exit", i);
-  WARNF("pthread_setaffinity failed to CPU %d, trying next CPU", i);
+  WARNF("pset_bind failed to CPU %d, trying next CPU", i);
   cpu_start++;
   goto try
     ;


### PR DESCRIPTION
even tough gcc plugin less good than LLVM, clang
is more buggy on this os.