### PR TITLE
Make @@ handling more flexible

### DIFF
--- a/afl-cmin
+++ b/afl-cmin
@@ -243,7 +243,7 @@ BEGIN {
   if (!stdin_file) {
     found_atat = 0
     for (prog_args_ind in prog_args) {
-      if ("@@" == prog_args[prog_args_ind]) {
+      if (match(prog_args[prog_args_ind], "@@") != 0) {
         found_atat = 1
         break
       }

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -70,30 +70,25 @@ void detect_file_args(char **argv, u8 *prog_in, bool *use_stdin) {
 
       *use_stdin = false;
 
-      if (prog_in[0] != 0) {  // not afl-showmap special case
+      /* Be sure that we're always using fully-qualified paths. */
 
-        u8 *n_arg;
+      *aa_loc = 0;
 
-        /* Be sure that we're always using fully-qualified paths. */
+      /* Construct a replacement argv value. */
+      u8 *n_arg;
 
-        *aa_loc = 0;
+      if (prog_in[0] == '/') {
 
-        /* Construct a replacement argv value. */
+        n_arg = alloc_printf("%s%s%s", argv[i], prog_in, aa_loc + 2);
 
-        if (prog_in[0] == '/') {
+      } else {
 
-          n_arg = alloc_printf("%s%s%s", argv[i], prog_in, aa_loc + 2);
-
-        } else {
-
-          n_arg = alloc_printf("%s%s/%s%s", argv[i], cwd, prog_in, aa_loc + 2);
-
-        }
-
-        ck_free(argv[i]);
-        argv[i] = n_arg;
+        n_arg = alloc_printf("%s%s/%s%s", argv[i], cwd, prog_in, aa_loc + 2);
 
       }
+
+      ck_free(argv[i]);
+      argv[i] = n_arg;
 
     }
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -737,7 +737,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   // TODO: u64 mem_limit = MEM_LIMIT;                  /* Memory limit (MB) */
 
-  s32    opt;
+  s32    opt, i;
   u8     mem_limit_given = 0, timeout_given = 0, unicorn_mode = 0, use_wine = 0;
   char **use_argv;
 
@@ -985,7 +985,7 @@ int main(int argc, char **argv_orig, char **envp) {
   if (getenv("AFL_DEBUG")) {
 
     DEBUGF("");
-    for (int i = 0; i < argc; i++)
+    for (i = 0; i < argc; i++)
       SAYF(" %s", argv[i]);
     SAYF("\n");
 

--- a/utils/crash_triage/triage_crashes.sh
+++ b/utils/crash_triage/triage_crashes.sh
@@ -60,12 +60,12 @@ if
 fi
 
 if [ ! -f "$BIN" -o ! -x "$BIN" ]; then
-  echo "[-] Error: binary '$2' not found or is not executable." 1>&2
+  echo "[-] Error: binary '$BIN' not found or is not executable." 1>&2
   exit 1
 fi
 
 if [ ! -d "$DIR/queue" ]; then
-  echo "[-] Error: directory '$1' not found or not created by afl-fuzz." 1>&2
+  echo "[-] Error: directory '$DIR' not found or not created by afl-fuzz." 1>&2
   exit 1
 fi
 

--- a/utils/crash_triage/triage_crashes.sh
+++ b/utils/crash_triage/triage_crashes.sh
@@ -90,8 +90,9 @@ for crash in $DIR/crashes/id:*; do
 
   for a in $@; do
 
-    if [ "$a" = "@@" ] ; then
-      use_args="$use_args $crash"
+    if echo "$a" | grep -qF '@@'; then
+      escaped_fname=`echo $crash | sed 's:/:\\\\/:g'`
+      use_args="$use_args `echo $a | sed "s/@@/$escaped_fname/g"`"
       unset use_stdio
     else
       use_args="$use_args $a"


### PR DESCRIPTION
Several of the AFL utilities currently require the @@ command line argument to be _its own_ argument rather than just a part of an argument. The documentation doesn't mention this limitation, so this goes a little bit contrary to what a user would expect.

Also, several of the tools already accept @@ as a partial argument and correctly replace the text with the input filename chosen by AFL++. So making them all consistent would be nice.

These changes fix a few of the utils to accept @@ as part of a command line argument rather than requiring it to be a separate argument. This is handy for targets that accept a filename in a format like `--file=@@` or for allowing the user to quote the file in case there are spaces in the path like `-i "@@"`.