### PR TITLE
Fix printf specifiers of (s)size_t in QAsan hooks

### DIFF
--- a/qemu_mode/libqasan/hooks.c
+++ b/qemu_mode/libqasan/hooks.c
@@ -50,9 +50,9 @@ ssize_t write(int fd, const void *buf, size_t count) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: write(%d, %p, %ld)\n", rtv, fd, buf, count);
+  QASAN_DEBUG("%14p: write(%d, %p, %zu)\n", rtv, fd, buf, count);
   ssize_t r = __lq_libc_write(fd, buf, count);
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zd\n", r);
 
   return r;
 
@@ -62,9 +62,9 @@ ssize_t read(int fd, void *buf, size_t count) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: read(%d, %p, %ld)\n", rtv, fd, buf, count);
+  QASAN_DEBUG("%14p: read(%d, %p, %zu)\n", rtv, fd, buf, count);
   ssize_t r = __lq_libc_read(fd, buf, count);
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zd\n", r);
 
   return r;
 
@@ -82,7 +82,7 @@ size_t malloc_usable_size(void *ptr) {
 
   QASAN_DEBUG("%14p: malloc_usable_size(%p)\n", rtv, ptr);
   size_t r = __libqasan_malloc_usable_size((void *)ptr);
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zu\n", r);
 
   return r;
 
@@ -92,7 +92,7 @@ void *malloc(size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: malloc(%ld)\n", rtv, size);
+  QASAN_DEBUG("%14p: malloc(%zu)\n", rtv, size);
   void *r = __libqasan_malloc(size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -104,7 +104,7 @@ void *calloc(size_t nmemb, size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: calloc(%ld, %ld)\n", rtv, nmemb, size);
+  QASAN_DEBUG("%14p: calloc(%zu, %zu)\n", rtv, nmemb, size);
   void *r = __libqasan_calloc(nmemb, size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -116,7 +116,7 @@ void *realloc(void *ptr, size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: realloc(%p, %ld)\n", rtv, ptr, size);
+  QASAN_DEBUG("%14p: realloc(%p, %zu)\n", rtv, ptr, size);
   void *r = __libqasan_realloc(ptr, size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -128,7 +128,7 @@ int posix_memalign(void **memptr, size_t alignment, size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: posix_memalign(%p, %ld, %ld)\n", rtv, memptr, alignment,
+  QASAN_DEBUG("%14p: posix_memalign(%p, %zu, %zu)\n", rtv, memptr, alignment,
               size);
   int r = __libqasan_posix_memalign(memptr, alignment, size);
   QASAN_DEBUG("\t\t = %d [*memptr = %p]\n", r, *memptr);
@@ -141,7 +141,7 @@ void *memalign(size_t alignment, size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memalign(%ld, %ld)\n", rtv, alignment, size);
+  QASAN_DEBUG("%14p: memalign(%zu, %zu)\n", rtv, alignment, size);
   void *r = __libqasan_memalign(alignment, size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -153,7 +153,7 @@ void *aligned_alloc(size_t alignment, size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: aligned_alloc(%ld, %ld)\n", rtv, alignment, size);
+  QASAN_DEBUG("%14p: aligned_alloc(%zu, %zu)\n", rtv, alignment, size);
   void *r = __libqasan_aligned_alloc(alignment, size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -165,7 +165,7 @@ void *valloc(size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: valloc(%ld)\n", rtv, size);
+  QASAN_DEBUG("%14p: valloc(%zu)\n", rtv, size);
   void *r = __libqasan_memalign(sysconf(_SC_PAGESIZE), size);
   QASAN_DEBUG("\t\t = %p\n", r);
 
@@ -177,7 +177,7 @@ void *pvalloc(size_t size) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: pvalloc(%ld)\n", rtv, size);
+  QASAN_DEBUG("%14p: pvalloc(%zu)\n", rtv, size);
   size_t page_size = sysconf(_SC_PAGESIZE);
   size = (size & (page_size - 1)) + page_size;
   void *r = __libqasan_memalign(page_size, size);
@@ -216,7 +216,7 @@ int memcmp(const void *s1, const void *s2, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memcmp(%p, %p, %ld)\n", rtv, s1, s2, n);
+  QASAN_DEBUG("%14p: memcmp(%p, %p, %zu)\n", rtv, s1, s2, n);
   QASAN_LOAD(s1, n);
   QASAN_LOAD(s2, n);
   int r = __libqasan_memcmp(s1, s2, n);
@@ -230,7 +230,7 @@ void *memcpy(void *dest, const void *src, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memcpy(%p, %p, %ld)\n", rtv, dest, src, n);
+  QASAN_DEBUG("%14p: memcpy(%p, %p, %zu)\n", rtv, dest, src, n);
   QASAN_LOAD(src, n);
   QASAN_STORE(dest, n);
   void *r = __libqasan_memcpy(dest, src, n);
@@ -244,7 +244,7 @@ void *mempcpy(void *dest, const void *src, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: mempcpy(%p, %p, %ld)\n", rtv, dest, src, n);
+  QASAN_DEBUG("%14p: mempcpy(%p, %p, %zu)\n", rtv, dest, src, n);
   QASAN_LOAD(src, n);
   QASAN_STORE(dest, n);
   void *r = (uint8_t *)__libqasan_memcpy(dest, src, n) + n;
@@ -258,7 +258,7 @@ void *memmove(void *dest, const void *src, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memmove(%p, %p, %ld)\n", rtv, dest, src, n);
+  QASAN_DEBUG("%14p: memmove(%p, %p, %zu)\n", rtv, dest, src, n);
   QASAN_LOAD(src, n);
   QASAN_STORE(dest, n);
   void *r = __libqasan_memmove(dest, src, n);
@@ -272,7 +272,7 @@ void *memset(void *s, int c, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memset(%p, %d, %ld)\n", rtv, s, c, n);
+  QASAN_DEBUG("%14p: memset(%p, %d, %zu)\n", rtv, s, c, n);
   QASAN_STORE(s, n);
   void *r = __libqasan_memset(s, c, n);
   QASAN_DEBUG("\t\t = %p\n", r);
@@ -285,7 +285,7 @@ void *memchr(const void *s, int c, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memchr(%p, %d, %ld)\n", rtv, s, c, n);
+  QASAN_DEBUG("%14p: memchr(%p, %d, %zu)\n", rtv, s, c, n);
   void *r = __libqasan_memchr(s, c, n);
   if (r == NULL)
     QASAN_LOAD(s, n);
@@ -301,7 +301,7 @@ void *memrchr(const void *s, int c, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memrchr(%p, %d, %ld)\n", rtv, s, c, n);
+  QASAN_DEBUG("%14p: memrchr(%p, %d, %zu)\n", rtv, s, c, n);
   QASAN_LOAD(s, n);
   void *r = __libqasan_memrchr(s, c, n);
   QASAN_DEBUG("\t\t = %p\n", r);
@@ -315,7 +315,7 @@ void *memmem(const void *haystack, size_t haystacklen, const void *needle,
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: memmem(%p, %ld, %p, %ld)\n", rtv, haystack, haystacklen,
+  QASAN_DEBUG("%14p: memmem(%p, %zu, %p, %zu)\n", rtv, haystack, haystacklen,
               needle, needlelen);
   QASAN_LOAD(haystack, haystacklen);
   QASAN_LOAD(needle, needlelen);
@@ -331,7 +331,7 @@ void bzero(void *s, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: bzero(%p, %ld)\n", rtv, s, n);
+  QASAN_DEBUG("%14p: bzero(%p, %zu)\n", rtv, s, n);
   QASAN_STORE(s, n);
   __libqasan_memset(s, 0, n);
 
@@ -343,7 +343,7 @@ void explicit_bzero(void *s, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: bzero(%p, %ld)\n", rtv, s, n);
+  QASAN_DEBUG("%14p: bzero(%p, %zu)\n", rtv, s, n);
   QASAN_STORE(s, n);
   __libqasan_memset(s, 0, n);
 
@@ -353,7 +353,7 @@ int bcmp(const void *s1, const void *s2, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: bcmp(%p, %p, %ld)\n", rtv, s1, s2, n);
+  QASAN_DEBUG("%14p: bcmp(%p, %p, %zu)\n", rtv, s1, s2, n);
   QASAN_LOAD(s1, n);
   QASAN_LOAD(s2, n);
   int r = __libqasan_bcmp(s1, s2, n);
@@ -411,7 +411,7 @@ int strncasecmp(const char *s1, const char *s2, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: strncasecmp(%p, %p, %ld)\n", rtv, s1, s2, n);
+  QASAN_DEBUG("%14p: strncasecmp(%p, %p, %zu)\n", rtv, s1, s2, n);
   size_t l1 = __libqasan_strnlen(s1, n);
   QASAN_LOAD(s1, l1);
   size_t l2 = __libqasan_strnlen(s2, n);
@@ -461,7 +461,7 @@ int strncmp(const char *s1, const char *s2, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: strncmp(%p, %p, %ld)\n", rtv, s1, s2, n);
+  QASAN_DEBUG("%14p: strncmp(%p, %p, %zu)\n", rtv, s1, s2, n);
   size_t l1 = __libqasan_strnlen(s1, n);
   QASAN_LOAD(s1, l1);
   size_t l2 = __libqasan_strnlen(s2, n);
@@ -492,7 +492,7 @@ char *strncpy(char *dest, const char *src, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: strncpy(%p, %p, %ld)\n", rtv, dest, src, n);
+  QASAN_DEBUG("%14p: strncpy(%p, %p, %zu)\n", rtv, dest, src, n);
   size_t l = __libqasan_strnlen(src, n);
   QASAN_STORE(dest, n);
   void *r;
@@ -551,7 +551,7 @@ size_t strlen(const char *s) {
   QASAN_DEBUG("%14p: strlen(%p)\n", rtv, s);
   size_t r = __libqasan_strlen(s);
   QASAN_LOAD(s, r + 1);
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zu\n", r);
 
   return r;
 
@@ -561,10 +561,10 @@ size_t strnlen(const char *s, size_t n) {
 
   void *rtv = __builtin_return_address(0);
 
-  QASAN_DEBUG("%14p: strnlen(%p, %ld)\n", rtv, s, n);
+  QASAN_DEBUG("%14p: strnlen(%p, %zu)\n", rtv, s, n);
   size_t r = __libqasan_strnlen(s, n);
   QASAN_LOAD(s, r);
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zu\n", r);
 
   return r;
 
@@ -651,7 +651,7 @@ size_t wcslen(const wchar_t *s) {
   QASAN_DEBUG("%14p: wcslen(%p)\n", rtv, s);
   size_t r = __libqasan_wcslen(s);
   QASAN_LOAD(s, sizeof(wchar_t) * (r + 1));
-  QASAN_DEBUG("\t\t = %ld\n", r);
+  QASAN_DEBUG("\t\t = %zu\n", r);
 
   return r;
 


### PR DESCRIPTION
* size_t specifier is %zu or %zx
* ssize_t specifier is %zd

Helpful for cross compiling