### PR TITLE
Fix for off by one in libqasan's memmem

### DIFF
--- a/qemu_mode/libqasan/string.c
+++ b/qemu_mode/libqasan/string.c
@@ -271,7 +271,7 @@ void *__libqasan_memmem(const void *haystack, size_t haystack_len,
 
     }
 
-  } while (h++ <= end);
+  } while (++h <= end);
 
   return 0;
 


### PR DESCRIPTION
Off by one error resulted in memmem calling memcmp where h + needle_len is one past the end. libqasan then detected and flagged itself in the case I hit.