### PR TITLE
Fixed stack use-after-return bug in strntoll

### DIFF
--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -282,7 +282,6 @@ static long long strntoll(const char *str, size_t sz, char **end, int base) {
   memcpy(buf, beg, sz);
   buf[sz] = '\0';
   ret = strtoll(buf, end, base);
-  if (ret == LLONG_MIN || ret == LLONG_MAX) return ret;
   if (end) *end = (char *)beg + (*end - buf);
   return ret;
 


### PR DESCRIPTION
When `str` holds a numerical value that cannot be represented by the numerical type, `strtol` returns the minimum or maximum value for that type, but it correctly sets `*endptr` to point to the first invalid character (or '\0').

Before this fix, `strntoll` did not correctly set `*endptr`, but left it to point somewhere within the stack buffer `char buf[64]`.
After returning from `strtoll`, `cmp_extend_encoding` uses the `*endptr` value to calculate the length of the number in the buffer. 

When the number is not representable, `*endptr` is still pointing somewhere in the previous stack frame, and is used to calculate `old_len = endptr - buf_8`, which turns out to be a huge number (because the stack is allocated at a high memory address).

`cmp_extend_encoding` then performs the following call:
```
memcpy(new_buf + idx + num_len, buf_8 + old_len, len - idx - old_len);
                                                           ^
                                                           `-- integer underflow (unless len-idx is large enough)
```
And the memcpy SEGFAULTs.

This was discovered when evaluating AFLplusplus against [Magma](https://github.com/HexHive/magma). One of the test cases of the `php` target had a 30-character repeated sequence of 1's, and the fuzzer kept crashing when fuzzing it. The crash was triaged with the help of ASan and UBSan.

Note: the AFL++ code base is riddled with undefined behavior for integers. I'm not sure if they affect the correctness or the effectiveness of the fuzzing process, but at least they don't crash the fuzzer yet (except for this bug).