### PR TITLE
Fix various spelling errors

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -416,7 +416,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - big code refactoring:
     * all includes are now in include/
     * all afl sources are now in src/ - see src/README.md
-    * afl-fuzz was splitted up in various individual files for including
+    * afl-fuzz was split up in various individual files for including
       functionality in other programs (e.g. forkserver, memory map, etc.)
       for better readability.
     * new code indention everywhere

--- a/llvm_mode/afl-llvm-rt.o.c
+++ b/llvm_mode/afl-llvm-rt.o.c
@@ -339,7 +339,7 @@ static void __afl_map_shm(void) {
 
     if (__afl_area_ptr == MAP_FAILED) {
 
-      fprintf(stderr, "can not aquire mmap for address %p\n",
+      fprintf(stderr, "can not acquire mmap for address %p\n",
               (void *)__afl_map_addr);
       exit(1);
 

--- a/llvm_mode/split-compares-pass.so.cc
+++ b/llvm_mode/split-compares-pass.so.cc
@@ -1272,7 +1272,7 @@ bool SplitComparesTransform::runOnModule(Module &M) {
     if (!be_quiet) {
 
       errs() << "Split-floatingpoint-compare-pass: " << count
-             << " FP comparisons splitted\n";
+             << " FP comparisons split\n";
 
     }
 
@@ -1290,7 +1290,7 @@ bool SplitComparesTransform::runOnModule(Module &M) {
       count = splitIntCompares(M, bitw);
       if (!be_quiet)
         errs() << "Split-integer-compare-pass " << bitw << "bit: " << count
-               << " splitted\n";
+               << " split\n";
 
       bitw >>= 1;
 #if LLVM_VERSION_MAJOR > 3 || \
@@ -1301,7 +1301,7 @@ bool SplitComparesTransform::runOnModule(Module &M) {
       count = splitIntCompares(M, bitw);
       if (!be_quiet)
         errs() << "Split-integer-compare-pass " << bitw << "bit: " << count
-               << " splitted\n";
+               << " split\n";
 
       bitw >>= 1;
 #if LLVM_VERSION_MAJOR > 3 || \
@@ -1312,7 +1312,7 @@ bool SplitComparesTransform::runOnModule(Module &M) {
       count = splitIntCompares(M, bitw);
       if (!be_quiet)
         errs() << "Split-integer-compare-pass " << bitw << "bit: " << count
-               << " splitted\n";
+               << " split\n";
 
       bitw >>= 1;
       break;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -191,7 +191,7 @@ static void usage(u8 *argv0, int more_help) {
       "AFL_QUIET: suppress forkserver status messages\n"
       "AFL_PRELOAD: LD_PRELOAD / DYLD_INSERT_LIBRARIES settings for target\n"
       "AFL_SHUFFLE_QUEUE: reorder the input queue randomly on startup\n"
-      "AFL_SKIP_BIN_CHECK: skip the check, if the target is an excutable\n"
+      "AFL_SKIP_BIN_CHECK: skip the check, if the target is an executable\n"
       "AFL_SKIP_CPUFREQ: do not warn about variable cpu clocking\n"
       "AFL_SKIP_CRASHES: during initial dry run do not terminate for crashing inputs\n"
       "AFL_TMPDIR: directory to use for input file generation (ramdisk recommended)\n"


### PR DESCRIPTION
All those spelling errors have been caught by lintian's built-in spellchecker:
https://lintian.debian.org/tags/spelling-error-in-binary.html