### PR TITLE
patch invalid free

### DIFF
--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -85,7 +85,6 @@ void detect_file_args(char **argv, u8 *prog_in, u8 *use_stdin) {
 
         }
 
-        ck_free(argv[i]);
         argv[i] = n_arg;
 
       }


### PR DESCRIPTION
Invalid free exists in detect_file_args function. The current code free the stack address, not the heap address.

```
void detect_file_args(char **argv, u8 *prog_in, u8 *use_stdin) {

  u32 i = 0;
  u8  cwd[PATH_MAX];
  if (getcwd(cwd, (size_t)sizeof(cwd)) == NULL) { PFATAL("getcwd() failed"); }

  /* we are working with libc-heap-allocated argvs. So do not mix them with
   * other allocation APIs like ck_alloc. That would disturb the free() calls.
   */
  while (argv[i]) {
/*생략*/
        ck_free(argv[i]);//Bug exists here.
        argv[i] = n_arg;

      }
    }
    i++;
  }
  /* argvs are automatically freed at exit. */
}
```
This bug can be proved by the command line below.

```
➜  ~ afl-analyze -Q -i ./in/asm1 /bin/sh @@ -f ./Makefile
afl-analyze++2.68c by Michal Zalewski
munmap_chunk(): invalid pointer
[1]    7322 abort (core dumped)  afl-analyze -Q -i ./in/asm1 /bin/sh @@ -f ./Makefile
```



valgrind said

```
➜ AFLplusplus git:(stable) valgrind afl-analyze -Q -i ./in/asm1 /bin/sh @@ -f ./Makefile
==19616== Memcheck, a memory error detector
==19616== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==19616== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==19616== Command: afl-analyze -Q -i ./in/asm1 /bin/sh @@ -f ./Makefile
==19616==
afl-analyze++2.68c by Michal Zalewski
==19616== Invalid free() / delete / delete[] / realloc()
==19616== at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19616== by 0x10C8F8: DFL_ck_free (alloc-inl.h:117)
==19616== by 0x10C8F8: detect_file_args.constprop.2 (afl-common.c:88)
==19616== by 0x10AB50: main (afl-analyze.c:1086)
==19616== Address 0x1fff00072f is on thread 1's stack
==19616==

[-] Oops, unable to find the 'afl-qemu-trace' binary. The binary must be built
separately by following the instructions in qemu_mode/README.md. If you
already have the binary installed, you may need to specify AFL_PATH in the
environment.

"Of course, even without QEMU, afl-fuzz can still work with binaries that are
instrumented at compile time with afl-gcc. It is also possible to use it as a
traditional non-instrumented fuzzer by specifying '-n' in the command line.

"

[-] PROGRAM ABORT : Failed to locate 'afl-qemu-trace'.
Location : get_qemu_argv(), src/afl-common.c:219

==19616==
==19616== HEAP SUMMARY:
==19616== in use at exit: 148 bytes in 4 blocks
==19616== total heap usage: 19 allocs, 16 frees, 2,781 bytes allocated
==19616==
==19616== LEAK SUMMARY:
==19616== definitely lost: 0 bytes in 0 blocks
==19616== indirectly lost: 0 bytes in 0 blocks
==19616== possibly lost: 0 bytes in 0 blocks
==19616== still reachable: 148 bytes in 4 blocks
==19616== suppressed: 0 bytes in 0 blocks
==19616== Rerun with --leak-check=full to see details of leaked memory
==19616==
==19616== For counts of detected and suppressed errors, rerun with: -v
==19616== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
