### PR TITLE
Option for specifying forkserver initialization timeout via environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .sync_tmp
 *.o
 *.so
+*.swp
 *.pyc
 *.dSYM
 as

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -353,7 +353,8 @@ typedef struct afl_env_vars {
       afl_cal_fast, afl_cycle_schedules, afl_expand_havoc;
 
   u8 *afl_tmpdir, *afl_custom_mutator_library, *afl_python_module, *afl_path,
-      *afl_hang_tmout, *afl_skip_crashes, *afl_preload, *afl_max_det_extras;
+      *afl_hang_tmout, *afl_forksrv_init_tmout, *afl_skip_crashes, *afl_preload,
+      *afl_max_det_extras;
 
 } afl_env_vars_t;
 

--- a/include/envs.h
+++ b/include/envs.h
@@ -48,6 +48,7 @@ static char *afl_environment_variables[] = {
     "AFL_GCC_INSTRUMENT_FILE",
     "AFL_GCJ",
     "AFL_HANG_TMOUT",
+    "AFL_FORKSRV_INIT_TMOUT",
     "AFL_HARDEN",
     "AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES",
     "AFL_IMPORT_FIRST",

--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -56,6 +56,7 @@ typedef struct afl_forkserver {
   u8 no_unlink;                         /* do not unlink cur_input          */
 
   u32 exec_tmout;                       /* Configurable exec timeout (ms)   */
+  u32 init_tmout;                       /* Configurable init timeout (ms)   */
   u32 map_size;                         /* map size used by the target      */
   u32 snapshot;                         /* is snapshot feature used         */
   u64 mem_limit;                        /* Memory cap for child (MB)        */

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -79,6 +79,7 @@ void afl_fsrv_init(afl_forkserver_t *fsrv) {
   fsrv->use_stdin = 1;
   fsrv->no_unlink = 0;
   fsrv->exec_tmout = EXEC_TIMEOUT;
+  fsrv->init_tmout = EXEC_TIMEOUT * FORK_WAIT_MULT;
   fsrv->mem_limit = MEM_LIMIT;
   fsrv->out_file = NULL;
 

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -101,6 +101,7 @@ void afl_fsrv_init_dup(afl_forkserver_t *fsrv_to, afl_forkserver_t *from) {
   fsrv_to->out_fd = from->out_fd;
   fsrv_to->dev_null_fd = from->dev_null_fd;
   fsrv_to->exec_tmout = from->exec_tmout;
+  fsrv_to->init_tmout = from->init_tmout;
   fsrv_to->mem_limit = from->mem_limit;
   fsrv_to->map_size = from->map_size;
   fsrv_to->support_shmem_fuzz = from->support_shmem_fuzz;

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -519,13 +519,13 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     u32 time_ms =
         read_s32_timed(fsrv->fsrv_st_fd, &status,
-                       fsrv->exec_tmout * FORK_WAIT_MULT, stop_soon_p);
+                       fsrv->init_tmout, stop_soon_p);
 
     if (!time_ms) {
 
       kill(fsrv->fsrv_pid, SIGKILL);
 
-    } else if (time_ms > fsrv->exec_tmout * FORK_WAIT_MULT) {
+    } else if (time_ms > fsrv->init_tmout) {
 
       fsrv->last_run_timed_out = 1;
       kill(fsrv->fsrv_pid, SIGKILL);

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -356,6 +356,13 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
             afl->afl_env.afl_max_det_extras =
                 (u8 *)get_afl_env(afl_environment_variables[i]);
 
+          } else if (!strncmp(env, "AFL_FORKSRV_INIT_TMOUT",
+
+                              afl_environment_variable_len)) {
+
+            afl->afl_env.afl_forksrv_init_tmout =
+                (u8 *) get_afl_env(afl_environment_variables[i]);
+
           }
 
         } else {

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -972,7 +972,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (afl->afl_env.afl_forksrv_init_tmout) {
 
-    afl->fsrv.init_tmout  = atoi(afl->afl_env.afl_forksrv_init_tmout);
+    afl->fsrv.init_tmout = atoi(afl->afl_env.afl_forksrv_init_tmout);
     if (!afl->fsrv.init_tmout) {
 
       FATAL("Invalid value of AFL_FORKSRV_INIT_TMOUT");

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -173,6 +173,7 @@ static void usage(u8 *argv0, int more_help) {
       "AFL_FAST_CAL: limit the calibration stage to three cycles for speedup\n"
       "AFL_FORCE_UI: force showing the status screen (for virtual consoles)\n"
       "AFL_HANG_TMOUT: override timeout value (in milliseconds)\n"
+      "AFL_FORKSRV_INIT_TMOUT: time spent waiting for forkserver during startup (in milliseconds)\n"
       "AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: don't warn about core dump handlers\n"
       "AFL_IMPORT_FIRST: sync and import test cases from other fuzzer instances first\n"
       "AFL_MAP_SIZE: the shared memory size for that target. must be >= the size\n"
@@ -968,6 +969,22 @@ int main(int argc, char **argv_orig, char **envp) {
     afl->max_det_extras = MAX_DET_EXTRAS;
 
   }
+
+  if (afl->afl_env.afl_forksrv_init_tmout) {
+
+    afl->fsrv.init_tmout  = atoi(afl->afl_env.afl_forksrv_init_tmout);
+    if (!afl->fsrv.init_tmout) {
+
+      FATAL("Invalid value of AFL_FORKSRV_INIT_TMOUT");
+
+    }
+
+  } else {
+
+    afl->fsrv.init_tmout = afl->fsrv.exec_tmout * FORK_WAIT_MULT;
+
+  }
+
 
   if (afl->non_instrumented_mode == 2 && afl->no_forkserver) {
 


### PR DESCRIPTION
This PR introduces a new environment variable which allows to specify the timespan AFL should wait for initial contact with the
forkserver. (Currently, this is set to `timeout * FORK_WAIT_MULT`).
    
This addition is useful for fuzz-targets requiring a rather long setup time before the actual fuzzing starts (e.g., unicorn).

Additionally, I included vim-generated *.swp files to the .gitignore.

Cheers,
Marius