### PR TITLE
add gnuplot and afl-dyninst shared libs to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN apt-get update && \
     gnuplot-nox \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main >> /etc/apt/sources.list && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 
-  
-RUN echo deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main >> /etc/apt/sources.list && \
+RUN echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >> /etc/apt/sources.list && \
+    wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" >> /etc/apt/sources.list && \
     apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 1E9377A2BA9EF27F
 
 RUN apt-get update && apt-get full-upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && apt-get upgrade -y && \
     libglib2.0-dev \
     wget vim jupp nano bash-completion \
     apt-utils apt-transport-https ca-certificates gnupg dialog \
-    libpixman-1-dev
+    libpixman-1-dev \
+    gnuplot-nox
 
 RUN echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main >> /etc/apt/sources.list && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "about"="AFLplusplus docker image"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && \
     apt-get -y install --no-install-suggests --no-install-recommends \
     automake \
     bison flex \
@@ -23,24 +23,24 @@ RUN apt-get update && apt-get upgrade -y && \
     wget vim jupp nano bash-completion \
     apt-utils apt-transport-https ca-certificates gnupg dialog \
     libpixman-1-dev \
-    gnuplot-nox
+    gnuplot-nox \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main >> /etc/apt/sources.list && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 
   
 RUN echo deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main >> /etc/apt/sources.list && \
     apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 1E9377A2BA9EF27F
-    
-RUN apt-get update && apt-get upgrade -y
 
-RUN apt-get install -y gcc-10 g++-10 gcc-10-plugin-dev gcc-10-multilib \
-    libc++-10-dev gdb lcov
-
-RUN apt-get install -y clang-11 clang-tools-11 libc++1-11 libc++-11-dev \
+RUN apt-get update && apt-get full-upgrade -y && \
+    apt-get -y install --no-install-suggests --no-install-recommends \
+    gcc-10 g++-10 gcc-10-plugin-dev gcc-10-multilib libc++-10-dev gdb lcov \
+    clang-11 clang-tools-11 libc++1-11 libc++-11-dev \
     libc++abi1-11 libc++abi-11-dev libclang1-11 libclang-11-dev \
     libclang-common-11-dev libclang-cpp11 libclang-cpp11-dev liblld-11 \
     liblld-11-dev liblldb-11 liblldb-11-dev libllvm11 libomp-11-dev \
-    libomp5-11 lld-11 lldb-11 llvm-11 llvm-11-dev llvm-11-runtime llvm-11-tools
+    libomp5-11 lld-11 lldb-11 llvm-11 llvm-11-dev llvm-11-runtime llvm-11-tools \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 0
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile for AFLplusplus uses Ubuntu 20.04 focal and
 # installs LLVM 11 from llvm.org for afl-clang-lto support :-)
 # It also installs gcc/g++ 10 from the Ubuntu development platform
-# has focal has gcc-10 but not g++-10 ...
+# since focal has gcc-10 but not g++-10 ...
 #
 
 FROM ubuntu:20.04 AS aflplusplus

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,3 +61,6 @@ RUN export REAL_CXX=g++-10 && export CC=gcc-10 && \
 RUN echo 'alias joe="jupp --wordwrap"' >> ~/.bashrc
 RUN echo 'export PS1="[afl++]$PS1"' >> ~/.bashrc
 ENV IS_DOCKER="1"
+
+COPY --from=aflplusplus/afl-dyninst /usr/local/lib/libdyninstAPI_RT.so /usr/local/lib/libdyninstAPI_RT.so
+COPY --from=aflplusplus/afl-dyninst /afl-dyninst/libAflDyninst.so /usr/local/lib/libAflDyninst.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 
 FROM ubuntu:20.04 AS aflplusplus
-MAINTAINER afl++ team <afl@aflplus.plus>
+LABEL "maintainer"="afl++ team <afl@aflplus.plus>"
 LABEL "about"="AFLplusplus docker image"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN apt-get update && apt-get full-upgrade -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 0
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 0
 
-RUN rm -rf /var/cache/apt/archives/*
-
 ENV LLVM_CONFIG=llvm-config-11
 ENV AFL_SKIP_CPUFREQ=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main
 
 RUN apt-get update && apt-get full-upgrade -y && \
     apt-get -y install --no-install-suggests --no-install-recommends \
-    gcc-10 g++-10 gcc-10-plugin-dev gcc-10-multilib libc++-10-dev gdb lcov \
+    gcc-10 g++-10 gcc-10-plugin-dev gcc-10-multilib gdb lcov \
     clang-11 clang-tools-11 libc++1-11 libc++-11-dev \
     libc++abi1-11 libc++abi-11-dev libclang1-11 libclang-11-dev \
     libclang-common-11-dev libclang-cpp11 libclang-cpp11-dev liblld-11 \

--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,14 @@ tasks, fuzzing may put a strain on your hardware and on the OS. In particular:
     $ iostat -d 3 -x -k [...optional disk ID...]
 ```
 
+    Using the `AFL_TMPDIR` environment variable and a RAM-disk you can have the
+    heavy writing done in RAM to prevent the aforementioned wear and tear. For
+    example the following line will run a Docker container with all this preset:
+    
+    ```shell
+    # docker run -ti --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk aflplusplus/aflplusplus
+    ```
+
 ## Known limitations & areas for improvement
 
 Here are some of the most important caveats for AFL:

--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ without feedback, bug reports, or patches from:
   Andrea Biondo                         Vincent Le Garrec
   Khaled Yakdan                         Kuang-che Wu
   Josephine Calliotte                   Konrad Welc
-  David Carlier
+  David Carlier                         Ruben ten Hove
 ```
 
 Thank you!

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -1154,7 +1154,7 @@ void show_init_stats(afl_state_t *afl) {
 
   } else {
 
-    OKF("-t option specified. We'll use an exec timeout of %s ms.", fsrv->exec_tmout);
+    OKF("-t option specified. We'll use an exec timeout of %s ms.", afl->fsrv.exec_tmout);
 
   }
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -1152,6 +1152,10 @@ void show_init_stats(afl_state_t *afl) {
     ACTF("Applying timeout settings from resumed session (%u ms).",
          afl->fsrv.exec_tmout);
 
+  } else {
+
+    OKF("-t option specified. We'll use an exec timeout of %s ms.", fsrv->exec_tmout);
+
   }
 
   /* In non-instrumented mode, re-running every timing out test case with a


### PR DESCRIPTION
I've added `gnuplot-nox` to be able to use `afl-plot` in the container. Adds some overhead, but actually makes the plotter usable.

I've also added two (now failing) instructions to COPY `libdyninstAPI_RT.so` and `libAflDyninst.so`, so any binaries instrumented using afl-dyninst can be fuzzed from the container. 
I see this as common enough to not have the user copy those `.so` files into a mounted dir/container, and having to set `LD_LIBRARY_PATH` for every run.
> Also dyninst seems to add a duplicate dependency of `libdyninstAPI_RT.so` with the full path (i.e. `/usr/local/lib/libdyninstAPI_RT`) to the binary, so it really needs to be in that location as well.

To make this work, there needs to be an afl-dyninst image available, which can be setup next to the build of the AFL++ container. I've set it to aflplusplus/afl-dyninst as that seemed a proper name for it.

Also added a bit to the README.md to suggest using tmpfs for input files to lighten the load for local storage devices.

And finally made some minor tweaks to the Dockerfile to clean it up. Commit messages should be self explanatory.