### PR TITLE
Instrumentation Suppression

### DIFF
--- a/frida_mode/include/instrument.h
+++ b/frida_mode/include/instrument.h
@@ -8,6 +8,7 @@
 extern __thread uint64_t previous_pc;
 extern uint8_t *         __afl_area_ptr;
 extern uint32_t          __afl_map_size;
+extern gboolean          instrument_suppression;
 
 void instrument_init(void);
 
@@ -17,6 +18,9 @@ GumStalkerTransformer *instrument_get_transformer(void);
 gboolean instrument_is_coverage_optimize_supported(void);
 
 void instrument_coverage_optimize(const cs_insn *   instr,
+                                  GumStalkerOutput *output);
+
+void instrument_coverage_suppress(const cs_insn *   instr,
                                   GumStalkerOutput *output);
 
 void     instrument_debug_init(void);

--- a/frida_mode/src/instrument/instrument_x64.c
+++ b/frida_mode/src/instrument/instrument_x64.c
@@ -1,8 +1,10 @@
 #include "frida-gum.h"
 
 #include "config.h"
+#include "debug.h"
 
 #include "instrument.h"
+#include "ranges.h"
 
 #if defined(__x86_64__)
 
@@ -22,7 +24,49 @@ static const guint8 afl_log_code[] = {
     0x48, 0x31, 0xfa,                                       /* xor rdx, rdi */
 
     0x48, 0x03, 0x15, 0x13,
-    0x00, 0x00, 0x00,                     /* add rdx, sym._afl_area_ptr_ptr */
+    0x00, 0x00, 0x00, /* add rdx, sym._afl_area_ptr_ptr
+                       */
+
+    0x80, 0x02, 0x01,                              /* add byte ptr [rdx], 1 */
+    0x80, 0x12, 0x00,                              /* adc byte ptr [rdx], 0 */
+    0x48, 0xd1, 0xef,                                         /* shr rdi, 1 */
+    0x48, 0x89, 0x39,                               /* mov qword [rcx], rdi */
+
+    0x5a,                                                        /* pop rdx */
+    0x59,                                                        /* pop rcx */
+    0x9d,                                                          /* popfq */
+
+    0xc3,                                                            /* ret */
+    0x90, 0x90, 0x90                                             /* nop pad */
+
+    /* Read-only data goes here: */
+    /* uint8_t* __afl_area_ptr */
+    /* uint64_t* &previous_pc */
+
+};
+
+static const guint8 afl_log_code_with_suppression[] = {
+
+    // 0xcc,
+
+    0x9c,                                                         /* pushfq */
+    0x51,                                                       /* push rcx */
+    0x52,                                                       /* push rdx */
+
+    0x8b, 0x8c, 0x24, 0x00, 0xc0, 0xff,
+    0xff,                                           /* mov ecx, [rsp-13684] */
+    0x81, 0xf9, 0xce, 0xfa, 0xad, 0xde,              /* cmp ecx, 0xdeadface */
+
+    0x74, 0x20,                                                 /* je done: */
+
+    0x48, 0x8b, 0x0d, 0x28, 0x00, 0x00,
+    0x00,                                      /* mov rcx, sym.&previous_pc */
+    0x48, 0x8b, 0x11,                               /* mov rdx, qword [rcx] */
+    0x48, 0x31, 0xfa,                                       /* xor rdx, rdi */
+
+    0x48, 0x03, 0x15, 0x13, 0x00, 0x00,
+    0x00, /* add rdx, sym._afl_area_ptr_ptr
+           */
 
     0x80, 0x02, 0x01,                              /* add byte ptr [rdx], 1 */
     0x80, 0x12, 0x00,                              /* adc byte ptr [rdx], 0 */
@@ -66,7 +110,16 @@ void instrument_coverage_optimize(const cs_insn *   instr,
     gum_x86_writer_put_jmp_near_label(cw, after_log_impl);
 
     current_log_impl = cw->pc;
-    gum_x86_writer_put_bytes(cw, afl_log_code, sizeof(afl_log_code));
+    if (instrument_suppression) {
+
+      gum_x86_writer_put_bytes(cw, afl_log_code_with_suppression,
+                               sizeof(afl_log_code_with_suppression));
+
+    } else {
+
+      gum_x86_writer_put_bytes(cw, afl_log_code, sizeof(afl_log_code));
+
+    }
 
     uint64_t *afl_prev_loc_ptr = &previous_pc;
     gum_x86_writer_put_bytes(cw, (const guint8 *)&__afl_area_ptr,
@@ -78,6 +131,8 @@ void instrument_coverage_optimize(const cs_insn *   instr,
 
   }
 
+  // gum_x86_writer_put_breakpoint(cw);
+
   gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP,
                                         -GUM_RED_ZONE_SIZE);
   gum_x86_writer_put_push_reg(cw, GUM_REG_RDI);
@@ -86,6 +141,249 @@ void instrument_coverage_optimize(const cs_insn *   instr,
   gum_x86_writer_put_pop_reg(cw, GUM_REG_RDI);
   gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP,
                                         GUM_RED_ZONE_SIZE);
+
+}
+
+static gboolean instrument_is_end_of_block(const cs_insn *instr) {
+
+  switch (instr->id) {
+
+    case X86_INS_RET:
+    case X86_INS_RETF:
+
+    case X86_INS_JCXZ:
+    case X86_INS_JECXZ:
+    case X86_INS_JRCXZ:
+    case X86_INS_JMP:
+
+    case X86_INS_JAE:
+    case X86_INS_JA:
+    case X86_INS_JBE:
+    case X86_INS_JB:
+    case X86_INS_JE:
+    case X86_INS_JGE:
+    case X86_INS_JG:
+    case X86_INS_JLE:
+    case X86_INS_JL:
+    case X86_INS_JNE:
+    case X86_INS_JNO:
+    case X86_INS_JNP:
+    case X86_INS_JNS:
+    case X86_INS_JO:
+    case X86_INS_JP:
+    case X86_INS_JS:
+
+    case X86_INS_CALL:
+      return TRUE;
+    default:
+      return FALSE;
+
+  }
+
+}
+
+static gboolean instrument_is_excluded_call(const cs_insn *instr) {
+
+  cs_x86     x86 = instr->detail->x86;
+  cs_x86_op *operand = &x86.operands[0];
+
+  if (instr->id != X86_INS_CALL) { return FALSE; }
+  if (x86.op_count != 1) { FATAL("Unexpected operand count"); }
+  if (operand->type != X86_OP_IMM) { return FALSE; }
+
+  if (!range_is_excluded(GSIZE_TO_POINTER(operand->imm))) { return FALSE; }
+
+  return TRUE;
+
+}
+
+static gssize instrument_get_offset_adjust(const cs_insn *instr) {
+
+  cs_x86     x86 = instr->detail->x86;
+  cs_x86_op *operand = &x86.operands[0];
+
+  switch (instr->id) {
+
+    case X86_INS_RET:
+      if (x86.op_count == 0) {
+
+        return -8;
+
+      } else {
+
+        if (operand->type == X86_OP_IMM) { return -((operand->imm + 1) * 8); }
+
+        return 0;
+
+      }
+
+    case X86_INS_RETF:
+      if (x86.op_count == 0) {
+
+        return -16;
+
+      } else {
+
+        if (operand->type != X86_OP_IMM) { FATAL("Unexpected operand type"); }
+        return -((operand->imm + 2) * 8);
+
+      }
+
+    case X86_INS_JCXZ:
+    case X86_INS_JECXZ:
+    case X86_INS_JRCXZ:
+    case X86_INS_JMP:
+
+    case X86_INS_JAE:
+    case X86_INS_JA:
+    case X86_INS_JBE:
+    case X86_INS_JB:
+    case X86_INS_JE:
+    case X86_INS_JGE:
+    case X86_INS_JG:
+    case X86_INS_JLE:
+    case X86_INS_JL:
+    case X86_INS_JNE:
+    case X86_INS_JNO:
+    case X86_INS_JNP:
+    case X86_INS_JNS:
+    case X86_INS_JO:
+    case X86_INS_JP:
+    case X86_INS_JS:
+      return 0;
+    case X86_INS_CALL:
+      /* far */
+      if (x86.op_count != 1) { FATAL("Unexpected operand count"); }
+
+      if (operand->type == X86_OP_MEM) {
+
+        if (operand->mem.segment != X86_REG_INVALID) { return 16; }
+
+      }
+
+      if (instrument_is_excluded_call(instr)) { return 0; }
+
+      return 8;
+    default:
+      FATAL("Unexpected instruction");
+
+  }
+
+}
+
+void instrument_coverage_write_cookie(const cs_insn *   instr,
+                                      GumStalkerOutput *output,
+                                      gssize            stack_offset) {
+
+  GumX86Writer *cw = output->writer.x86;
+  cs_x86        x86 = instr->detail->x86;
+  cs_x86_op *   operand = &x86.operands[0];
+  guint32       suppress_cookie = 0xdeadface;
+  guint32       no_suppress_cookie = 0xb00bd00d;
+
+  switch (instr->id) {
+
+    case X86_INS_RET:
+      gum_x86_writer_put_mov_reg_offset_ptr_u32(cw, GUM_REG_RSP, -stack_offset,
+                                                no_suppress_cookie);
+      return;
+
+    case X86_INS_RETF:
+      gum_x86_writer_put_mov_reg_offset_ptr_u32(cw, GUM_REG_RSP, -stack_offset,
+                                                no_suppress_cookie);
+      return;
+
+    case X86_INS_JCXZ:
+    case X86_INS_JECXZ:
+    case X86_INS_JRCXZ:
+    case X86_INS_JMP:
+    case X86_INS_CALL:
+      /* far */
+      if (x86.op_count != 1) { FATAL("Unexpected operand count"); }
+
+      if (operand->type == X86_OP_IMM) {
+
+        gum_x86_writer_put_mov_reg_offset_ptr_u32(
+            cw, GUM_REG_RSP, -stack_offset, suppress_cookie);
+
+      } else {
+
+        gum_x86_writer_put_mov_reg_offset_ptr_u32(
+            cw, GUM_REG_RSP, -stack_offset, no_suppress_cookie);
+
+      }
+
+      return;
+
+    case X86_INS_JAE:
+    case X86_INS_JA:
+    case X86_INS_JBE:
+    case X86_INS_JB:
+    case X86_INS_JE:
+    case X86_INS_JGE:
+    case X86_INS_JG:
+    case X86_INS_JLE:
+    case X86_INS_JL:
+    case X86_INS_JNE:
+    case X86_INS_JNO:
+    case X86_INS_JNP:
+    case X86_INS_JNS:
+    case X86_INS_JO:
+    case X86_INS_JP:
+    case X86_INS_JS: {
+
+      gconstpointer match = cw->code + 1;
+      gconstpointer done_match = cw->code + 2;
+      gum_x86_writer_put_jcc_short_label(cw, instr->id, match, GUM_NO_HINT);
+      gum_x86_writer_put_mov_reg_offset_ptr_u32(cw, GUM_REG_RSP, -stack_offset,
+                                                no_suppress_cookie);
+      gum_x86_writer_put_jmp_short_label(cw, done_match);
+      gum_x86_writer_put_label(cw, match);
+      gum_x86_writer_put_mov_reg_offset_ptr_u32(cw, GUM_REG_RSP, -stack_offset,
+                                                suppress_cookie);
+      gum_x86_writer_put_label(cw, done_match);
+      return;
+
+    }
+
+    default:
+      FATAL("Unexpected instruction");
+
+  }
+
+}
+
+void instrument_coverage_suppress(const cs_insn *   instr,
+                                  GumStalkerOutput *output) {
+
+  GumX86Writer *cw = output->writer.x86;
+  // -------------------------
+  // | RDX (callee saved)    |
+  // -------------------------
+  // | RCX (callee saved)    |
+  // -------------------------
+  // | RFLAGS (callee saved) |
+  // -------------------------
+  // | return address        |
+  // -------------------------
+  // | RDI (caller saved)    |
+  // -------------------------
+  // | red-zone              |
+  // -------------------------
+  // | old sp                |
+  // -------------------------
+
+  if (!instrument_suppression) { return; }
+
+  if (!instrument_is_end_of_block(instr)) { return; }
+
+  gssize offset = 16384;
+  gssize used = (GUM_RED_ZONE_SIZE + (5 * 8));
+  gssize adjust = instrument_get_offset_adjust(instr);
+
+  gssize stack_offset = offset + used + adjust;
+
+  instrument_coverage_write_cookie(instr, output, stack_offset);
 
 }
 

--- a/frida_mode/test/png/GNUmakefile
+++ b/frida_mode/test/png/GNUmakefile
@@ -27,10 +27,11 @@ endif
 
 TEST_DATA_DIR:=$(LIBPNG_DIR)contrib/pngsuite/
 
+AFLPP_DRIVER_DUMMY_INPUT:=$(BUILD_DIR)in
 QEMU_OUT:=$(BUILD_DIR)qemu-out
 FRIDA_OUT:=$(BUILD_DIR)frida-out
 
-.PHONY: all clean qemu frida
+.PHONY: all clean qemu frida debug
 
 all: $(TEST_BIN)
 	make -C $(ROOT)frida_mode/
@@ -40,6 +41,9 @@ all: $(TEST_BIN)
 
 $(BUILD_DIR):
 	mkdir -p $@
+
+$(AFLPP_DRIVER_DUMMY_INPUT): | $(BUILD_DIR)
+	truncate -s 1M $@
 
 ######### HARNESS ########
 $(HARNESS_BUILD_DIR): | $(BUILD_DIR)
@@ -112,3 +116,9 @@ frida: $(TEST_BIN)
 		-o $(FRIDA_OUT) \
 		-- \
 			$(TEST_BIN) @@
+
+debug: $(AFLPP_DRIVER_DUMMY_INPUT)
+	gdb \
+		--ex 'set environment LD_PRELOAD=$(ROOT)afl-frida-trace.so' \
+		--ex 'set disassembly-flavor intel' \
+		--args $(TEST_BIN) $(AFLPP_DRIVER_DUMMY_INPUT)

--- a/frida_mode/test/png/Makefile
+++ b/frida_mode/test/png/Makefile
@@ -14,3 +14,6 @@ qemu:
 
 frida:
 	@gmake frida
+
+debug:
+	@gmake debug


### PR DESCRIPTION
**DO NOT MERGE INTO DEV**

This PR includes changes for x64 which support the suppression of the generation of coverage information when either:

- There is a `call`, `jmp` `jrcxz` etc where the target is given as an immediate
- There is a conditional branch `jae`, `ja`, `jbe`, `jb` .... where the branch is not taken.

The theory is that in the case of the former, the branch was always going to happen, and always going to the same location. Hence given that execution reached the block of the caller, the generated coverage information was inevitable and hence superfluous.

In the case of the latter, whilst the conditional branch is considered the end of a basic block, the branch was not actually taken and hence the absence of the coverage information from the taken branch is sufficiently distinguishing.

The intention of this approach is to remove unnecessary coverage information from polluting the coverage map and potentially creating collisions. However, this comes at the expense of a performance overhead (albeit mostly incurred during block compilation rather than execution).

The code which updates the coverage map is in the destination block (since calculating the target address at the source block is likely expensive and complicated). However, at the destination block we don't know how the block was reached (e.g. whether by a `call imm` or `call reg`, each block could be reached by multiple different instructions) and hence whether to suppress the coverage generation.

Therefore, we instrument the instruction which causes the block transition to write a cookie into the stack (far beyond the stack pointer, since stalker internally is at liberty to use the stack beyond the red-zone). This cookie is then detected in the coverage generation code.