### PR TITLE
Patching and improving AFLFast schedules.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -205,7 +205,7 @@ endif
 
 ifneq "$(filter Linux GNU%,$(shell uname))" ""
   override CFLAGS += -D_FORTIFY_SOURCE=2
-  LDFLAGS += -ldl -lrt
+  LDFLAGS += -ldl -lrt -lm
 endif
 
 ifneq "$(findstring FreeBSD, $(shell uname))" ""

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -155,7 +155,6 @@ struct queue_entry {
 
   u64 exec_us,                          /* Execution time (us)              */
       handicap,                         /* Number of queue cycles behind    */
-      n_fuzz,                           /* Number of fuzz, does not overflow*/
       depth,                            /* Path depth                       */
       exec_cksum;                       /* Checksum of the execution trace  */
 
@@ -491,6 +490,9 @@ typedef struct afl_state {
       *virgin_crash;                    /* Bits we haven't seen in crashes  */
 
   u8 *var_bytes;                        /* Bytes that appear to be variable */
+
+  #define n_fuzz_size (1 << 21)
+  u32 *n_fuzz;
 
   volatile u8 stop_soon,                /* Ctrl-C pressed?                  */
       clear_screen;                     /* Window resized?                  */

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -555,19 +555,9 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
     cksum = hash64(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
 
-    struct queue_entry *q = afl->queue;
-    while (q) {
-
-      if (q->exec_cksum == cksum) {
-
-        ++q->n_fuzz;
-        break;
-
-      }
-
-      q = q->next;
-
-    }
+    /* Saturated increment */
+    if (afl->n_fuzz[cksum % n_fuzz_size] < 0xFFFFFFFF)
+      afl->n_fuzz[cksum % n_fuzz_size]++;
 
   }
 
@@ -609,6 +599,8 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
     else
       afl->queue_top->exec_cksum =
           hash64(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
+
+    afl->n_fuzz[cksum % n_fuzz_size] = 1;
 
     /* Try to calibrate inline; this also calls update_bitmap_score() when
        successful. */

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -729,6 +729,14 @@ void read_testcases(afl_state_t *afl, u8 *directory) {
     add_to_queue(afl, fn2, st.st_size >= MAX_FILE ? MAX_FILE : st.st_size,
                  passed_det);
 
+    if (unlikely(afl->schedule >= FAST && afl->schedule <= RARE)) {
+
+      u64 cksum = hash64(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
+
+      afl->n_fuzz[cksum % n_fuzz_size] = 1;
+
+    }
+
   }
 
   free(nl);                                                  /* not tracked */

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -936,6 +936,13 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+  /* Dynamically allocate memory for AFLFast schedules */
+  if (afl->schedule >= FAST && afl->schedule <= RARE) {
+
+    afl->n_fuzz = ck_alloc(n_fuzz_size * sizeof(u32));
+
+  }
+
   if (get_afl_env("AFL_NO_FORKSRV")) { afl->no_forkserver = 1; }
   if (get_afl_env("AFL_NO_CPU_RED")) { afl->no_cpu_meter_red = 1; }
   if (get_afl_env("AFL_NO_ARITH")) { afl->no_arith = 1; }


### PR DESCRIPTION
1. Patch for #438. The performance hit comes from looping over all seeds to find one that has the same checksum every time a new input is generated. I introduced this performance regression sometime during maintenance, hoping to trade a bit of efficiency for a better memory footprint.
2. Changes the FAST and COE schedules following a recent evaluation on Fuzzbench: (Report: https://github.com/google/fuzzbench/issues/249#issuecomment-700470906 and [[2020-09-25]](https://www.fuzzbench.com/reports/experimental/2020-09-25/index.html) - COE3 and FAST3).