### PR TITLE
Fix bug in qemu mode

### DIFF
--- a/qemu_mode/patches/afl-qemu-cpu-inl.h
+++ b/qemu_mode/patches/afl-qemu-cpu-inl.h
@@ -620,7 +620,8 @@ static void afl_wait_tsl(CPUState *cpu, int fd) {
 
         last_tb = tb_htable_lookup(cpu, c.last_tb.pc, c.last_tb.cs_base,
                                    c.last_tb.flags, c.cf_mask);
-        if (last_tb) { tb_add_jump(last_tb, c.tb_exit, tb); }
+#define TB_JMP_RESET_OFFSET_INVALID 0xffff
+        if (last_tb && (last_tb->jmp_reset_offset[c.tb_exit] != TB_JMP_RESET_OFFSET_INVALID)) { tb_add_jump(last_tb, c.tb_exit, tb); }
 
       }
 


### PR DESCRIPTION
Fix bug in function afl_wait_tsl at qemu_mode/patches/afl-qemu-cpu-inl.h.
In order to improve the speed of fuzz,  the forkserver uses tb_add_jump to make TB jmp to another directly. But sometimes the TranslationBlock may generated without jmp target.
```
    /* The following data are used to directly call another TB from
     * the code of this one. This can be done either by emitting direct or
     * indirect native jump instructions. These jumps are reset so that the TB
     * just continues its execution. The TB can be linked to another one by
     * setting one of the jump targets (or patching the jump instruction). Only
     * two of such jumps are supported.
     */
    uint16_t jmp_reset_offset[2]; /* offset of original jump target */
#define TB_JMP_RESET_OFFSET_INVALID 0xffff /* indicates no jump generated */
    uintptr_t jmp_target_arg[2];  /* target address or offset */
```
In this case:
jmp_reset_offset[0]=jmp_reset_offset[1]=TB_JMP_RESET_OFFSET_INVALID;
jmp_target_arg[0]= jmp_target_arg[1]=0;
tb_add_jump(last_tb, c.tb_exit, tb)   ->  tb_target_set_jmp_target(tc_ptr, tc_ptr + offset, addr);
( offset = tb->jmp_target_arg[n]=0;    tc_ptr = tb->tc.ptr;)
As a result, the start codes of TranslationBlock (tb->tc.ptr) will change to illegal instructions, which will lead to a terrible crash.