### PR TITLE
fix ui fuzzing stage index

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -1017,9 +1017,10 @@ void show_stats(afl_state_t *afl) {
   if (unlikely(afl->afl_env.afl_custom_mutator_library)) {
 
     strcat(tmp, " ");
-    strcat(tmp, u_stringify_int(IB(2), afl->stage_finds[STAGE_PYTHON]));
+    strcat(tmp, u_stringify_int(IB(2), afl->stage_finds[STAGE_CUSTOM_MUTATOR]));
     strcat(tmp, "/");
-    strcat(tmp, u_stringify_int(IB(3), afl->stage_cycles[STAGE_PYTHON]));
+    strcat(tmp,
+           u_stringify_int(IB(3), afl->stage_cycles[STAGE_CUSTOM_MUTATOR]));
     strcat(tmp, ",");
 
   } else {


### PR DESCRIPTION
UI use incorrect index `STAGE_PYTHON` instead of `STAGE_CUSTOM_MUTATOR` for custom mutator status.