### PR TITLE
CMPLOG llvm pass: use CreateIntCast to cast to the right integer type

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -49,7 +49,6 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
       CLANG for old afl-clang
     - fixed a potential crash in the LAF feature
     - workaround for llvm 13
-    - workaround for llvm internal lto bug that lets not bitcast from _ExtInt()
   - qemuafl
     - QASan (address sanitizer for Qemu) ported to qemuafl!
       See qemu_mode/libqasan/README.md

--- a/include/envs.h
+++ b/include/envs.h
@@ -16,7 +16,6 @@ static char *afl_environment_deprecated[] = {
 
 static char *afl_environment_variables[] = {
 
-    "_AFL_LTO_COMPILE",
     "AFL_ALIGNED_ALLOC",
     "AFL_ALLOW_TMP",
     "AFL_ANALYZE_HEX",

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -19,12 +19,13 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <iostream>
 #include <list>
 #include <string>
 #include <fstream>
 #include <sys/time.h>
-#include "llvm/Config/llvm-config.h"
 
+#include "llvm/Config/llvm-config.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -323,38 +324,8 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
       Value *CompareTo = Val;
 
       if (do_cast) {
-
-        ConstantInt *cint = dyn_cast<ConstantInt>(Val);
-        if (cint) {
-
-          uint64_t val = cint->getZExtValue();
-          // fprintf(stderr, "ConstantInt: %lu\n", val);
-          switch (cast_size) {
-
-            case 8:
-              CompareTo = ConstantInt::get(Int8Ty, val);
-              break;
-            case 16:
-              CompareTo = ConstantInt::get(Int16Ty, val);
-              break;
-            case 32:
-              CompareTo = ConstantInt::get(Int32Ty, val);
-              break;
-            case 64:
-              CompareTo = ConstantInt::get(Int64Ty, val);
-              break;
-            case 128:
-              CompareTo = ConstantInt::get(Int128Ty, val);
-              break;
-
-          }
-
-        } else {
-
-          CompareTo = IRB.CreateBitCast(Val, IntegerType::get(C, cast_size));
-
-        }
-
+        CompareTo =
+            IRB.CreateIntCast(CompareTo, IntegerType::get(C, cast_size), false);
       }
 
       for (SwitchInst::CaseIt i = SI->case_begin(), e = SI->case_end(); i != e;
@@ -374,29 +345,8 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
           Value *new_param = cint;
 
           if (do_cast) {
-
-            uint64_t val = cint->getZExtValue();
-            // fprintf(stderr, "ConstantInt: %lu\n", val);
-            switch (cast_size) {
-
-              case 8:
-                new_param = ConstantInt::get(Int8Ty, val);
-                break;
-              case 16:
-                new_param = ConstantInt::get(Int16Ty, val);
-                break;
-              case 32:
-                new_param = ConstantInt::get(Int32Ty, val);
-                break;
-              case 64:
-                new_param = ConstantInt::get(Int64Ty, val);
-                break;
-              case 128:
-                new_param = ConstantInt::get(Int128Ty, val);
-                break;
-
-            }
-
+            new_param =
+                IRB.CreateIntCast(cint, IntegerType::get(C, cast_size), false);
           }
 
           if (new_param) {
@@ -604,88 +554,27 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
 
       }
 
-      if (do_cast) {
+      // errs() << "[CMPLOG] cmp  " << *cmpInst << "(in function " <<
+      // cmpInst->getFunction()->getName() << ")\n";
 
-        // F*cking LLVM optimized out any kind of bitcasts of ConstantInt values
-        // creating illegal calls. WTF. So we have to work around this.
+      // first bitcast to integer type of the same bitsize as the original
+      // type (this is a nop, if already integer)
+      Value *op0_i = IRB.CreateBitCast(
+          op0, IntegerType::get(C, op0->getType()->getPrimitiveSizeInBits()));
+      // then create a int cast, which does zext, trunc or bitcast. In our case
+      // usually zext to the next larger supported type (this is a nop if
+      // already the right type)
+      Value *V0 =
+          IRB.CreateIntCast(op0_i, IntegerType::get(C, cast_size), false);
+      args.push_back(V0);
+      Value *op1_i = IRB.CreateBitCast(
+          op1, IntegerType::get(C, op1->getType()->getPrimitiveSizeInBits()));
+      Value *V1 =
+          IRB.CreateIntCast(op1_i, IntegerType::get(C, cast_size), false);
+      args.push_back(V1);
 
-        ConstantInt *cint = dyn_cast<ConstantInt>(op0);
-        if (cint) {
-
-          uint64_t val = cint->getZExtValue();
-          // fprintf(stderr, "ConstantInt: %lu\n", val);
-          ConstantInt *new_param = NULL;
-          switch (cast_size) {
-
-            case 8:
-              new_param = ConstantInt::get(Int8Ty, val);
-              break;
-            case 16:
-              new_param = ConstantInt::get(Int16Ty, val);
-              break;
-            case 32:
-              new_param = ConstantInt::get(Int32Ty, val);
-              break;
-            case 64:
-              new_param = ConstantInt::get(Int64Ty, val);
-              break;
-            case 128:
-              new_param = ConstantInt::get(Int128Ty, val);
-              break;
-
-          }
-
-          if (!new_param) { continue; }
-          args.push_back(new_param);
-
-        } else {
-
-          Value *V0 = IRB.CreateBitCast(op0, IntegerType::get(C, cast_size));
-          args.push_back(V0);
-
-        }
-
-        cint = dyn_cast<ConstantInt>(op1);
-        if (cint) {
-
-          uint64_t     val = cint->getZExtValue();
-          ConstantInt *new_param = NULL;
-          switch (cast_size) {
-
-            case 8:
-              new_param = ConstantInt::get(Int8Ty, val);
-              break;
-            case 16:
-              new_param = ConstantInt::get(Int16Ty, val);
-              break;
-            case 32:
-              new_param = ConstantInt::get(Int32Ty, val);
-              break;
-            case 64:
-              new_param = ConstantInt::get(Int64Ty, val);
-              break;
-            case 128:
-              new_param = ConstantInt::get(Int128Ty, val);
-              break;
-
-          }
-
-          if (!new_param) { continue; }
-          args.push_back(new_param);
-
-        } else {
-
-          Value *V1 = IRB.CreateBitCast(op1, IntegerType::get(C, cast_size));
-          args.push_back(V1);
-
-        }
-
-      } else {
-
-        args.push_back(op0);
-        args.push_back(op1);
-
-      }
+      // errs() << "[CMPLOG] casted parameters:\n0: " << *V0 << "\n1: " << *V1
+      // << "\n";
 
       ConstantInt *attribute = ConstantInt::get(Int8Ty, attr);
       args.push_back(attribute);

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -114,8 +114,6 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
   IntegerType *Int64Ty = IntegerType::getInt64Ty(C);
   IntegerType *Int128Ty = IntegerType::getInt128Ty(C);
 
-  char *is_lto = getenv("_AFL_LTO_COMPILE");
-
 #if LLVM_VERSION_MAJOR < 9
   Constant *
 #else
@@ -268,20 +266,10 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
       unsigned int  max_size = Val->getType()->getIntegerBitWidth(), cast_size;
       unsigned char do_cast = 0;
 
-      if (!SI->getNumCases() || max_size < 16) { continue; }
+      if (!SI->getNumCases() || max_size < 16 || max_size % 8) {
 
-      if (max_size % 8) {
-
-        if (is_lto) {
-
-          continue;  // LTO cannot bitcast from _ExtInt() :(
-
-        } else {
-
-          max_size = (((max_size / 8) + 1) * 8);
-          do_cast = 1;
-
-        }
+        // if (!be_quiet) errs() << "skip trivial switch..\n";
+        continue;
 
       }
 
@@ -298,7 +286,6 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
 
         }
 
-        if (is_lto) { continue; }  // LTO cannot bitcast _ExtInt() :(
         max_size = 128;
         do_cast = 1;
 
@@ -315,7 +302,6 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
           cast_size = max_size;
           break;
         default:
-          if (is_lto) { continue; }  // LTO cannot bitcast _ExtInt() :(
           cast_size = 128;
           do_cast = 1;
 
@@ -504,22 +490,7 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
 
       }
 
-      if (!max_size || max_size < 16) { continue; }
-
-      if (max_size % 8) {
-
-        if (is_lto) {
-
-          continue;  // LTO cannot bitcast from _ExtInt() :(
-
-        } else {
-
-          max_size = (((max_size / 8) + 1) * 8);
-          do_cast = 1;
-
-        }
-
-      }
+      if (!max_size || max_size % 8 || max_size < 16) { continue; }
 
       if (max_size > 128) {
 
@@ -531,7 +502,6 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
 
         }
 
-        if (is_lto) { continue; }  // LTO cannot bitcast from _ExtInt() :(
         max_size = 128;
         do_cast = 1;
 
@@ -548,7 +518,6 @@ bool CmpLogInstructions::hookInstrs(Module &M) {
           cast_size = max_size;
           break;
         default:
-          if (is_lto) { continue; }  // LTO cannot bitcast from _ExtInt() :(
           cast_size = 128;
           do_cast = 1;
 

--- a/qemu_mode/libqasan/dlmalloc.c
+++ b/qemu_mode/libqasan/dlmalloc.c
@@ -3917,7 +3917,6 @@ static void internal_malloc_stats(mstate m) {
                                                                 \
         } else if (RTCHECK(B == smallbin_at(M, I) ||            \
                                                                 \
-                                                                \
                            (ok_address(M, B) && B->fd == P))) { \
                                                                 \
           F->bk = B;                                            \
@@ -4129,7 +4128,6 @@ static void internal_malloc_stats(mstate m) {
                                                                      \
         } else                                                       \
                                                                      \
-                                                                     \
           CORRUPTION_ERROR_ACTION(M);                                \
         if (R != 0) {                                                \
                                                                      \
@@ -4146,7 +4144,6 @@ static void internal_malloc_stats(mstate m) {
                                                                      \
               } else                                                 \
                                                                      \
-                                                                     \
                 CORRUPTION_ERROR_ACTION(M);                          \
                                                                      \
             }                                                        \
@@ -4159,13 +4156,11 @@ static void internal_malloc_stats(mstate m) {
                                                                      \
               } else                                                 \
                                                                      \
-                                                                     \
                 CORRUPTION_ERROR_ACTION(M);                          \
                                                                      \
             }                                                        \
                                                                      \
           } else                                                     \
-                                                                     \
                                                                      \
             CORRUPTION_ERROR_ACTION(M);                              \
                                                                      \

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1875,8 +1875,6 @@ int main(int argc, char **argv, char **envp) {
 
   edit_params(argc, argv, envp);
 
-  if (lto_mode) { setenv("_AFL_LTO_COMPILE", "1", 1); }
-
   if (debug) {
 
     DEBUGF("cd '%s';", getthecwd());

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -1547,7 +1547,6 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u8 *cbuf,
       is_n = 1;
 
   }
-
 #endif
 
   for (i = 0; i < loggeds; ++i) {


### PR DESCRIPTION
In the current dev branch I get errors while compiling a target with cmplog (afl-clang-lto++). My target uses bigints, which leads to trouble for the cmplog instrumentation. This PR fixes the issues (at least for me). Currently I get the following error:

```
Invalid bitcast
  %10 = bitcast i80 %9 to i128, !dbg !29860
in function _ZSt7signbite
LLVM ERROR: Broken function found, compilation aborted!
```

I think bitcast `i80` to `i128` doesn't work since bitcast only works with types of the exact same bit size. So we need to use `zext` instead to extend to `i128` in the case above. I believe that `CreateIntCast` on the `IRBuilder` is the right function for this job (except we need a bitcast to an integer type first in case we are dealing with floating point values).

I think that previously 128 bit integer types were also implicitly truncated due to the use of `uint64_t val = cint->getZExtValue();` to create a new constant integer. I haven't tested this, but this should be fixed now too.

