### PR TITLE
Fix grammar mutator build script

### DIFF
--- a/custom_mutators/grammar_mutator/build_grammar_mutator.sh
+++ b/custom_mutators/grammar_mutator/build_grammar_mutator.sh
@@ -106,23 +106,23 @@ git status 1>/dev/null 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "[*] initializing grammar mutator submodule"
   git submodule init || exit 1
-  git submodule update ./grammar-mutator 2>/dev/null # ignore errors
+  git submodule update ./grammar_mutator 2>/dev/null # ignore errors
 else
   echo "[*] cloning grammar mutator"
-  test -d grammar-mutator || {
+  test -d grammar_mutator || {
     CNT=1
-    while [ '!' -d grammar-mutator -a "$CNT" -lt 4 ]; do
-      echo "Trying to clone grammar-mutator (attempt $CNT/3)"
+    while [ '!' -d grammar_mutator -a "$CNT" -lt 4 ]; do
+      echo "Trying to clone grammar_mutator (attempt $CNT/3)"
       git clone "$GRAMMAR_REPO" 
       CNT=`expr "$CNT" + 1`
     done
   }
 fi
 
-test -d grammar-mutator || { echo "[-] not checked out, please install git or check your internet connection." ; exit 1 ; }
+test -d grammar_mutator || { echo "[-] not checked out, please install git or check your internet connection." ; exit 1 ; }
 echo "[+] Got grammar mutator."
 
-cd "grammar-mutator" || exit 1
+cd "grammar_mutator" || exit 1
 echo "[*] Checking out $GRAMMAR_VERSION"
 sh -c 'git stash && git stash drop' 1>/dev/null 2>/dev/null
 git checkout "$GRAMMAR_VERSION" || exit 1
@@ -134,7 +134,7 @@ echo
 echo
 echo "[+] All successfully prepared!"
 echo "[!] To build for your grammar just do:"
-echo "      cd grammar-mutator"
+echo "      cd grammar_mutator"
 echo "      make GRAMMAR_FILE=/path/to/your/grammar"
-echo "[+] You will find a JSON and RUBY grammar in grammar-mutator/grammars to play with."
+echo "[+] You will find a JSON and RUBY grammar in grammar_mutator/grammars to play with."
 echo


### PR DESCRIPTION
Fixes: 6d2ac3e3140 ("fix grammar download script")

The git submodle entry point is "grammar_mutator" not "grammar-mutator"

The build script fails without this