### PR TITLE
Add AFL_QEMU_CUSTOM_BIN environment flag

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -393,6 +393,10 @@ checks or alter some of the more exotic semantics of the tool:
 
   - In QEMU mode (-Q), `AFL_PATH` will be searched for afl-qemu-trace.
 
+  - In QEMU mode (-Q), setting `AFL_QEMU_CUSTOM_BIN` cause afl-fuzz to skip
+    prepending `afl-qemu-trace` to your command line. Use this if you wish to use a
+    custom afl-qemu-trace or if you need to modify the afl-qemu-trace arguments.
+
   - Setting `AFL_CYCLE_SCHEDULES` will switch to a different schedule everytime
     a cycle is finished.
 

--- a/include/envs.h
+++ b/include/envs.h
@@ -130,6 +130,7 @@ static char *afl_environment_variables[] = {
     "AFL_PERFORMANCE_FILE",
     "AFL_PRELOAD",
     "AFL_PYTHON_MODULE",
+    "AFL_QEMU_CUSTOM_BIN",
     "AFL_QEMU_COMPCOV",
     "AFL_QEMU_COMPCOV_DEBUG",
     "AFL_QEMU_DEBUG_MAPS",

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -149,6 +149,13 @@ void argv_cpy_free(char **argv) {
 
 char **get_qemu_argv(u8 *own_loc, u8 **target_path_p, int argc, char **argv) {
 
+  if (unlikely(getenv("AFL_QEMU_CUSTOM_BIN"))) {
+    WARNF(
+      "AFL_QEMU_CUSTOM_BIN is enabled. "
+      "You must run your target under afl-qemu-trace on your own!");
+    return argv;
+  }
+
   if (!unlikely(own_loc)) { FATAL("BUG: param own_loc is NULL"); }
 
   u8 *tmp, *cp = NULL, *rsl, *own_copy;

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2592,6 +2592,7 @@ void check_binary(afl_state_t *afl, u8 *fname) {
   }
 
   if (afl->afl_env.afl_skip_bin_check || afl->use_wine || afl->unicorn_mode ||
+      (afl->fsrv.qemu_mode && getenv("AFL_QEMU_CUSTOM_BIN")) ||
       afl->non_instrumented_mode) {
 
     return;


### PR DESCRIPTION
In QEMU mode (-Q), setting AFL_QEMU_CUSTOM_BIN cause afl-fuzz to skip
prepending afl-qemu-trace to your command line. Use this if you wish to use a
custom afl-qemu-trace or if you need to modify the afl-qemu-trace arguments.