### PR TITLE
Exit on time

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -284,6 +284,10 @@ checks or alter some of the more exotic semantics of the tool:
     normally indicated by the cycle counter in the UI turning green. May be
     convenient for some types of automated jobs.
 
+  - `AFL_EXIT_ON_TIME` Causes afl-fuzz to terminate if no new paths were 
+    found within a specified period of time. May be convenient for some 
+    types of automated jobs.
+
   - `AFL_EXIT_ON_SEED_ISSUES` will restore the vanilla afl-fuzz behaviour
     which does not allow crashes or timeout seeds in the initial -i corpus.
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -385,14 +385,14 @@ typedef struct afl_env_vars {
       afl_force_ui, afl_i_dont_care_about_missing_crashes, afl_bench_just_one,
       afl_bench_until_crash, afl_debug_child, afl_autoresume, afl_cal_fast,
       afl_cycle_schedules, afl_expand_havoc, afl_statsd, afl_cmplog_only_new,
-      afl_exit_on_seed_issues, afl_exit_on_time;
+      afl_exit_on_seed_issues;
 
   u8 *afl_tmpdir, *afl_custom_mutator_library, *afl_python_module, *afl_path,
       *afl_hang_tmout, *afl_forksrv_init_tmout, *afl_skip_crashes, *afl_preload,
       *afl_max_det_extras, *afl_statsd_host, *afl_statsd_port,
       *afl_crash_exitcode, *afl_statsd_tags_flavor, *afl_testcache_size,
       *afl_testcache_entries, *afl_kill_signal, *afl_target_env,
-      *afl_persistent_record;
+      *afl_persistent_record, *afl_exit_on_time;
 
 } afl_env_vars_t;
 
@@ -575,7 +575,8 @@ typedef struct afl_state {
       last_sync_cycle,                  /* Cycle no. of the last sync       */
       last_path_time,                   /* Time for most recent path (ms)   */
       last_crash_time,                  /* Time for most recent crash (ms)  */
-      last_hang_time;                   /* Time for most recent hang (ms)   */
+      last_hang_time,                   /* Time for most recent hang (ms)   */
+      exit_on_time;                     /* Delay to exit if no new paths    */
 
   u32 slowest_exec_ms,                  /* Slowest testcase non hang in ms  */
       subseq_tmouts;                    /* Number of timeouts in a row      */

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -385,7 +385,7 @@ typedef struct afl_env_vars {
       afl_force_ui, afl_i_dont_care_about_missing_crashes, afl_bench_just_one,
       afl_bench_until_crash, afl_debug_child, afl_autoresume, afl_cal_fast,
       afl_cycle_schedules, afl_expand_havoc, afl_statsd, afl_cmplog_only_new,
-      afl_exit_on_seed_issues;
+      afl_exit_on_seed_issues, afl_exit_on_time;
 
   u8 *afl_tmpdir, *afl_custom_mutator_library, *afl_python_module, *afl_path,
       *afl_hang_tmout, *afl_forksrv_init_tmout, *afl_skip_crashes, *afl_preload,

--- a/include/envs.h
+++ b/include/envs.h
@@ -49,6 +49,7 @@ static char *afl_environment_variables[] = {
     "AFL_DUMB_FORKSRV",
     "AFL_ENTRYPOINT",
     "AFL_EXIT_WHEN_DONE",
+    "AFL_EXIT_ON_TIME",
     "AFL_EXIT_ON_SEED_ISSUES",
     "AFL_FAST_CAL",
     "AFL_FORCE_UI",

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -193,7 +193,7 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
                               afl_environment_variable_len)) {
 
             afl->afl_env.afl_exit_on_time =
-                (u64 *) get_afl_env(afl_environment_variables[i]);
+                (u8 *) get_afl_env(afl_environment_variables[i]);
 
           } else if (!strncmp(env, "AFL_NO_AFFINITY",
 

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -99,6 +99,7 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->cal_cycles = CAL_CYCLES;
   afl->cal_cycles_long = CAL_CYCLES_LONG;
   afl->hang_tmout = EXEC_TIMEOUT;
+  afl->exit_on_time = 0;
   afl->stats_update_freq = 1;
   afl->stats_avg_exec = 0;
   afl->skip_deterministic = 1;
@@ -186,6 +187,13 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
             afl->afl_env.afl_exit_when_done =
                 get_afl_env(afl_environment_variables[i]) ? 1 : 0;
+
+          } else if (!strncmp(env, "AFL_EXIT_ON_TIME",
+
+                              afl_environment_variable_len)) {
+
+            afl->afl_env.afl_exit_on_time =
+                (u64 *) get_afl_env(afl_environment_variables[i]);
 
           } else if (!strncmp(env, "AFL_NO_AFFINITY",
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -574,6 +574,16 @@ void show_stats(afl_state_t *afl) {
 
   }
 
+  /* AFL_EXIT_ON_TIME. */ 
+
+  if (unlikely(afl->last_path_time && !afl->non_instrumented_mode && 
+    afl->cycles_wo_finds > 1 && !afl->pending_not_fuzzed && afl->afl_env.afl_exit_on_time &&
+    (cur_ms - afl->last_path_time) > afl->exit_on_time)) {
+
+    afl->stop_soon = 2;
+
+  }
+
   if (unlikely(afl->total_crashes && afl->afl_env.afl_bench_until_crash)) {
 
     afl->stop_soon = 2;

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -577,8 +577,8 @@ void show_stats(afl_state_t *afl) {
   /* AFL_EXIT_ON_TIME. */ 
 
   if (unlikely(afl->last_path_time && !afl->non_instrumented_mode && 
-    afl->cycles_wo_finds > 1 && !afl->pending_not_fuzzed && afl->afl_env.afl_exit_on_time &&
-    (cur_ms - afl->last_path_time) > afl->exit_on_time)) {
+    afl->afl_env.afl_exit_on_time && 
+    (get_cur_time() - afl->last_path_time) > afl->exit_on_time)) {
 
     afl->stop_soon = 2;
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -578,7 +578,7 @@ void show_stats(afl_state_t *afl) {
 
   if (unlikely(afl->last_path_time && !afl->non_instrumented_mode && 
     afl->afl_env.afl_exit_on_time && 
-    (get_cur_time() - afl->last_path_time) > afl->exit_on_time)) {
+    (cur_ms - afl->last_path_time) > afl->exit_on_time)) {
 
     afl->stop_soon = 2;
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1250,7 +1250,6 @@ int main(int argc, char **argv_orig, char **envp) {
   if (afl->afl_env.afl_exit_on_time) {
 
     u64 exit_on_time = atoi(afl->afl_env.afl_exit_on_time);
-    if (exit_on_time < 1) { FATAL("Invalid value for AFL_EXIT_ON_TIME"); }
     afl->exit_on_time = (u64)exit_on_time * 1000;
 
   }

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -204,6 +204,7 @@ static void usage(u8 *argv0, int more_help) {
       "AFL_DISABLE_TRIM: disable the trimming of test cases\n"
       "AFL_DUMB_FORKSRV: use fork server without feedback from target\n"
       "AFL_EXIT_WHEN_DONE: exit when all inputs are run and no new finds are found\n"
+      "AFL_EXIT_ON_TIME: exit when no new paths are found within the specified time period\n"
       "AFL_EXPAND_HAVOC_NOW: immediately enable expand havoc mode (default: after 60 minutes and a cycle without finds)\n"
       "AFL_FAST_CAL: limit the calibration stage to three cycles for speedup\n"
       "AFL_FORCE_UI: force showing the status screen (for virtual consoles)\n"
@@ -1243,6 +1244,14 @@ int main(int argc, char **argv_orig, char **envp) {
     s32 hang_tmout = atoi(afl->afl_env.afl_hang_tmout);
     if (hang_tmout < 1) { FATAL("Invalid value for AFL_HANG_TMOUT"); }
     afl->hang_tmout = (u32)hang_tmout;
+
+  }
+
+  if (afl->afl_env.afl_exit_on_time) {
+
+    u64 exit_on_time = atoi(afl->afl_env.afl_exit_on_time);
+    if (exit_on_time < 1) { FATAL("Invalid value for AFL_EXIT_ON_TIME"); }
+    afl->exit_on_time = (u64)exit_on_time;
 
   }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1251,7 +1251,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
     u64 exit_on_time = atoi(afl->afl_env.afl_exit_on_time);
     if (exit_on_time < 1) { FATAL("Invalid value for AFL_EXIT_ON_TIME"); }
-    afl->exit_on_time = (u64)exit_on_time;
+    afl->exit_on_time = (u64)exit_on_time * 1000;
 
   }
 

--- a/test/test-performance.sh
+++ b/test/test-performance.sh
@@ -18,6 +18,7 @@ export AFL_QUIET=1
 export AFL_PATH=`pwd`/..
 
 unset AFL_EXIT_WHEN_DONE
+unset AFL_EXIT_ON_TIME
 unset AFL_SKIP_CPUFREQ
 unset AFL_DEBUG
 unset AFL_HARDEN

--- a/test/test-pre.sh
+++ b/test/test-pre.sh
@@ -62,6 +62,7 @@ $ECHO \\101 2>&1 | grep -qE '^A' || {
 test -z "$ECHO" && { printf Error: printf command does not support octal character codes ; exit 1 ; }
 
 export AFL_EXIT_WHEN_DONE=1
+export AFL_EXIT_ON_TIME=60
 export AFL_SKIP_CPUFREQ=1
 export AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
 unset AFL_NO_X86


### PR DESCRIPTION
Added code to terminate fuzzing by timeout if no new paths are found.
The absence of new paths found may indicate fuzzing problems. It can be pointless to continue fuzzing.
The patch adds the ability to end fuzzing after a specified time.