### PR TITLE
Integer overflow/underflow fixes in libdislocator

### DIFF
--- a/utils/libdislocator/libdislocator.so.c
+++ b/utils/libdislocator/libdislocator.so.c
@@ -144,7 +144,7 @@ typedef struct {
 
 /* Configurable stuff (use AFL_LD_* to set): */
 
-static u32 max_mem = MAX_ALLOC;         /* Max heap usage to permit         */
+static size_t max_mem = MAX_ALLOC;      /* Max heap usage to permit         */
 static u8  alloc_verbose,               /* Additional debug messages        */
     hard_fail,                          /* abort() when max_mem exceeded?   */
     no_calloc_over,                     /* abort() on calloc() overflows?   */
@@ -172,9 +172,9 @@ static void *__dislocator_alloc(size_t len) {
 
   if (total_mem + len > max_mem || total_mem + len < total_mem) {
 
-    if (hard_fail) FATAL("total allocs exceed %u MB", max_mem / 1024 / 1024);
+    if (hard_fail) FATAL("total allocs exceed %zu MB", max_mem / 1024 / 1024);
 
-    DEBUGF("total allocs exceed %u MB, returning NULL", max_mem / 1024 / 1024);
+    DEBUGF("total allocs exceed %zu MB, returning NULL", max_mem / 1024 / 1024);
 
     return NULL;
 
@@ -500,19 +500,20 @@ size_t malloc_usable_size(const void *ptr) {
 
 __attribute__((constructor)) void __dislocator_init(void) {
 
-  u8 *tmp = (u8 *)getenv("AFL_LD_LIMIT_MB");
+  char *tmp = getenv("AFL_LD_LIMIT_MB");
 
   if (tmp) {
 
-    u8 *tok;
-    s32 mmem = (s32)strtol((char *)tmp, (char **)&tok, 10);
-    if (*tok != '\0' || errno == ERANGE) FATAL("Bad value for AFL_LD_LIMIT_MB");
+    char *tok;
+    unsigned long long mmem = strtoull(tmp, &tok, 10);
+    if (*tok != '\0' || errno == ERANGE || mmem > SIZE_MAX / 1024 / 1024)
+      FATAL("Bad value for AFL_LD_LIMIT_MB");
     max_mem = mmem * 1024 * 1024;
 
   }
 
   alloc_canary = ALLOC_CANARY;
-  tmp = (u8 *)getenv("AFL_RANDOM_ALLOC_CANARY");
+  tmp = getenv("AFL_RANDOM_ALLOC_CANARY");
 
   if (tmp) arc4random_buf(&alloc_canary, sizeof(alloc_canary));
 
@@ -549,4 +550,3 @@ void *erealloc(void *ptr, size_t len) {
   return realloc(ptr, len);
 
 }
-

--- a/utils/libdislocator/libdislocator.so.c
+++ b/utils/libdislocator/libdislocator.so.c
@@ -154,7 +154,7 @@ static u8  alloc_verbose,               /* Additional debug messages        */
   #define __thread
   #warning no thread support available
 #endif
-static __thread size_t total_mem;       /* Currently allocated mem          */
+static _Atomic size_t total_mem;        /* Currently allocated mem          */
 
 static __thread u32 call_depth;         /* To avoid recursion via fprintf() */
 static u32          alloc_canary;


### PR DESCRIPTION
1. Adding the check of integer overflow of 'max_mem' variable when calculating bytes number from megabytes number; changing 'max_mem' type from 'u32' to 'size_t' to be able to store more than 4 GB value on 64-bit machines;

2. Consider the following scenario: multithreaded application, one thread allocates some data and the another thread frees that data. 'total_mem' variable is defined as thread local, so when the second thread frees the data, its 'total_mem' value may be underflowed (line 353):
https://github.com/AFLplusplus/AFLplusplus/blob/da65eef57279dae7b652c40bdb31bc6cd749f63d/utils/libdislocator/libdislocator.so.c#L341-L353 Also, in my opinion, there is no sense of making 'total_mem' value separate for each thread as long as all threads share the same heap.