### PR TITLE
Frida cmplog fix

### DIFF
--- a/frida_mode/src/cmplog/cmplog_x64.c
+++ b/frida_mode/src/cmplog/cmplog_x64.c
@@ -175,6 +175,8 @@ static void cmplog_call_callout(GumCpuContext *context, gpointer user_data) {
   guint64 rdi = cmplog_read_reg(context, X86_REG_RDI);
   guint64 rsi = cmplog_read_reg(context, X86_REG_RSI);
 
+  if (((G_MAXULONG - rdi) < 32) || ((G_MAXULONG - rsi) < 32)) return;
+
   void *ptr1 = GSIZE_TO_POINTER(rdi);
   void *ptr2 = GSIZE_TO_POINTER(rsi);
 
@@ -223,18 +225,6 @@ static void cmplog_instrument_put_operand(cmplog_ctx_t *ctx,
 
 }
 
-static void cmplog_instrument_call_put_callout(GumStalkerIterator *iterator,
-                                               cs_x86_op *         operand) {
-
-  cmplog_ctx_t *ctx = g_malloc(sizeof(cmplog_ctx_t));
-  if (ctx == NULL) return;
-
-  cmplog_instrument_put_operand(ctx, operand);
-
-  gum_stalker_iterator_put_callout(iterator, cmplog_call_callout, ctx, g_free);
-
-}
-
 static void cmplog_instrument_call(const cs_insn *     instr,
                                    GumStalkerIterator *iterator) {
 
@@ -251,7 +241,7 @@ static void cmplog_instrument_call(const cs_insn *     instr,
   if (operand->type == X86_OP_MEM && operand->mem.segment != X86_REG_INVALID)
     return;
 
-  cmplog_instrument_call_put_callout(iterator, operand);
+  gum_stalker_iterator_put_callout(iterator, cmplog_call_callout, NULL, NULL);
 
 }
 


### PR DESCRIPTION
When handling CMPLOG for call instructions, we check whether `RSI` and `RDI` are within a mapped readable range. If (as seen in this example) one of the registers is `0xffffffff`ffffffff`, then when we calculate the limit of the range (we check if we can read 32 bytes) we have a numeric overflow. This caused a logic bug which resulted in frida mode calculating that the range was readable and attempting to read 32 bytes from `0xffffffff`ffffffff`.

Also the target address of the call was being passed through to the code updating the cmplog mapping which was unused and hence unnecessary. This has therefore been removed.