### PR TITLE
qemu argv index was still wrong

### DIFF
--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -146,7 +146,7 @@ char **get_qemu_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
   u8 *   tmp, *cp = NULL, *rsl, *own_copy;
 
   memcpy(&new_argv[3], &argv[1], (int)(sizeof(char *)) * (argc - 1));
-  new_argv[argc + 2] = NULL;
+  new_argv[argc + 3] = NULL;
 
   new_argv[2] = *target_path_p;
   new_argv[1] = "--";


### PR DESCRIPTION
Copy and paste error from previous "fix" resulted in wrong index. Should be the last one, not next to last.