### PR TITLE
Add support for specific custom mutator name

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -656,6 +656,7 @@ typedef struct afl_state {
 struct custom_mutator {
 
   const char *name;
+  char *      name_short;
   void *      dh;
   u8 *        post_process_buf;
   size_t      post_process_size;

--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -142,6 +142,7 @@ struct custom_mutator *load_custom_mutator(afl_state_t *afl, const char *fn) {
   struct custom_mutator *mutator = ck_alloc(sizeof(struct custom_mutator));
 
   mutator->name = fn;
+  mutator->name_short = strrchr(fn, '/') + 1;
   ACTF("Loading custom mutator library from '%s'...", fn);
 
   dh = dlopen(fn, RTLD_NOW);

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -1683,6 +1683,8 @@ custom_mutator_stage:
 
       has_custom_fuzz = true;
 
+      afl->stage_short = el->name_short;
+
       for (afl->stage_cur = 0; afl->stage_cur < afl->stage_max;
            ++afl->stage_cur) {
 


### PR DESCRIPTION
Currently the stage_short is only set to "custom" for each custom mutator. This results in queue files where it is unclear which custom mutator was responsible for producing the file.

Now
```
id:001452,src:001329,time:23965354,op:custom,pos:0
```
will become
```
id:000158,src:000002,time:1717,op:honggfuzz.so,pos:0
```