### PR TITLE
remove redundant unsetenv

### DIFF
--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -339,7 +339,6 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
     if (afl->fsrv.support_shmem_fuzz && !afl->fsrv.use_shmem_fuzz) {
 
-      unsetenv(SHM_FUZZ_ENV_VAR);
       afl_shm_deinit(afl->shm_fuzz);
       ck_free(afl->shm_fuzz);
       afl->shm_fuzz = NULL;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2286,13 +2286,10 @@ stop_fuzzing:
   destroy_queue(afl);
   destroy_extras(afl);
   destroy_custom_mutators(afl);
-  unsetenv(SHM_ENV_VAR);
-  unsetenv(CMPLOG_SHM_ENV_VAR);
   afl_shm_deinit(&afl->shm);
 
   if (afl->shm_fuzz) {
 
-    unsetenv(SHM_FUZZ_ENV_VAR);
     afl_shm_deinit(afl->shm_fuzz);
     ck_free(afl->shm_fuzz);
 


### PR DESCRIPTION
`afl_shm_deinit` will unset shm environment variables, some of callers call `unsetenv` by themself which is redundant.