### PR TITLE
Allow the fuzzer to write empty buffer to the file

### DIFF
--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -286,6 +286,15 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf,
           "Trimmed data returned by custom mutator is larger than original "
           "data");
 
+    } else if (unlikely(retlen == 0)) {
+
+      /* Do not run the empty test case on the target. To keep the custom
+         trimming function running, we simply treat the empty test case as an
+         unsuccessful trimming and skip it, instead of aborting the trimming. */
+
+      ++afl->trim_execs;
+      goto unsuccessful_trimming;
+
     }
 
     write_to_testcase(afl, retbuf, retlen);
@@ -324,6 +333,8 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf,
       }
 
     } else {
+
+unsuccessful_trimming:
 
       /* Tell the custom mutator that the trimming was unsuccessful */
       afl->stage_cur = mutator->afl_custom_post_trim(mutator->data, 0);

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -109,7 +109,7 @@ void write_to_testcase(afl_state_t *afl, void *mem, u32 len) {
 
     });
 
-    if (unlikely(!new_buf && (new_size < 0))) {
+    if (unlikely(!new_buf && (new_size <= 0))) {
 
       FATAL("Custom_post_process failed (ret: %lu)", (long unsigned)new_size);
 

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -109,7 +109,7 @@ void write_to_testcase(afl_state_t *afl, void *mem, u32 len) {
 
     });
 
-    if (unlikely(!new_buf && (new_size <= 0))) {
+    if (unlikely(!new_buf && (new_size < 0))) {
 
       FATAL("Custom_post_process failed (ret: %lu)", (long unsigned)new_size);
 


### PR DESCRIPTION
Sometimes, the custom mutator will generate an empty buffer for the test case (e.g., trimming in the grammar mutator). The only change in this pull request is to allow the fuzzer to write empty buffer (i.e., `len == 0`) to the file while using custom mutators.

In my case, the custom mutator does not define `custom_post_process`, so `new_buf` will be `NULL`. If `len` is 0, `new_size` will remain 0 as well. When the fuzzer checks `!new_buf && (new_size < 0)` in `afl-fuzz-run.c` Line 112, it will generates an error.

I have run simple tests. No error is observed. Hope it works fine.