### PR TITLE
Added "-g" option for maximum number of user-specified tokens

### DIFF
--- a/src/afl-fuzz-extras.c
+++ b/src/afl-fuzz-extras.c
@@ -248,10 +248,10 @@ static void extras_check_and_sort(afl_state_t *afl, u32 min_len, u32 max_len,
 
   }
 
-  if (afl->extras_cnt > MAX_DET_EXTRAS) {
+  if (afl->extras_cnt > afl->max_dict_entries) {
 
     WARNF("More than %d tokens - will use them probabilistically.",
-          MAX_DET_EXTRAS);
+    		afl->max_dict_entries);
 
   }
 
@@ -403,10 +403,10 @@ void add_extra(afl_state_t *afl, u8 *mem, u32 len) {
 
   /* We only want to print this once */
 
-  if (afl->extras_cnt == MAX_DET_EXTRAS + 1) {
+  if (afl->extras_cnt == afl->max_dict_entries + 1) {
 
     WARNF("More than %d tokens - will use them probabilistically.",
-          MAX_DET_EXTRAS);
+    		afl->max_dict_entries);
 
   }
 

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -1509,13 +1509,13 @@ skip_interest:
 
     for (j = 0; j < afl->extras_cnt; ++j) {
 
-      /* Skip extras probabilistically if afl->extras_cnt > MAX_DET_EXTRAS. Also
+      /* Skip extras probabilistically if afl->extras_cnt > afl->max_dict_entries. Also
          skip them if there's no room to insert the payload, if the token
          is redundant, or if its entire span has no bytes set in the effector
          map. */
 
-      if ((afl->extras_cnt > MAX_DET_EXTRAS &&
-           rand_below(afl, afl->extras_cnt) >= MAX_DET_EXTRAS) ||
+      if ((afl->extras_cnt > afl->max_dict_entries &&
+           rand_below(afl, afl->extras_cnt) >= afl->max_dict_entries) ||
           afl->extras[j].len > len - i ||
           !memcmp(afl->extras[j].data, out_buf + i, afl->extras[j].len) ||
           !memchr(eff_map + EFF_APOS(i), 1,
@@ -3722,13 +3722,13 @@ skip_interest:
 
     for (j = 0; j < afl->extras_cnt; ++j) {
 
-      /* Skip extras probabilistically if afl->extras_cnt > MAX_DET_EXTRAS. Also
+      /* Skip extras probabilistically if afl->extras_cnt > afl->max_dict_entries. Also
          skip them if there's no room to insert the payload, if the token
          is redundant, or if its entire span has no bytes set in the effector
          map. */
 
-      if ((afl->extras_cnt > MAX_DET_EXTRAS &&
-           rand_below(afl, afl->extras_cnt) >= MAX_DET_EXTRAS) ||
+      if ((afl->extras_cnt > afl->max_dict_entries &&
+           rand_below(afl, afl->extras_cnt) >= afl->max_dict_entries) ||
           afl->extras[j].len > len - i ||
           !memcmp(afl->extras[j].data, out_buf + i, afl->extras[j].len) ||
           !memchr(eff_map + EFF_APOS(i), 1,

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -124,6 +124,8 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
 
   afl->fsrv.mem_limit = MEM_LIMIT;
 
+  afl->max_dict_entries = MAX_DET_EXTRAS;
+
   afl->stats_update_freq = 1;
 
   afl->fsrv.dev_urandom_fd = -1;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -146,7 +146,9 @@ static void usage(u8 *argv0, int more_help) {
       "  -b cpu_id     - bind the fuzzing process to the specified CPU core "
       "(0-...)\n"
       "  -e ext        - file extension for the fuzz test input file (if "
-      "needed)\n\n",
+      "needed)\n"
+	  "  -g max        - maximum number of user-specified dictionary tokens "
+      "to use in deterministic steps\n\n",
       argv0, EXEC_TIMEOUT, MEM_LIMIT, FOREIGN_SYNCS_MAX);
 
   if (more_help > 1) {
@@ -277,7 +279,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   while ((opt = getopt(
               argc, argv,
-              "+b:c:i:I:o:f:F:m:t:T:dDnCB:S:M:x:QNUWe:p:s:V:E:L:hRP:")) > 0) {
+              "+b:c:i:I:o:f:F:m:t:T:dDnCB:S:M:x:QNUWe:g:p:s:V:E:L:hRP:")) > 0) {
 
     switch (opt) {
 
@@ -368,6 +370,18 @@ int main(int argc, char **argv_orig, char **envp) {
         if (afl->file_extension) { FATAL("Multiple -e options not supported"); }
 
         afl->file_extension = optarg;
+
+        break;
+
+      case 'g':
+
+        if (afl->max_dict_entries != MAX_DET_EXTRAS) { FATAL("Multiple -g options not supported"); }
+
+        if (sscanf(optarg, "%d", &afl->max_dict_entries) < 0) {
+
+          FATAL("Bad syntax used for -g");
+
+        }
 
         break;
 


### PR DESCRIPTION
Sometimes I've needed to make use of bigger dictionaries (with more than 200 items). Until now, the only option was to modify MAX_DET_EXTRAS in config.h.

I think it would be a good idea to be able to modify this option at runtime.