### PR TITLE
Set kill signal before using it in afl-showmap

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1104,6 +1104,9 @@ int main(int argc, char **argv_orig, char **envp) {
                                  : 0);
     be_quiet = save_be_quiet;
 
+    fsrv->kill_signal =
+        parse_afl_kill_signal_env(getenv("AFL_KILL_SIGNAL"), SIGKILL);
+
     if (new_map_size) {
 
       // only reinitialize when it makes sense
@@ -1210,9 +1213,6 @@ int main(int argc, char **argv_orig, char **envp) {
       fsrv->init_tmout = (u32)forksrv_init_tmout;
 
     }
-
-    fsrv->kill_signal =
-        parse_afl_kill_signal_env(getenv("AFL_KILL_SIGNAL"), SIGKILL);
 
     if (getenv("AFL_CRASH_EXITCODE")) {
 


### PR DESCRIPTION
This is a fairly trivial change in showmap to resolve #911 .

Tested with [kfx](https://github.com/intel/kernel-fuzzer-for-xen-project). Leftover Xen domains after running `afl-cmin.bash` on 7 inputs:

```
% xl list
Name                                        ID   Mem VCPUs      State   Time(s)
Domain-0                                     0  8192     4     r-----  120607.0
xxx                                          1    17     1     --p---      84.2
(null)                                    8930    17     1     --p---       0.0
(null)                                    8931     0     1     --p---       0.0
(null)                                    8934    17     1     --p---       0.0
(null)                                    8935     0     1     --p---       0.0
(null)                                    8938    17     1     --p---       0.0
(null)                                    8939     0     1     --p---       0.0
(null)                                    8942    17     1     --p---       0.0
(null)                                    8943     0     1     --p---       0.0
(null)                                    8946    17     1     --p---       0.0
(null)                                    8947     0     1     --p---       0.0
(null)                                    8950    17     1     --p---       0.0
(null)                                    8951     0     1     --p---       0.0
(null)                                    8954    17     1     --p---       0.0
(null)                                    8955     0     1     --p---       0.0
(null)                                    8958    17     1     --p---       0.0
(null)                                    8959     0     1     --p---       0.0
```
(the +2 increments in domID's show that kill signal was properly set for the second initialization of the forkserver)

After the patch:

```
% xl list
Name                                        ID   Mem VCPUs      State   Time(s)
Domain-0                                     0  8192     4     r-----  121328.9
xxx                                          1    17     1     --p---      84.2
```

I don't have full unit test coverage, but those that run, pass - let's see the CI results...