### PR TITLE
Fix qemu argv construction

### DIFF
--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -146,7 +146,7 @@ char **get_qemu_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
   u8 *   tmp, *cp = NULL, *rsl, *own_copy;
 
   memcpy(&new_argv[3], &argv[1], (int)(sizeof(char *)) * (argc - 1));
-  new_argv[argc - 1] = NULL;
+  new_argv[argc + 2] = NULL;
 
   new_argv[2] = *target_path_p;
   new_argv[1] = "--";


### PR DESCRIPTION
AFL++ is currently putting NULL into a wrong location for QEMU arguments.

the `new_argv` will have (argc + 2) arguments. So, we need to set NULL to `new_argv[argc + 2]`.
```
/path/to/afl-qemu-trace -- argv[0] argv[1] ... argv[argc - 1] NULL
```

Before this patch:
```
# ps aux | grep base64
root     26451  0.0  0.2  28684  5096 pts/3    S+   11:47   0:00 ../../fuzz/AFLplusplus/afl-fuzz -i corpus -o afl-output -Q -- /usr/bin/base64 a b c d e f
root     26452  1.3  0.4 150824  9476 ?        Ssl  11:47   0:00 ../../fuzz/AFLplusplus/afl-qemu-trace -- /usr/bin/base64 a b c
```

After:
```
# ps aux | grep base64
root     29672  0.0  0.2  28688  5060 pts/3    S+   11:48   0:00 ../../fuzz/AFLplusplus/afl-fuzz -i corpus -o afl-output -Q -- /usr/bin/base64 a b c d e f
root     29673  1.0  0.5 150824 10588 ?        Ssl  11:48   0:00 ../../fuzz/AFLplusplus/afl-qemu-trace -- /usr/bin/base64 a b c d e f
```