### PR TITLE
Haiku set explicitly to performance.

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -82,6 +82,11 @@
   #include <sys/sysctl.h>
 #endif                           /* __APPLE__ || __FreeBSD__ || __OpenBSD__ */
 
+#if defined(__HAIKU__)
+  #include <kernel/OS.h>
+  #include <kernel/scheduler.h>
+#endif
+
 /* For systems that have sched_setaffinity; right now just Linux, but one
    can hope... */
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1057,6 +1057,11 @@ int main(int argc, char **argv_orig, char **envp) {
   bind_to_free_cpu(afl);
   #endif                                                   /* HAVE_AFFINITY */
 
+  #ifdef __HAIKU__
+  /* Prioritizes performance over power saving */
+  set_scheduler_mode(SCHEDULER_MODE_LOW_LATENCY);
+  #endif
+
   afl->fsrv.trace_bits =
       afl_shm_init(&afl->shm, afl->fsrv.map_size, afl->non_instrumented_mode);
 


### PR DESCRIPTION
No command line to set through afl-system-config (the only one is a GUI).