### PR TITLE
Bug 703 wrong src attribute in sync stage filenames

### DIFF
--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -627,9 +627,8 @@ void sync_fuzzers(afl_state_t *afl) {
     }
 
     if (m >= n) { goto close_sync; }  // nothing new
-    o = n - 1;
 
-    while (o >= m) {
+    for (o = m; o < n; o++) {
 
       s32         fd;
       struct stat st;
@@ -637,7 +636,6 @@ void sync_fuzzers(afl_state_t *afl) {
       snprintf(path, sizeof(path), "%s/%s", qd_path, namelist[o]->d_name);
       afl->syncing_case = next_min_accept;
       next_min_accept++;
-      o--;
 
       /* Allow this to fail in case the other fuzzer is resuming or so... */
 


### PR DESCRIPTION
The src attribute on sync stage filenames is wrong, pr fixes this, bug #703 