### PR TITLE
Enable afl-cc to find helper obj from argv[0]

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,6 +22,7 @@ HASH=\#
 PREFIX     ?= /usr/local
 BIN_PATH    = $(PREFIX)/bin
 HELPER_PATH = $(PREFIX)/lib/afl
+BIN2HELPER  = ../lib/afl
 DOC_PATH    = $(PREFIX)/share/doc/afl
 MISC_PATH   = $(PREFIX)/share/afl
 MAN_PATH    = $(PREFIX)/man/man8
@@ -298,7 +299,7 @@ ifdef TEST_MMAP
 endif
 
 .PHONY: all
-all:	test_x86 test_shm test_python ready $(PROGS) afl-as llvm gcc_plugin test_build all_done
+all:	test_x86 test_shm test_python ready $(PROGS) afl-cc.sh afl-as llvm gcc_plugin test_build all_done
 
 .PHONY: llvm
 llvm:
@@ -329,6 +330,10 @@ test-performance:	performance-test
 performance-test:	source-only
 	@cd test ; ./test-performance.sh
 
+
+afl-cc.sh: afl-cc.sh.in
+	@sed "s,@BIN2HELPER@,$(BIN2HELPER),g" < afl-cc.sh.in > afl-cc.shT
+	@mv afl-cc.shT afl-cc.sh
 
 # hint: make targets are also listed in the top level README.md
 .PHONY: help
@@ -623,6 +628,8 @@ install: all $(MANPAGES)
 	@rm -f $${DESTDIR}$(BIN_PATH)/afl-as
 	@rm -f $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt.o $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt-32.o $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt-64.o $${DESTDIR}$(HELPER_PATH)/afl-gcc-rt.o
 	install -m 755 $(PROGS) $(SH_PROGS) $${DESTDIR}$(BIN_PATH)
+	install -m 755 afl-cc.sh $${DESTDIR}$(BIN_PATH)/afl-cc
+	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-c++
 	@if [ -f afl-qemu-trace ]; then install -m 755 afl-qemu-trace $${DESTDIR}$(BIN_PATH); fi
 	@if [ -f libdislocator.so ]; then set -e; install -m 755 libdislocator.so $${DESTDIR}$(HELPER_PATH); fi
 	@if [ -f libtokencap.so ]; then set -e; install -m 755 libtokencap.so $${DESTDIR}$(HELPER_PATH); fi
@@ -639,6 +646,8 @@ install: all $(MANPAGES)
 	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-g++
 	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang
 	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang++
+	ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-gcc
+	ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-g++
 	@mkdir -m 0755 -p ${DESTDIR}$(MAN_PATH)
 	install -m0644 *.8 ${DESTDIR}$(MAN_PATH)
 	install -m 755 afl-as $${DESTDIR}$(HELPER_PATH)

--- a/GNUmakefile.gcc_plugin
+++ b/GNUmakefile.gcc_plugin
@@ -175,6 +175,8 @@ all_done: test_build
 install: all
 	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-gcc-fast
 	ln -sf afl-c++ $${DESTDIR}$(BIN_PATH)/afl-g++-fast
+	ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-gcc-fast
+	ln -sf afl-c++ $${DESTDIR}$(HELPER_PATH)/afl-g++-fast
 	ln -sf afl-compiler-rt.o $${DESTDIR}$(HELPER_PATH)/afl-gcc-rt.o
 	install -m 755 ./afl-gcc-pass.so $${DESTDIR}$(HELPER_PATH)
 	install -m 644 -T instrumentation/README.gcc_plugin.md $${DESTDIR}$(DOC_PATH)/README.gcc_plugin.md

--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -468,7 +468,7 @@ all_done: test_build
 .PHONY: install
 install: all
 	@install -d -m 755 $${DESTDIR}$(BIN_PATH) $${DESTDIR}$(HELPER_PATH) $${DESTDIR}$(DOC_PATH) $${DESTDIR}$(MISC_PATH)
-	@if [ -f ./afl-cc ]; then set -e; install -m 755 ./afl-cc $${DESTDIR}$(BIN_PATH); ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-c++; fi
+	@if [ -f ./afl-cc ]; then set -e; install -m 755 ./afl-cc $${DESTDIR}$(HELPER_PATH); ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-c++; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-c++; fi
 	@rm -f $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt*.o $${DESTDIR}$(HELPER_PATH)/afl-gcc-rt*.o
 	@if [ -f ./afl-compiler-rt.o ]; then set -e; install -m 755 ./afl-compiler-rt.o $${DESTDIR}$(HELPER_PATH); ln -sf afl-compiler-rt.o $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt.o ;fi
 	@if [ -f ./afl-lto ]; then set -e; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-lto; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-lto++; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang-lto; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang-lto++; install -m 755 ./afl-llvm-lto-instrumentation.so ./afl-llvm-rt-lto*.o ./afl-llvm-lto-instrumentlist.so $${DESTDIR}$(HELPER_PATH); fi
@@ -478,6 +478,8 @@ install: all
 	@if [ -f ./compare-transform-pass.so ]; then set -e; install -m 755 ./*.so $${DESTDIR}$(HELPER_PATH); fi
 	@if [ -f ./compare-transform-pass.so ]; then set -e; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang-fast ; ln -sf ./afl-c++ $${DESTDIR}$(BIN_PATH)/afl-clang-fast++ ; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang ; ln -sf ./afl-c++ $${DESTDIR}$(BIN_PATH)/afl-clang++ ; fi
 	@if [ -f ./SanitizerCoverageLTO.so ]; then set -e; ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-clang-lto ; ln -sf ./afl-c++ $${DESTDIR}$(BIN_PATH)/afl-clang-lto++ ; fi
+	@if [ -f ./compare-transform-pass.so ]; then set -e; ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-clang-fast ; ln -sf ./afl-c++ $${DESTDIR}$(HELPER_PATH)/afl-clang-fast++ ; ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-clang ; ln -sf ./afl-c++ $${DESTDIR}$(BIN_PATH)/afl-clang++ ; fi
+	@if [ -f ./SanitizerCoverageLTO.so ]; then set -e; ln -sf afl-cc $${DESTDIR}$(HELPER_PATH)/afl-clang-lto ; ln -sf ./afl-c++ $${DESTDIR}$(HELPER_PATH)/afl-clang-lto++ ; fi
 	set -e; install -m 644 ./dynamic_list.txt $${DESTDIR}$(HELPER_PATH)
 	install -m 644 instrumentation/README.*.md $${DESTDIR}$(DOC_PATH)/
 

--- a/afl-cc.sh.in
+++ b/afl-cc.sh.in
@@ -1,0 +1,5 @@
+#! /bin/sh
+# This script is to be installed in BIN_PATH, to reexec the actual
+# executable in HELPER_PATH with an argv[0] that enables it to find
+# other helper files.
+exec `echo "$0" | sed 's,/*[^/]*$,,;s,^$,.,'`/@BIN2HELPER@/`echo "$0" | sed 's,^.*/,,'` ${1+"$@"}


### PR DESCRIPTION
Installed wrapper scripts in BIN_PATH, that re-execute the programs with a resolved path in HELPER_PATH, so that they can then use argv[0]'s dirname to find helper files.

This allows the afl-cc script installed in BIN_PATH to be replaced with a symlink to $(BIN2HELPER)/afl-cc to avoid the tiny overhead of the wrapper, at the expense of having to set AFL_PATH to HELPER_PATH in case the install tree is relocated.