### PR TITLE
preserve plot_data for in-place resume

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -1365,7 +1365,7 @@ u32 find_start_position(afl_state_t *afl) {
     fn = alloc_printf("%s/../fuzzer_stats", afl->in_dir);
 
   }
-
+/
   fd = open(fn, O_RDONLY);
   ck_free(fn);
 
@@ -1812,9 +1812,13 @@ static void handle_existing_out_dir(afl_state_t *afl) {
 
   }
 
-  fn = alloc_printf("%s/plot_data", afl->out_dir);
-  if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
-  ck_free(fn);
+  if (!afl->in_place_resume) {
+
+    fn = alloc_printf("%s/plot_data", afl->out_dir);
+    if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }
+    ck_free(fn);
+
+  }
 
   fn = alloc_printf("%s/cmdline", afl->out_dir);
   if (unlink(fn) && errno != ENOENT) { goto dir_cleanup_failed; }


### PR DESCRIPTION
This pull request checks for in place resume before attempting to unlink plot_data to fix https://github.com/AFLplusplus/AFLplusplus/issues/828