### PR TITLE
load existing stats file when in AFL_AUTORESUME or -i - mode.

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1067,7 +1067,7 @@ void destroy_extras(afl_state_t *);
 
 /* Stats */
 
-void load_stats_file(afl_state_t *);
+u32  load_stats_file(afl_state_t *);
 void write_setup_file(afl_state_t *, u32, char **);
 void write_stats_file(afl_state_t *, double, double, double);
 void maybe_update_plot_file(afl_state_t *, double, double);

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -425,7 +425,8 @@ typedef struct afl_state {
     really makes no sense to haul them around as function parameters. */
   u64 orig_hit_cnt_puppet, last_limit_time_start, tmp_pilot_time,
       total_pacemaker_time, total_puppet_find, temp_puppet_find, most_time_key,
-      most_time, most_execs_key, most_execs, old_hit_count, force_ui_update;
+      most_time, most_execs_key, most_execs, old_hit_count, force_ui_update,
+      prev_run_time;
 
   MOpt_globals_t mopt_globals_core, mopt_globals_pilot;
 
@@ -569,7 +570,6 @@ typedef struct afl_state {
       blocks_eff_total,                 /* Blocks subject to effector maps  */
       blocks_eff_select,                /* Blocks selected as fuzzable      */
       start_time,                       /* Unix start time (ms)             */
-      prev_run_time,                    /* Runtime read from prev stats file*/
       last_path_time,                   /* Time for most recent path (ms)   */
       last_crash_time,                  /* Time for most recent crash (ms)  */
       last_hang_time;                   /* Time for most recent hang (ms)   */

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -569,6 +569,7 @@ typedef struct afl_state {
       blocks_eff_total,                 /* Blocks subject to effector maps  */
       blocks_eff_select,                /* Blocks selected as fuzzable      */
       start_time,                       /* Unix start time (ms)             */
+      prev_run_time,                    /* Runtime read from prev stats file*/
       last_path_time,                   /* Time for most recent path (ms)   */
       last_crash_time,                  /* Time for most recent crash (ms)  */
       last_hang_time;                   /* Time for most recent hang (ms)   */
@@ -1067,7 +1068,7 @@ void destroy_extras(afl_state_t *);
 
 /* Stats */
 
-u32  load_stats_file(afl_state_t *);
+void load_stats_file(afl_state_t *);
 void write_setup_file(afl_state_t *, u32, char **);
 void write_stats_file(afl_state_t *, double, double, double);
 void maybe_update_plot_file(afl_state_t *, double, double);

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1067,6 +1067,7 @@ void destroy_extras(afl_state_t *);
 
 /* Stats */
 
+void load_stats_file(afl_state_t *);
 void write_setup_file(afl_state_t *, u32, char **);
 void write_stats_file(afl_state_t *, double, double, double);
 void maybe_update_plot_file(afl_state_t *, double, double);

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -90,20 +90,20 @@ void write_setup_file(afl_state_t *afl, u32 argc, char **argv) {
 }
 
 /* load some of the existing stats file when resuming.*/
-u32 load_stats_file(afl_state_t *afl) {
+void load_stats_file(afl_state_t *afl) {
 
   FILE *f;
   u8    buf[MAX_LINE];
   u8 *  lptr;
   u8    fn[PATH_MAX];
   u32   lineno = 0;
-  u32   prev_run_time = 0;
+  afl->prev_run_time = 0;
   snprintf(fn, PATH_MAX, "%s/fuzzer_stats", afl->out_dir);
   f = fopen(fn, "r");
   if (!f) {
 
     WARNF("Unable to load stats file '%s'", fn);
-    return prev_run_time;
+    return;
 
   }
 
@@ -137,8 +137,8 @@ u32 load_stats_file(afl_state_t *afl) {
         case 3:
           if (!strcmp(keystring, "run_time          ")) {
 
-            prev_run_time = 1000 * strtoull(lptr, &nptr, 10);
-            afl->start_time -= prev_run_time;
+            afl->prev_run_time = 1000 * strtoull(lptr, &nptr, 10);
+            afl->start_time -= afl->prev_run_time;
 
           }
 
@@ -185,7 +185,7 @@ u32 load_stats_file(afl_state_t *afl) {
 
   }
 
-  return prev_run_time;
+  return;
 
 }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1682,8 +1682,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (unlikely(afl->old_seed_selection)) seek_to = find_start_position(afl);
 
-  afl->start_time = get_cur_time();  // without this, time taken for
-                                     // perform_dry_run gets added to run time.
+  afl->start_time = get_cur_time();
   if (afl->in_place_resume || afl->afl_env.afl_autoresume) load_stats_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
@@ -1703,8 +1702,6 @@ int main(int argc, char **argv_orig, char **envp) {
   // (void)nice(-20);  // does not improve the speed
   // real start time, we reset, so this works correctly with -V
   afl->start_time = get_cur_time();
-  if (afl->in_place_resume || afl->afl_env.afl_autoresume)
-    afl->start_time -= afl->prev_run_time;
 
   u32 runs_in_current_cycle = (u32)-1;
   u32 prev_queued_paths = 0;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1682,6 +1682,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (unlikely(afl->old_seed_selection)) seek_to = find_start_position(afl);
 
+  if (afl->in_place_resume || afl->afl_env.afl_autoresume) load_stats_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1682,7 +1682,11 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (unlikely(afl->old_seed_selection)) seek_to = find_start_position(afl);
 
-  if (afl->in_place_resume || afl->afl_env.afl_autoresume) load_stats_file(afl);
+  u32 prev_run_time = 0;  // to not call load_stats_file again after line 1705
+  afl->start_time = get_cur_time();  // without this, time taken for
+                                     // perform_dry_run gets added to run time.
+  if (afl->in_place_resume || afl->afl_env.afl_autoresume)
+    prev_run_time = load_stats_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);
@@ -1701,6 +1705,8 @@ int main(int argc, char **argv_orig, char **envp) {
   // (void)nice(-20);  // does not improve the speed
   // real start time, we reset, so this works correctly with -V
   afl->start_time = get_cur_time();
+  if (afl->in_place_resume || afl->afl_env.afl_autoresume)
+    afl->start_time -= prev_run_time;
 
   u32 runs_in_current_cycle = (u32)-1;
   u32 prev_queued_paths = 0;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1682,11 +1682,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (unlikely(afl->old_seed_selection)) seek_to = find_start_position(afl);
 
-  u32 prev_run_time = 0;  // to not call load_stats_file again after line 1705
   afl->start_time = get_cur_time();  // without this, time taken for
                                      // perform_dry_run gets added to run time.
-  if (afl->in_place_resume || afl->afl_env.afl_autoresume)
-    prev_run_time = load_stats_file(afl);
+  if (afl->in_place_resume || afl->afl_env.afl_autoresume) load_stats_file(afl);
   write_stats_file(afl, 0, 0, 0);
   maybe_update_plot_file(afl, 0, 0);
   save_auto(afl);
@@ -1706,7 +1704,7 @@ int main(int argc, char **argv_orig, char **envp) {
   // real start time, we reset, so this works correctly with -V
   afl->start_time = get_cur_time();
   if (afl->in_place_resume || afl->afl_env.afl_autoresume)
-    afl->start_time -= prev_run_time;
+    afl->start_time -= afl->prev_run_time;
 
   u32 runs_in_current_cycle = (u32)-1;
   u32 prev_queued_paths = 0;


### PR DESCRIPTION
Hi, this is my first PR here :) 
It loads some of the variables in the stats file when using AFL_AUTORESUME or "-i -" . ( issue #274  )
It can load the following fields on status screen:
Overall Results:
- cycles done
- total paths
- uniq crashes
- uniq hangs
Findings in Depth:
- favored paths
Path Geometry:
- levels
- pending
- pend fav
- own finds
- imported
