### PR TITLE
Remove binary-only target's depend on source tools

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -586,7 +586,7 @@ distrib: all
 	-cd unicorn_mode && unset CFLAGS && sh ./build_unicorn_support.sh
 
 .PHONY: binary-only
-binary-only: all
+binary-only: $(PROGS)
 	$(MAKE) -C utils/libdislocator
 	$(MAKE) -C utils/libtokencap
 	$(MAKE) -C utils/afl_network_proxy

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -586,7 +586,7 @@ distrib: all
 	-cd unicorn_mode && unset CFLAGS && sh ./build_unicorn_support.sh
 
 .PHONY: binary-only
-binary-only: $(PROGS)
+binary-only: test_shm test_python ready $(PROGS)
 	$(MAKE) -C utils/libdislocator
 	$(MAKE) -C utils/libtokencap
 	$(MAKE) -C utils/afl_network_proxy


### PR DESCRIPTION
The `binary-only` target currently depends on the `all` target which
always build the source tools, such as afl-cc and afl-as.  This is
unnecessary if the user specifically is asking for only binary fuzzing
tools.