### PR TITLE
Export set afl_environment_variables to stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ without feedback, bug reports, or patches from:
   Andrea Biondo                         Vincent Le Garrec
   Khaled Yakdan                         Kuang-che Wu
   Josephine Calliotte                   Konrad Welc
+  Thomas Rooijakkers
 ```
 
 Thank you!

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -945,12 +945,11 @@ void destroy_extras(afl_state_t *);
 
 /* Stats */
 
-FILE *open_file(const char *);
-void  write_fuzzer_config_file(afl_state_t *);
-void  write_stats_file(afl_state_t *, double, double, double);
-void  maybe_update_plot_file(afl_state_t *, double, double);
-void  show_stats(afl_state_t *);
-void  show_init_stats(afl_state_t *);
+void write_fuzzer_config_file(afl_state_t *);
+void write_stats_file(afl_state_t *, double, double, double);
+void maybe_update_plot_file(afl_state_t *, double, double);
+void show_stats(afl_state_t *);
+void show_init_stats(afl_state_t *);
 
 /* Run */
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -945,10 +945,12 @@ void destroy_extras(afl_state_t *);
 
 /* Stats */
 
-void write_stats_file(afl_state_t *, double, double, double);
-void maybe_update_plot_file(afl_state_t *, double, double);
-void show_stats(afl_state_t *);
-void show_init_stats(afl_state_t *);
+FILE *open_file(const char *);
+void  write_fuzzer_setup_file(afl_state_t *);
+void  write_stats_file(afl_state_t *, double, double, double);
+void  maybe_update_plot_file(afl_state_t *, double, double);
+void  show_stats(afl_state_t *);
+void  show_init_stats(afl_state_t *);
 
 /* Run */
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -946,7 +946,7 @@ void destroy_extras(afl_state_t *);
 /* Stats */
 
 FILE *open_file(const char *);
-void  write_fuzzer_setup_file(afl_state_t *);
+void  write_fuzzer_config_file(afl_state_t *);
 void  write_stats_file(afl_state_t *, double, double, double);
 void  maybe_update_plot_file(afl_state_t *, double, double);
 void  show_stats(afl_state_t *);

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -27,6 +27,69 @@
 #include "envs.h"
 #include <limits.h>
 
+/* Open file for writing */
+
+FILE *open_file(const char *fn) {
+
+  s32   fd;
+  FILE *f;
+
+  fd = open(fn, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+  if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
+
+  f = fdopen(fd, "w");
+
+  if (!f) { PFATAL("fdopen() failed"); }
+
+  return f;
+
+}
+
+/* Write fuzzer setup file */
+
+void write_fuzzer_setup_file(afl_state_t *afl) {
+
+  u8    fn[PATH_MAX];
+  FILE *f;
+
+  snprintf(fn, PATH_MAX, "%s/fuzzer_setup", afl->out_dir);
+  f = open_file(fn);
+
+  char *   val;
+  uint32_t i = 0;
+  uint32_t s_afl_env =
+      sizeof(afl_environment_variables) / sizeof(afl_environment_variables[0]) -
+      1;
+
+  uint32_t max_len = 0;
+  uint32_t cur_len = 0;
+  for (i = 0; i < s_afl_env; i++) {
+
+    if ((val = getenv(afl_environment_variables[i])) != NULL) {
+
+      cur_len = strlen(afl_environment_variables[i]);
+      max_len = cur_len > max_len ? cur_len : max_len;
+
+    }
+
+  }
+
+  for (i = 0; i < s_afl_env; i++) {
+
+    if ((val = getenv(afl_environment_variables[i])) != NULL) {
+
+      fprintf(f, "%*.*s : %s\n", -max_len, strlen(afl_environment_variables[i]),
+              afl_environment_variables[i], val);
+
+    }
+
+  }
+
+  fclose(f);
+
+}
+
 /* Update stats file for unattended monitoring. */
 
 void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
@@ -37,20 +100,12 @@ void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
 #endif
 
   unsigned long long int cur_time = get_cur_time();
-  u8                     fn[PATH_MAX];
-  s32                    fd;
-  FILE *                 f;
   u32                    t_bytes = count_non_255_bytes(afl, afl->virgin_bits);
+  u8                     fn[PATH_MAX];
+  FILE *                 f;
 
   snprintf(fn, PATH_MAX, "%s/fuzzer_stats", afl->out_dir);
-
-  fd = open(fn, O_WRONLY | O_CREAT | O_TRUNC, 0600);
-
-  if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
-
-  f = fdopen(fd, "w");
-
-  if (!f) { PFATAL("fdopen() failed"); }
+  f = open_file(fn);
 
   /* Keep last values in case we're called from another context
      where exec/sec stats and such are not readily available. */
@@ -165,27 +220,11 @@ void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
               : "default",
           afl->orig_cmdline);
 
-  char *   val;
-  uint32_t i = 0;
-  uint32_t s_afl_env =
-      sizeof(afl_environment_variables) / sizeof(afl_environment_variables[0]) -
-      1;
-
-  for (i = 0; i < s_afl_env; i++) {
-
-    if ((val = get_afl_env(afl_environment_variables[i])) != NULL) {
-
-      fprintf(f, "%-18.*s: %s\n", strlen(afl_environment_variables[i]),
-              afl_environment_variables[i], val);
-
-    }
-
-  }
-
   /* ignore errors */
 
   if (afl->debug) {
 
+    uint32_t i = 0;
     fprintf(f, "virgin_bytes     :");
     for (i = 0; i < afl->fsrv.map_size; i++) {
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -48,39 +48,24 @@ FILE *open_file(const char *fn) {
 
 /* Write fuzzer setup file */
 
-void write_fuzzer_setup_file(afl_state_t *afl) {
+void write_fuzzer_config_file(afl_state_t *afl) {
 
   u8    fn[PATH_MAX];
   FILE *f;
 
-  snprintf(fn, PATH_MAX, "%s/fuzzer_setup", afl->out_dir);
+  snprintf(fn, PATH_MAX, "%s/fuzzer_config", afl->out_dir);
   f = open_file(fn);
 
-  char *   val;
-  uint32_t i = 0;
+  char *val;
+
   uint32_t s_afl_env =
       sizeof(afl_environment_variables) / sizeof(afl_environment_variables[0]) -
       1;
-
-  uint32_t max_len = 0;
-  uint32_t cur_len = 0;
-  for (i = 0; i < s_afl_env; i++) {
+  for (uint32_t i = 0; i < s_afl_env; i++) {
 
     if ((val = getenv(afl_environment_variables[i])) != NULL) {
 
-      cur_len = strlen(afl_environment_variables[i]);
-      max_len = cur_len > max_len ? cur_len : max_len;
-
-    }
-
-  }
-
-  for (i = 0; i < s_afl_env; i++) {
-
-    if ((val = getenv(afl_environment_variables[i])) != NULL) {
-
-      fprintf(f, "%*.*s : %s\n", -max_len, strlen(afl_environment_variables[i]),
-              afl_environment_variables[i], val);
+      fprintf(f, "%s=%s\n", afl_environment_variables[i], val);
 
     }
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -29,7 +29,7 @@
 
 /* Open file for writing */
 
-FILE *open_file(const char *fn) {
+inline FILE *open_file(const char *fn) {
 
   s32   fd;
   FILE *f;

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -24,6 +24,7 @@
  */
 
 #include "afl-fuzz.h"
+#include "envs.h"
 #include <limits.h>
 
 /* Update stats file for unattended monitoring. */
@@ -163,11 +164,28 @@ void write_stats_file(afl_state_t *afl, double bitmap_cvg, double stability,
               ? ""
               : "default",
           afl->orig_cmdline);
+
+  char *   val;
+  uint32_t i = 0;
+  uint32_t s_afl_env =
+      sizeof(afl_environment_variables) / sizeof(afl_environment_variables[0]) -
+      1;
+
+  for (i = 0; i < s_afl_env; i++) {
+
+    if ((val = get_afl_env(afl_environment_variables[i])) != NULL) {
+
+      fprintf(f, "%-18.*s: %s\n", strlen(afl_environment_variables[i]),
+              afl_environment_variables[i], val);
+
+    }
+
+  }
+
   /* ignore errors */
 
   if (afl->debug) {
 
-    uint32_t i = 0;
     fprintf(f, "virgin_bytes     :");
     for (i = 0; i < afl->fsrv.map_size; i++) {
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1274,7 +1274,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   seek_to = find_start_position(afl);
 
-  write_fuzzer_setup_file(afl);
+  write_fuzzer_config_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1274,6 +1274,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   seek_to = find_start_position(afl);
 
+  write_fuzzer_setup_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);


### PR DESCRIPTION
Logging the AFL environment variables is useful to improve reproducibility of fuzzing campaigns and allow for proper analysis.

The logging of these variables, wheLogging the AFL environment variables is useful to improve reproducibility of fuzzing campaigns and allow for proper analysis.

The logging of these variables, when set, is now integrated in `afl-stats`.