### PR TITLE
Fixes missing variable declaration afl network example

### DIFF
--- a/examples/afl_network_proxy/afl-network-server.c
+++ b/examples/afl_network_proxy/afl-network-server.c
@@ -72,6 +72,7 @@ static u8 *in_file,                    /* Minimizer input test case         */
 
 static u8 *in_data;                    /* Input data for trimming           */
 static u8 *buf2;
+static s32 buf2_len;
 
 static s32 in_len;
 static u32 map_size = MAP_SIZE;


### PR DESCRIPTION
I couldn't get the project get compiled using `make distrib`. Fixing the compiler warning by adding the missing variable declaration solved it for me.