### PR TITLE
Actually make python 'fuzz' method optional

### DIFF
--- a/src/afl-fuzz-python.c
+++ b/src/afl-fuzz-python.c
@@ -329,9 +329,7 @@ struct custom_mutator *load_custom_mutator_py(afl_state_t *afl,
 
   if (py_functions[PY_FUNC_DEINIT]) { mutator->afl_custom_deinit = deinit_py; }
 
-  /* "afl_custom_fuzz" should not be NULL, but the interface of Python mutator
-     is quite different from the custom mutator. */
-  mutator->afl_custom_fuzz = fuzz_py;
+  if (py_functions[PY_FUNC_FUZZ]) { mutator->afl_custom_fuzz = fuzz_py; }
 
   if (py_functions[PY_FUNC_POST_PROCESS]) {
 


### PR DESCRIPTION
The documentation states that the fuzz method is optional, but it crashes if you don't specify one.

Perhaps originally `mutator->afl_custom_fuzz` was not allowed to be NULL? However, that doesn't seem to be the case anymore. Thanks for all your hard work on this!