### PR TITLE
Add network_proxy build targets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ libAFLQemuDriver.a
 test/.afl_performance
 gmon.out
 afl-frida-trace.so
+utils/afl_network_proxy/afl-network-client
+utils/afl_network_proxy/afl-network-server


### PR DESCRIPTION
All other build targets in `utils/` are ignored except for these due to the lack of file extension.