### PR TITLE
Clarify usage of LD_LIBRARY_PATH in afl_frida

### DIFF
--- a/utils/afl_frida/README.md
+++ b/utils/afl_frida/README.md
@@ -20,7 +20,7 @@ search and edit the `STEP 1`, `STEP 2` and `STEP 3` locations.
 
 Example (after modifying afl-frida.c to your needs and compile it):
 ```
-LD_LIBRARY_PATH=/path/to/the/target/library afl-fuzz -i in -o out -- ./afl-frida
+LD_LIBRARY_PATH=/path/to/the/target/library/ afl-fuzz -i in -o out -- ./afl-frida
 ```
 (or even remote via afl-network-proxy).
 


### PR DESCRIPTION
This will help not *accidentally* trying to set the variable to the library's binary.