### PR TITLE
Update documentation to reflect new default power schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ For every secondary fuzzer there should be a variation, e.g.:
 All other secondaries should be used like this:
  * A third to a half with the MOpt mutator enabled: `-L 0`
  * run with a different power schedule, available are:
-   `explore (default), fast, coe, lin, quad, exploit, mmopt, rare, seek`
+   `fast (default), explore, coe, lin, quad, exploit, mmopt, rare, seek`
    which you can set with e.g. `-p seek`
 
 You can also use different fuzzers.

--- a/docs/power_schedules.md
+++ b/docs/power_schedules.md
@@ -13,8 +13,8 @@ We find that AFL's exploitation-based constant schedule assigns **too much energ
 
 | AFL flag | Power Schedule             | 
 | ------------- | -------------------------- |
-| `-p explore` (default)| ![EXPLORE](http://latex.codecogs.com/gif.latex?p%28i%29%3D%5Cfrac%7B%5Calpha%28i%29%7D%7B%5Cbeta%7D) |
-| `-p fast` | ![FAST](http://latex.codecogs.com/gif.latex?p(i)=\\min\\left(\\frac{\\alpha(i)}{\\beta}\\cdot\\frac{2^{s(i)}}{f(i)},M\\right))  |
+| `-p explore` | ![EXPLORE](http://latex.codecogs.com/gif.latex?p%28i%29%3D%5Cfrac%7B%5Calpha%28i%29%7D%7B%5Cbeta%7D) |
+| `-p fast` (default)| ![FAST](http://latex.codecogs.com/gif.latex?p(i)=\\min\\left(\\frac{\\alpha(i)}{\\beta}\\cdot\\frac{2^{s(i)}}{f(i)},M\\right))  |
 | `-p coe` | ![COE](http://latex.codecogs.com/gif.latex?p%28i%29%3D%5Cbegin%7Bcases%7D%200%20%26%20%5Ctext%7B%20if%20%7D%20f%28i%29%20%3E%20%5Cmu%5C%5C%20%5Cmin%5Cleft%28%5Cfrac%7B%5Calpha%28i%29%7D%7B%5Cbeta%7D%5Ccdot%202%5E%7Bs%28i%29%7D%2C%20M%5Cright%29%20%26%20%5Ctext%7B%20otherwise.%7D%20%5Cend%7Bcases%7D) |
 | `-p quad` | ![QUAD](http://latex.codecogs.com/gif.latex?p%28i%29%20%3D%20%5Cmin%5Cleft%28%5Cfrac%7B%5Calpha%28i%29%7D%7B%5Cbeta%7D%5Ccdot%5Cfrac%7Bs%28i%29%5E2%7D%7Bf%28i%29%7D%2CM%5Cright%29) |
 | `-p lin` | ![LIN](http://latex.codecogs.com/gif.latex?p%28i%29%20%3D%20%5Cmin%5Cleft%28%5Cfrac%7B%5Calpha%28i%29%7D%7B%5Cbeta%7D%5Ccdot%5Cfrac%7Bs%28i%29%7D%7Bf%28i%29%7D%2CM%5Cright%29) |

--- a/docs/status_screen.md
+++ b/docs/status_screen.md
@@ -29,13 +29,18 @@ With that out of the way, let's talk about what's actually on the screen...
 
 ### The status bar
 
+```
+american fuzzy lop ++3.01a (default) [fast] {0}
+```
+
 The top line shows you which mode afl-fuzz is running in
 (normal: "american fuzy lop", crash exploration mode: "peruvian rabbit mode")
 and the version of afl++.
 Next to the version is the banner, which, if not set with -T by hand, will
 either show the binary name being fuzzed, or the -M/-S main/secondary name for
 parallel fuzzing.
-Finally, the last item is the power schedule mode being run (default: explore).
+Second to last is the power schedule mode being run (default: fast).
+Finally, the last item is the CPU id. 
 
 ### Process timing
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -103,8 +103,8 @@ static void usage(u8 *argv0, int more_help) {
 
       "Execution control settings:\n"
       "  -p schedule   - power schedules compute a seed's performance score:\n"
-      "                  <explore(default), rare, exploit, seek, mmopt, coe, "
-      "fast,\n"
+      "                  <fast(default), rare, exploit, seek, mmopt, coe, "
+      "explore,\n"
       "                  lin, quad> -- see docs/power_schedules.md\n"
       "  -f file       - location read by the fuzzed program (default: stdin "
       "or @@)\n"


### PR DESCRIPTION
afl++ v3.0 changed the default power schedule from explore to default. This has not been updated everywhere. 
Furthermore the  status bar of the status screen contains the CPU id which was not mentioned earlier. 