### PR TITLE
Use GitHub Actions to build Docker image

### DIFF
--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -1,0 +1,27 @@
+name: Publish Docker Images
+on:
+  push:
+    branches: [ stable, dev ]
+    paths:
+    - Dockerfile
+  pull_request:
+    branches: [ stable, dev ]
+    paths:
+    - Dockerfile
+jobs:
+  push_to_registry:
+    name: Push Docker images to Dockerhub
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Login to Dockerhub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+    - name: Publish afl_for_r2 to Registry
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: teamconclusion/aflplusplus:latest


### PR DESCRIPTION
Relates to #662: Adds a GitHub Action to build the docker image, then push it to [hub.docker.com/u/aflplusplus](https://hub.docker.com/u/aflplusplus).

For the action to work, you will need to add `DOCKER_USERNAME` set to `aflplusplus` and `DOCKER_TOKEN` to a value created using https://hub.docker.com/settings/security (while logged in as `aflplusplus`).

Built successfully from my fork and deployed to https://hub.docker.com/r/teamconclusion/aflplusplus .