### PR TITLE
Add -fdebug-prefix-map to CFLAGS_SAFE

### DIFF
--- a/llvm_mode/GNUmakefile
+++ b/llvm_mode/GNUmakefile
@@ -224,7 +224,8 @@ CFLAGS_SAFE     := -Wall -g -Wno-pointer-sign -I ../include/ \
                    -DAFL_REAL_LD=\"$(AFL_REAL_LD)\" \
                    -DAFL_CLANG_LDPATH=\"$(AFL_CLANG_LDPATH)\" \
                    -DAFL_CLANG_FUSELD=\"$(AFL_CLANG_FUSELD)\" \
-                   -DCLANG_BIN=\"$(CLANG_BIN)\" -DCLANGPP_BIN=\"$(CLANGPP_BIN)\" -DUSE_BINDIR=$(USE_BINDIR) -Wno-unused-function
+                   -DCLANG_BIN=\"$(CLANG_BIN)\" -DCLANGPP_BIN=\"$(CLANGPP_BIN)\" -DUSE_BINDIR=$(USE_BINDIR) -Wno-unused-function \
+                   -fdebug-prefix-map="$(CURDIR)=llvm_mode"
 override CFLAGS += $(CFLAGS_SAFE)
 
 ifdef AFL_TRACE_PC


### PR DESCRIPTION
In Debian, we override CFLAGS to include -fdebug-prefix-map to avoid
hardcoding the build path in any generated debug information. This is
to help with getting the package to build reproducibly.

However you seem to voluntarily not honor CFLAGS but only CFLAGS_SAFE
for a limited number of source files. This resulted in a lintian warning
on Debian's side (https://lintian.debian.org/tags/file-references-package-build-path.html)
pointing to /usr/lib/afl/afl-llvm-rt-64.o and /usr/lib/afl/afl-llvm-rt.o.

With this commit, I'm manually adding -fdebug-prefix-map as a safe
build flag to CFLAGS_SAFE.