### PR TITLE
fix persistent_demo_new compilation with afl-gcc

### DIFF
--- a/examples/persistent_demo/persistent_demo_new.c
+++ b/examples/persistent_demo/persistent_demo_new.c
@@ -37,7 +37,7 @@ unsigned char fuzz_buf[1024000];
   #define __AFL_FUZZ_TESTCASE_LEN fuzz_len
   #define __AFL_FUZZ_TESTCASE_BUF fuzz_buf
   #define __AFL_FUZZ_INIT() void sync(void);
-  #define __AFL_LOOP(x) ((fuzz_len = read(0, fuzz_buf, sizeof(fuzz_buf))) > 0 ?
+  #define __AFL_LOOP(x) ((fuzz_len = read(0, fuzz_buf, sizeof(fuzz_buf))) > 0)
   #define __AFL_INIT() sync()
 
 #endif


### PR DESCRIPTION
this changes __AFL_LOOP macro defined in persistent_demo_new.c to fix compilation when there is no afl-clang/-fast/-lto available