### PR TITLE
closes fd when executing one by one.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -558,6 +558,7 @@ clean:
 	-$(MAKE) -f GNUmakefile.gcc_plugin clean
 	$(MAKE) -C utils/libdislocator clean
 	$(MAKE) -C utils/libtokencap clean
+	$(MAKE) -C utils/aflpp_driver clean
 	$(MAKE) -C utils/afl_network_proxy clean
 	$(MAKE) -C utils/socket_fuzzing clean
 	$(MAKE) -C utils/argv_fuzzing clean

--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -186,6 +186,7 @@ static int ExecuteFilesOnyByOne(int argc, char **argv) {
       printf("Execution successful.\n");
 
     }
+    close(fd);
 
   }
 


### PR DESCRIPTION
Causes too many open files errors if this functionality is used.