### PR TITLE
Warn if non deterministic mode and dictionary is used.

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -456,6 +456,10 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         extras_dir[extras_dir_cnt++] = optarg;
+
+        if (afl->skip_deterministic) {
+            WARNF("Dictionary is not supported in non deterministic runs"); 
+        }
         break;
 
       case 't': {                                                /* timeout */
@@ -550,6 +554,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
         afl->skip_deterministic = 1;
         afl->use_splicing = 1;
+        if (extras_dir_cnt) { 
+            WARNF("Dictionary is not supported in non deterministic runs"); 
+        }
         break;
 
       case 'B':                                              /* load bitmap */

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -458,8 +458,11 @@ int main(int argc, char **argv_orig, char **envp) {
         extras_dir[extras_dir_cnt++] = optarg;
 
         if (afl->skip_deterministic) {
-            WARNF("Dictionary is not supported in non deterministic runs"); 
+
+          WARNF("Dictionary is not supported in non deterministic runs");
+
         }
+
         break;
 
       case 't': {                                                /* timeout */
@@ -554,9 +557,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
         afl->skip_deterministic = 1;
         afl->use_splicing = 1;
-        if (extras_dir_cnt) { 
-            WARNF("Dictionary is not supported in non deterministic runs"); 
+        if (extras_dir_cnt) {
+
+          WARNF("Dictionary is not supported in non deterministic runs");
+
         }
+
         break;
 
       case 'B':                                              /* load bitmap */


### PR DESCRIPTION
This commit adds a warning if a non deterministic mode (`-S` or `-d`) and a dictionary (`-x`) is used together. Dictionary mode is only used in the deterministic mode this it makes no sense to use it in non deterministic mode. 

I decided to print a warning and not terminate as it might break some peoples scripts. 