### PR TITLE
Changes to bump FRIDA version and to clone FRIDA repo in to build dir…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,3 @@
 [submodule "qemu_mode/qemuafl"]
 	path = qemu_mode/qemuafl
 	url = https://github.com/AFLplusplus/qemuafl
-[submodule "frida_mode/frida"]
-	path = frida_mode/frida
-	url = https://github.com/WorksButNotTested/frida.git
-	branch = x64_stalker_fix

--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -64,7 +64,7 @@ ifndef OS
  $(error "Operating system unsupported")
 endif
 
-GUM_DEVKIT_VERSION=14.2.17
+GUM_DEVKIT_VERSION=14.2.18
 GUM_DEVKIT_FILENAME=frida-gum-devkit-$(GUM_DEVKIT_VERSION)-$(OS)-$(ARCH).tar.xz
 GUM_DEVKIT_URL="https://github.com/frida/frida/releases/download/$(GUM_DEVKIT_VERSION)/$(GUM_DEVKIT_FILENAME)"
 
@@ -72,17 +72,18 @@ GUM_DEVKIT_TARBALL:=$(FRIDA_BUILD_DIR)$(GUM_DEVKIT_FILENAME)
 GUM_DEVIT_LIBRARY=$(FRIDA_BUILD_DIR)libfrida-gum.a
 GUM_DEVIT_HEADER=$(FRIDA_BUILD_DIR)frida-gum.h
 
-FRIDA_DIR:=$(PWD)frida/
+FRIDA_DIR:=$(PWD)build/frida-source/
 FRIDA_MAKEFILE:=$(FRIDA_DIR)Makefile
 FRIDA_GUM:=$(FRIDA_DIR)build/frida-linux-x86_64/lib/libfrida-gum-1.0.a
 FRIDA_GUM_DEVKIT_DIR:=$(FRIDA_DIR)build/gum-devkit/
 FRIDA_GUM_DEVKIT_HEADER:=$(FRIDA_GUM_DEVKIT_DIR)frida-gum.h
-FRIDA_GUM_DEVKIT_TARBALL:=$(FRIDA_DIR)build/$(GUM_DEVKIT_FILENAME)
+FRIDA_GUM_DEVKIT_TARBALL:=$(FRIDA_DIR)build/frida-gum-devkit-$(GUM_DEVKIT_VERSION)-$(OS)-$(ARCH).tar
+FRIDA_GUM_DEVKIT_COMPRESSED_TARBALL:=$(FRIDA_DIR)build/$(GUM_DEVKIT_FILENAME)
 
 AFL_COMPILER_RT_SRC:=$(ROOT)instrumentation/afl-compiler-rt.o.c
 AFL_COMPILER_RT_OBJ:=$(OBJ_DIR)afl-compiler-rt.o
 
-.PHONY: all clean format
+.PHONY: all clean format $(FRIDA_GUM)
 
 ############################## ALL #############################################
 
@@ -97,8 +98,8 @@ $(OBJ_DIR): | $(BUILD_DIR)
 
 ############################# FRIDA ############################################
 
-$(FRIDA_MAKEFILE):
-	git submodule update --init --recursive $(FRIDA_DIR)
+$(FRIDA_MAKEFILE): | $(BUILD_DIR)
+	git clone --recursive https://github.com/frida/frida.git $(FRIDA_DIR)
 
 $(FRIDA_GUM): $(FRIDA_MAKEFILE)
 	cd $(FRIDA_DIR) && make gum-linux-$(ARCH)
@@ -107,7 +108,10 @@ $(FRIDA_GUM_DEVKIT_HEADER): $(FRIDA_GUM)
 	$(FRIDA_DIR)releng/devkit.py frida-gum linux-$(ARCH) $(FRIDA_DIR)build/gum-devkit/
 
 $(FRIDA_GUM_DEVKIT_TARBALL): $(FRIDA_GUM_DEVKIT_HEADER)
-	cd $(FRIDA_GUM_DEVKIT_DIR) && tar cJvf $(FRIDA_GUM_DEVKIT_TARBALL) .
+	cd $(FRIDA_GUM_DEVKIT_DIR) && tar cvf $(FRIDA_GUM_DEVKIT_TARBALL) .
+
+$(FRIDA_GUM_DEVKIT_COMPRESSED_TARBALL): $(FRIDA_GUM_DEVKIT_TARBALL)
+	xz -k -f -0 $(FRIDA_GUM_DEVKIT_TARBALL)
 
 ############################# DEVKIT ###########################################
 
@@ -115,7 +119,7 @@ $(FRIDA_BUILD_DIR): | $(BUILD_DIR)
 	mkdir -p $@
 
 ifdef FRIDA_SOURCE
-$(GUM_DEVKIT_TARBALL): $(FRIDA_GUM_DEVKIT_TARBALL)| $(FRIDA_BUILD_DIR)
+$(GUM_DEVKIT_TARBALL): $(FRIDA_GUM_DEVKIT_COMPRESSED_TARBALL)| $(FRIDA_BUILD_DIR)
 	cp -v $< $@
 else
 $(GUM_DEVKIT_TARBALL): | $(FRIDA_BUILD_DIR)


### PR DESCRIPTION
FRIDA doesn't like being built from a submodule as it can't find it's `.git` directory back at the repo root. Therefore we instead (if built with `FRIDA_SOURCE=1`) clone it into the build directory and build it from there. This also means that we don't have frida as a submobule in the git repo and have to worry about updating the commit we are referencing each time, instead we get the HEAD each time which is probably what we want if we are hacking on FRIDA features.

`$(FRIDA_GUM)` is marked as `.PHONY` which means that `make` will be run inside the cloned FRIDA repo on each build (to check if any sources have been updated e.g. to allow the developer to tweak stuff in FRIDA and build it into `frida_mode`). Again only if `frida_mode` is built with `FRIDA_SOURCE=1`. I have also changed the devkit in this case to compress with `xz -0` to speed up the build, since the tarball will never be distributed size shouldn't be an issue. Note that this has been updated to clone from the official FRIDA repo rather than my fork now that the fix has been merged.

Lastly, the frida version number has been bumped to `14.2.18` which includes the fix. As before when not building with `FRIDA_SOURCE=1` the tarball is downloaded from the official FRIDA releases.