### PR TITLE
Dynamic map2

### DIFF
--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -20,6 +20,7 @@ RT_CFLAGS:=-Wno-unused-parameter \
 		   -Wno-unused-function \
 		   -Wno-unused-result \
 		   -Wno-int-to-pointer-cast \
+		   -Wno-pointer-sign \
 
 LDFLAGS+=-shared \
 		 -lpthread \

--- a/frida_mode/include/instrument.h
+++ b/frida_mode/include/instrument.h
@@ -4,10 +4,11 @@
 #include "frida-gum.h"
 
 #include "config.h"
+#include "sharedmem.h"
 
 extern __thread uint64_t previous_pc;
 extern uint8_t *         __afl_area_ptr;
-extern uint32_t          __afl_map_size;
+extern struct map_size * __afl_map_size_addr;
 
 void instrument_init(void);
 

--- a/frida_mode/src/cmplog/cmplog_arm64.c
+++ b/frida_mode/src/cmplog/cmplog_arm64.c
@@ -114,6 +114,7 @@ static void cmplog_call_callout(GumCpuContext *context, gpointer user_data) {
   uintptr_t k = address;
 
   k = (k >> 4) ^ (k << 8);
+  // TODO: DONT HARD CODE THE MAP SIZE
   k &= CMP_MAP_W - 1;
 
   __afl_cmp_map->headers[k].type = CMP_TYPE_RTN;
@@ -191,6 +192,7 @@ static void cmplog_handle_cmp_sub(GumCpuContext *context, gsize operand1,
   register uintptr_t k = (uintptr_t)address;
 
   k = (k >> 4) ^ (k << 8);
+  // TODO: DONT HARD CODE THE MAP SIZE
   k &= CMP_MAP_W - 1;
 
   __afl_cmp_map->headers[k].type = CMP_TYPE_INS;

--- a/frida_mode/src/cmplog/cmplog_x64.c
+++ b/frida_mode/src/cmplog/cmplog_x64.c
@@ -5,6 +5,7 @@
 
 #include "ctx.h"
 #include "frida_cmplog.h"
+#include "instrument.h"
 #include "util.h"
 
 #if defined(__x86_64__)
@@ -109,7 +110,7 @@ static void cmplog_call_callout(GumCpuContext *context, gpointer user_data) {
   uintptr_t k = address;
 
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   __afl_cmp_map->entries[k].type = CMP_TYPE_RTN;
 
@@ -175,7 +176,7 @@ static void cmplog_handle_cmp_sub(GumCpuContext *context, gsize operand1,
   register uintptr_t k = (uintptr_t)address;
 
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
 

--- a/frida_mode/src/cmplog/cmplog_x64.c
+++ b/frida_mode/src/cmplog/cmplog_x64.c
@@ -111,18 +111,16 @@ static void cmplog_call_callout(GumCpuContext *context, gpointer user_data) {
   k = (k >> 4) ^ (k << 8);
   k &= CMP_MAP_W - 1;
 
-  __afl_cmp_map->headers[k].type = CMP_TYPE_RTN;
+  __afl_cmp_map->entries[k].type = CMP_TYPE_RTN;
 
-  u32 hits = __afl_cmp_map->headers[k].hits;
-  __afl_cmp_map->headers[k].hits = hits + 1;
+  u32 hits = __afl_cmp_map->entries[k].hits;
+  __afl_cmp_map->entries[k].hits = hits + 1;
 
-  __afl_cmp_map->headers[k].shape = 31;
+  __afl_cmp_map->entries[k].shape = 31;
 
   hits &= CMP_MAP_RTN_H - 1;
-  gum_memcpy(((struct cmpfn_operands *)__afl_cmp_map->log[k])[hits].v0, ptr1,
-             32);
-  gum_memcpy(((struct cmpfn_operands *)__afl_cmp_map->log[k])[hits].v1, ptr2,
-             32);
+  gum_memcpy(__afl_cmp_map->entries[k].log[hits].fn.v0, ptr1, 32);
+  gum_memcpy(__afl_cmp_map->entries[k].log[hits].fn.v1, ptr2, 32);
 
 }
 
@@ -179,16 +177,16 @@ static void cmplog_handle_cmp_sub(GumCpuContext *context, gsize operand1,
   k = (k >> 4) ^ (k << 8);
   k &= CMP_MAP_W - 1;
 
-  __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+  __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
 
-  u32 hits = __afl_cmp_map->headers[k].hits;
-  __afl_cmp_map->headers[k].hits = hits + 1;
+  u32 hits = __afl_cmp_map->entries[k].hits;
+  __afl_cmp_map->entries[k].hits = hits + 1;
 
-  __afl_cmp_map->headers[k].shape = (size - 1);
+  __afl_cmp_map->entries[k].shape = (size - 1);
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = operand1;
-  __afl_cmp_map->log[k][hits].v1 = operand2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = operand1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = operand2;
 
 }
 

--- a/frida_mode/src/cmplog/cmplog_x86.c
+++ b/frida_mode/src/cmplog/cmplog_x86.c
@@ -114,6 +114,7 @@ static void cmplog_call_callout(GumCpuContext *context, gpointer user_data) {
   uintptr_t k = address;
 
   k = (k >> 4) ^ (k << 8);
+  // TODO: DONT HARD CODE THE MAP SIZE
   k &= CMP_MAP_W - 1;
 
   __afl_cmp_map->headers[k].type = CMP_TYPE_RTN;
@@ -182,6 +183,7 @@ static void cmplog_handle_cmp_sub(GumCpuContext *context, gsize operand1,
   register uintptr_t k = (uintptr_t)address;
 
   k = (k >> 4) ^ (k << 8);
+  // TODO: DONT HARD CODE THE MAP SIZE
   k &= CMP_MAP_W - 1;
 
   __afl_cmp_map->headers[k].type = CMP_TYPE_INS;

--- a/frida_mode/src/instrument/instrument.c
+++ b/frida_mode/src/instrument/instrument.c
@@ -26,6 +26,13 @@ __attribute__((hot)) static void on_basic_block(GumCpuContext *context,
                                                 gpointer       user_data) {
 
   UNUSED_PARAMETER(context);
+
+  if (__afl_map_size_addr->size != MAP_SIZE) {
+
+    FATAL("Unexpected map size: %u", __afl_map_size_addr->size);
+
+  }
+
   /*
    * This function is performance critical as it is called to instrument every
    * basic block. By moving our print buffer to a global, we avoid it affecting
@@ -173,12 +180,6 @@ void instrument_init(void) {
   if (tracing && optimize) {
 
     FATAL("AFL_FRIDA_INST_OPTIMIZE and AFL_FRIDA_INST_TRACE are incompatible");
-
-  }
-
-  if (__afl_map_size != 0x10000) {
-
-    FATAL("Bad map size: 0x%08x", __afl_map_size);
 
   }
 

--- a/frida_mode/src/instrument/instrument_arm64.c
+++ b/frida_mode/src/instrument/instrument_arm64.c
@@ -55,6 +55,8 @@ void instrument_coverage_optimize(const cs_insn *   instr,
 
   guint64 current_pc = instr->address;
   guint64 area_offset = (current_pc >> 4) ^ (current_pc << 8);
+
+  // TODO: DONT HARD CODE THE MAP SIZE
   area_offset &= MAP_SIZE - 1;
   GumArm64Writer *cw = output->writer.arm64;
 

--- a/frida_mode/src/instrument/instrument_x86.c
+++ b/frida_mode/src/instrument/instrument_x86.c
@@ -54,6 +54,8 @@ void instrument_coverage_optimize(const cs_insn *   instr,
 
   guint64 current_pc = instr->address;
   guint64 area_offset = (current_pc >> 4) ^ (current_pc << 8);
+
+  // TODO: DONT HARD CODE THE MAP SIZE
   area_offset &= MAP_SIZE - 1;
   GumX86Writer *cw = output->writer.x86;
 

--- a/include/alloc-inl.h
+++ b/include/alloc-inl.h
@@ -167,9 +167,9 @@ static inline void *DFL_ck_alloc(u32 size) {
 
 }
 
-/* Free memory, checking for double free and corrupted heap. When DEBUG_BUILD
-   is set, the old memory will be also clobbered with 0xFF. */
-
+  /* Free memory, checking for double free and corrupted heap. When DEBUG_BUILD
+     is set, the old memory will be also clobbered with 0xFF. */
+  #include <execinfo.h>
 static inline void DFL_ck_free(void *mem) {
 
   if (!mem) { return; }

--- a/include/alloc-inl.h
+++ b/include/alloc-inl.h
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <sys/mman.h>
 
 #include "config.h"
 #include "types.h"
@@ -43,6 +44,16 @@
 
 #ifndef _WANT_ORIGINAL_AFL_ALLOC
   // afl++ stuff without memory corruption checks - for speed
+
+  #define NO_COMMIT_MAGIC 0xdeadface
+
+typedef struct {
+
+  u32 magic;
+  u32 size;
+  u8  buffer[0];
+
+} no_commit_t;
 
   /* User-facing macro to sprintf() to a dynamically allocated buffer. */
 
@@ -94,6 +105,34 @@ static inline void *DFL_ck_alloc_nozero(u32 size) {
 
 }
 
+static inline void *DFL_ck_alloc_no_commit(u32 size) {
+
+  no_commit_t *mem;
+
+  if (size == 0) { return NULL; }
+  if (UINT32_MAX - sizeof(no_commit_t) < size) {
+
+    FATAL("Requested too much memory: %u bytes", size);
+
+  }
+
+  int flags = MAP_PRIVATE | MAP_ANONYMOUS;  // | MAP_NORESERVE;
+
+  mem = (no_commit_t *)mmap(NULL, size + sizeof(no_commit_t),
+                            PROT_READ | PROT_WRITE, flags, -1, 0);
+  if (mem == MAP_FAILED) {
+
+    FATAL("Failed to allocate: %u bytes, errno: %d", size, errno);
+
+  }
+
+  mem->magic = NO_COMMIT_MAGIC;
+  mem->size = size + sizeof(no_commit_t);
+
+  return &mem->buffer;
+
+}
+
 /* Allocate a buffer, returning zeroed memory.
   Returns null for 0 size */
 
@@ -116,6 +155,26 @@ static inline void DFL_ck_free(void *mem) {
   if (!mem) { return; }
 
   free(mem);
+
+}
+
+static inline void DFL_ck_free_no_commit(void *mem) {
+
+  if (mem == NULL) { return; }
+  if (mem < (void *)offsetof(no_commit_t, buffer)) {
+
+    FATAL("Invalid address: %p", mem);
+
+  }
+
+  no_commit_t *hdr = (no_commit_t *)((u8 *)mem - offsetof(no_commit_t, buffer));
+  if (hdr->magic != NO_COMMIT_MAGIC) { FATAL("Corrupted magic"); }
+
+  if (munmap(hdr, hdr->size) < 0) {
+
+    FATAL("Failed to free: %p, errno: %d", mem, errno);
+
+  }
 
 }
 
@@ -147,6 +206,13 @@ static inline void *DFL_ck_realloc(void *orig, u32 size) {
 
 }
 
+static inline void *DFL_ck_realloc_no_commit(void *orig, u32 size) {
+
+  DFL_ck_free_no_commit(orig);
+  return DFL_ck_alloc_no_commit(size);
+
+}
+
 /* Create a buffer with a copy of a string. Returns NULL for NULL inputs. */
 
 static inline u8 *DFL_ck_strdup(u8 *str) {
@@ -174,6 +240,10 @@ static inline u8 *DFL_ck_strdup(u8 *str) {
   #define ck_realloc DFL_ck_realloc
   #define ck_strdup DFL_ck_strdup
   #define ck_free DFL_ck_free
+
+  #define ck_alloc_no_commit DFL_ck_alloc_no_commit
+  #define ck_realloc_no_commit DFL_ck_realloc_no_commit
+  #define ck_free_no_commit DFL_ck_free_no_commit
 
   #define alloc_report()
 

--- a/include/cmplog.h
+++ b/include/cmplog.h
@@ -32,7 +32,6 @@
 
 #define CMPLOG_LVL_MAX 3
 
-#define CMP_MAP_W 65536
 #define CMP_MAP_H 32
 #define CMP_MAP_RTN_H (CMP_MAP_H / 4)
 
@@ -79,7 +78,7 @@ struct cmp_entry {
 
 struct cmp_map {
 
-  struct cmp_entry entries[CMP_MAP_W];
+  struct cmp_entry entries[0];
 
 };
 

--- a/include/cmplog.h
+++ b/include/cmplog.h
@@ -41,17 +41,6 @@
 #define CMP_TYPE_INS 1
 #define CMP_TYPE_RTN 2
 
-struct cmp_header {
-
-  unsigned hits : 24;
-  unsigned id : 24;
-  unsigned shape : 5;
-  unsigned type : 2;
-  unsigned attribute : 4;
-  unsigned reserved : 5;
-
-} __attribute__((packed));
-
 struct cmp_operands {
 
   u64 v0;
@@ -68,12 +57,29 @@ struct cmpfn_operands {
 
 };
 
-typedef struct cmp_operands cmp_map_list[CMP_MAP_H];
+union cmp_log {
+
+  struct cmp_operands   cmp;
+  struct cmpfn_operands fn;
+
+};
+
+struct cmp_entry {
+
+  unsigned hits : 24;
+  unsigned id : 24;
+  unsigned shape : 5;
+  unsigned type : 2;
+  unsigned attribute : 4;
+  unsigned reserved : 5;
+
+  union cmp_log log[CMP_MAP_H];
+
+};
 
 struct cmp_map {
 
-  struct cmp_header   headers[CMP_MAP_W];
-  struct cmp_operands log[CMP_MAP_W][CMP_MAP_H];
+  struct cmp_entry entries[CMP_MAP_W];
 
 };
 

--- a/include/config.h
+++ b/include/config.h
@@ -439,6 +439,7 @@
 
 #define MAP_SIZE_POW2 16
 #define MAP_SIZE (1U << MAP_SIZE_POW2)
+#define MAX_MAP_SIZE (256UL << 20)
 
 /* Maximum allocator request size (keep well under INT_MAX): */
 

--- a/include/config.h
+++ b/include/config.h
@@ -382,6 +382,10 @@
 
 #define SHM_ENV_VAR "__AFL_SHM_ID"
 
+/* Environment variable used to pass SHM SIZE ID to the called program. */
+
+#define SHM_SIZE_ENV_VAR "__AFL_SHM_SIZE_ID"
+
 /* Environment variable used to pass SHM FUZZ ID to the called program. */
 
 #define SHM_FUZZ_ENV_VAR "__AFL_SHM_FUZZ_ID"

--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -47,7 +47,9 @@ typedef struct {
 } sharedmem_alloc_t;
 
 struct map_size {
+
   u32 size;
+
 };
 
 typedef struct sharedmem {
@@ -59,9 +61,9 @@ typedef struct sharedmem {
   int cmplog_mode;
   int shmemfuzz_mode;
 
-  size_t          map_size;                        /* actual allocated size */
+  size_t map_size;                                 /* actual allocated size */
 
-  struct cmp_map  *cmp_map;
+  struct cmp_map * cmp_map;
   struct map_size *map_size_ptr;
 
 } sharedmem_t;

--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -46,16 +46,23 @@ typedef struct {
 
 } sharedmem_alloc_t;
 
+struct map_size {
+  u32 size;
+};
+
 typedef struct sharedmem {
 
   sharedmem_alloc_t shm;
   sharedmem_alloc_t cmplog_shm;
+  sharedmem_alloc_t mapsize_shm;
 
   int cmplog_mode;
   int shmemfuzz_mode;
 
-  struct cmp_map *cmp_map;
   size_t          map_size;                        /* actual allocated size */
+
+  struct cmp_map  *cmp_map;
+  struct map_size *map_size_ptr;
 
 } sharedmem_t;
 

--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -55,7 +55,6 @@ typedef struct sharedmem {
   int shmemfuzz_mode;
 
   struct cmp_map *cmp_map;
-  u8 *            map;                              /* shared memory region */
   size_t          map_size;                        /* actual allocated size */
 
 } sharedmem_t;

--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -30,29 +30,33 @@
 
 #include "types.h"
 
-typedef struct sharedmem {
-
-  // extern unsigned char *trace_bits;
+typedef struct {
 
 #ifdef USEMMAP
   /* ================ Proteas ================ */
   int  g_shm_fd;
   char g_shm_file_path[L_tmpnam];
-  int  cmplog_g_shm_fd;
-  char cmplog_g_shm_file_path[L_tmpnam];
 /* ========================================= */
 #else
   s32 shm_id;                          /* ID of the SHM region              */
-  s32 cmplog_shm_id;
 #endif
 
-  u8 *map;                                          /* shared memory region */
+  void * map;
+  size_t size;
 
-  size_t map_size;                                 /* actual allocated size */
+} sharedmem_alloc_t;
 
-  int             cmplog_mode;
-  int             shmemfuzz_mode;
+typedef struct sharedmem {
+
+  sharedmem_alloc_t shm;
+  sharedmem_alloc_t cmplog_shm;
+
+  int cmplog_mode;
+  int shmemfuzz_mode;
+
   struct cmp_map *cmp_map;
+  u8 *            map;                              /* shared memory region */
+  size_t          map_size;                        /* actual allocated size */
 
 } sharedmem_t;
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -94,10 +94,8 @@ u8 *       __afl_fuzz_ptr;
 static u32 __afl_fuzz_len_dummy;
 u32 *      __afl_fuzz_len = &__afl_fuzz_len_dummy;
 
-struct map_size __afl_map_size_addr_default = {
-  .size = MAP_SIZE
-};
-struct map_size* __afl_map_size_addr = &__afl_map_size_addr_default;
+struct map_size  __afl_map_size_addr_default = {.size = MAP_SIZE};
+struct map_size *__afl_map_size_addr = &__afl_map_size_addr_default;
 
 u32 __afl_final_loc;
 u32 __afl_map_size = MAP_SIZE;
@@ -195,10 +193,11 @@ static void send_forkserver_error(int error) {
 
 }
 
-static void* __afl_map(char * id_str, size_t size, void * addr) {
+static void *__afl_map(char *id_str, size_t size, void *addr) {
+
   u8 *map = NULL;
 
-  #ifdef USEMMAP
+#ifdef USEMMAP
   const char *shm_file_path = id_str;
   int         shm_fd = -1;
 
@@ -214,11 +213,14 @@ static void* __afl_map(char * id_str, size_t size, void * addr) {
 
   if (addr == NULL) {
 
-  map =
-      (u8 *)mmap(0, size, PROT_READ, MAP_NORESERVE | MAP_SHARED, shm_fd, 0);
+    map = (u8 *)mmap(0, size, PROT_READ, MAP_NORESERVE | MAP_SHARED, shm_fd, 0);
+
   } else {
+
     map =
-      (u8 *)mmap(0, size, PROT_READ, MAP_NORESERVE | MAP_FIXED_NOREPLACE | MAP_SHARED, shm_fd, 0);
+        (u8 *)mmap(0, size, PROT_READ,
+                   MAP_NORESERVE | MAP_FIXED_NOREPLACE | MAP_SHARED, shm_fd, 0);
+
   }
 
   if (map == MAP_FAILED) {
@@ -235,12 +237,12 @@ static void* __afl_map(char * id_str, size_t size, void * addr) {
 
   }
 
-
 #else
   u32 shm_id = atoi(id_str);
   map = (u8 *)shmat(shm_id, addr, 0);
 
   if (!map || map == (void *)-1) {
+
     fprintf(stderr, "shmat() failed\n");
     perror("shmat for map");
 
@@ -256,18 +258,21 @@ static void* __afl_map(char * id_str, size_t size, void * addr) {
 
 #endif
   return map;
+
 }
 
-void __afl_unmap(void * addr, size_t size) {
+void __afl_unmap(void *addr, size_t size) {
+
 #ifdef USEMMAP
 
-    munmap((void *)addr, size);
+  munmap((void *)addr, size);
 
 #else
 
-    shmdt((void *)addr);
+  shmdt((void *)addr);
 
 #endif
+
 }
 
 /* SHM fuzzing setup. */
@@ -419,7 +424,7 @@ static void __afl_map_shm(void) {
 
 #endif
 
-    __afl_area_ptr = __afl_map(id_str, MAX_MAP_SIZE, (void*)__afl_map_addr);
+    __afl_area_ptr = __afl_map(id_str, MAX_MAP_SIZE, (void *)__afl_map_addr);
 
     /* Write something into the bitmap so that even with low AFL_INST_RATIO,
        our parent doesn't give up on us. */
@@ -460,10 +465,14 @@ static void __afl_map_shm(void) {
 
   id_str = getenv(SHM_SIZE_ENV_VAR);
   if (id_str) {
+
     __afl_map_size_addr = __afl_map(id_str, sizeof(struct map_size), NULL);
+
   } else {
+
     __afl_map_size_addr = &__afl_map_size_addr_default;
     __afl_map_size_addr_default.size = __afl_map_size;
+
   }
 
   __afl_area_ptr_backup = __afl_area_ptr;
@@ -570,8 +579,6 @@ static void __afl_unmap_shm(void) {
     __afl_map_size_addr = NULL;
 
   }
-
-
 
   id_str = getenv(CMPLOG_SHM_ENV_VAR);
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -632,7 +632,7 @@ static void __afl_unmap_shm(void) {
 
 #define write_error(text) write_error_with_location(text, __FILE__, __LINE__)
 
-void write_error_with_location(char *text, char* filename, int linenumber) {
+void write_error_with_location(char *text, char *filename, int linenumber) {
 
   u8 *  o = getenv("__AFL_OUT_DIR");
   char *e = strerror(errno);
@@ -645,14 +645,16 @@ void write_error_with_location(char *text, char* filename, int linenumber) {
 
     if (f) {
 
-      fprintf(f, "File %s, line %d: Error(%s): %s\n", filename, linenumber, text, e);
+      fprintf(f, "File %s, line %d: Error(%s): %s\n", filename, linenumber,
+              text, e);
       fclose(f);
 
     }
 
   }
 
-  fprintf(stderr, "File %s, line %d: Error(%s): %s\n", filename, linenumber, text, e);
+  fprintf(stderr, "File %s, line %d: Error(%s): %s\n", filename, linenumber,
+          text, e);
 
 }
 
@@ -1501,24 +1503,24 @@ void __cmplog_ins_hook1(uint8_t arg1, uint8_t arg2, uint8_t attr) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = 0;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = 0;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = arg1;
-  __afl_cmp_map->log[k][hits].v1 = arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = arg2;
 
 }
 
@@ -1532,30 +1534,30 @@ void __cmplog_ins_hook2(uint16_t arg1, uint16_t arg2, uint8_t attr) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = 1;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = 1;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (!__afl_cmp_map->headers[k].shape) {
+    if (!__afl_cmp_map->entries[k].shape) {
 
-      __afl_cmp_map->headers[k].shape = 1;
+      __afl_cmp_map->entries[k].shape = 1;
 
     }
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = arg1;
-  __afl_cmp_map->log[k][hits].v1 = arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = arg2;
 
 }
 
@@ -1571,30 +1573,30 @@ void __cmplog_ins_hook4(uint32_t arg1, uint32_t arg2, uint8_t attr) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = 3;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = 3;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (__afl_cmp_map->headers[k].shape < 3) {
+    if (__afl_cmp_map->entries[k].shape < 3) {
 
-      __afl_cmp_map->headers[k].shape = 3;
+      __afl_cmp_map->entries[k].shape = 3;
 
     }
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = arg1;
-  __afl_cmp_map->log[k][hits].v1 = arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = arg2;
 
 }
 
@@ -1610,30 +1612,30 @@ void __cmplog_ins_hook8(uint64_t arg1, uint64_t arg2, uint8_t attr) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = 7;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = 7;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (__afl_cmp_map->headers[k].shape < 7) {
+    if (__afl_cmp_map->entries[k].shape < 7) {
 
-      __afl_cmp_map->headers[k].shape = 7;
+      __afl_cmp_map->entries[k].shape = 7;
 
     }
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = arg1;
-  __afl_cmp_map->log[k][hits].v1 = arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = arg2;
 
 }
 
@@ -1654,35 +1656,35 @@ void __cmplog_ins_hookN(uint128_t arg1, uint128_t arg2, uint8_t attr,
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = size;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = size;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (__afl_cmp_map->headers[k].shape < size) {
+    if (__afl_cmp_map->entries[k].shape < size) {
 
-      __afl_cmp_map->headers[k].shape = size;
+      __afl_cmp_map->entries[k].shape = size;
 
     }
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = (u64)arg1;
-  __afl_cmp_map->log[k][hits].v1 = (u64)arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = (u64)arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = (u64)arg2;
 
   if (size > 7) {
 
-    __afl_cmp_map->log[k][hits].v0_128 = (u64)(arg1 >> 64);
-    __afl_cmp_map->log[k][hits].v1_128 = (u64)(arg2 >> 64);
+    __afl_cmp_map->entries[k].log[hits].cmp.v0_128 = (u64)(arg1 >> 64);
+    __afl_cmp_map->entries[k].log[hits].cmp.v1_128 = (u64)(arg2 >> 64);
 
   }
 
@@ -1698,32 +1700,32 @@ void __cmplog_ins_hook16(uint128_t arg1, uint128_t arg2, uint8_t attr) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
     hits = 0;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = 15;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = 15;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (__afl_cmp_map->headers[k].shape < 15) {
+    if (__afl_cmp_map->entries[k].shape < 15) {
 
-      __afl_cmp_map->headers[k].shape = 15;
+      __afl_cmp_map->entries[k].shape = 15;
 
     }
 
   }
 
-  __afl_cmp_map->headers[k].attribute = attr;
+  __afl_cmp_map->entries[k].attribute = attr;
 
   hits &= CMP_MAP_H - 1;
-  __afl_cmp_map->log[k][hits].v0 = (u64)arg1;
-  __afl_cmp_map->log[k][hits].v1 = (u64)arg2;
-  __afl_cmp_map->log[k][hits].v0_128 = (u64)(arg1 >> 64);
-  __afl_cmp_map->log[k][hits].v1_128 = (u64)(arg2 >> 64);
+  __afl_cmp_map->entries[k].log[hits].cmp.v0 = (u64)arg1;
+  __afl_cmp_map->entries[k].log[hits].cmp.v1 = (u64)arg2;
+  __afl_cmp_map->entries[k].log[hits].cmp.v0_128 = (u64)(arg1 >> 64);
+  __afl_cmp_map->entries[k].log[hits].cmp.v1_128 = (u64)(arg2 >> 64);
 
 }
 
@@ -1804,30 +1806,30 @@ void __sanitizer_cov_trace_switch(uint64_t val, uint64_t *cases) {
 
     u32 hits;
 
-    if (__afl_cmp_map->headers[k].type != CMP_TYPE_INS) {
+    if (__afl_cmp_map->entries[k].type != CMP_TYPE_INS) {
 
-      __afl_cmp_map->headers[k].type = CMP_TYPE_INS;
+      __afl_cmp_map->entries[k].type = CMP_TYPE_INS;
       hits = 0;
-      __afl_cmp_map->headers[k].hits = 1;
-      __afl_cmp_map->headers[k].shape = 7;
+      __afl_cmp_map->entries[k].hits = 1;
+      __afl_cmp_map->entries[k].shape = 7;
 
     } else {
 
-      hits = __afl_cmp_map->headers[k].hits++;
+      hits = __afl_cmp_map->entries[k].hits++;
 
-      if (__afl_cmp_map->headers[k].shape < 7) {
+      if (__afl_cmp_map->entries[k].shape < 7) {
 
-        __afl_cmp_map->headers[k].shape = 7;
+        __afl_cmp_map->entries[k].shape = 7;
 
       }
 
     }
 
-    __afl_cmp_map->headers[k].attribute = 1;
+    __afl_cmp_map->entries[k].attribute = 1;
 
     hits &= CMP_MAP_H - 1;
-    __afl_cmp_map->log[k][hits].v0 = val;
-    __afl_cmp_map->log[k][hits].v1 = cases[i + 2];
+    __afl_cmp_map->entries[k].log[hits].cmp.v0 = val;
+    __afl_cmp_map->entries[k].log[hits].cmp.v1 = cases[i + 2];
 
   }
 
@@ -1906,30 +1908,28 @@ void __cmplog_rtn_hook(u8 *ptr1, u8 *ptr2) {
 
   u32 hits;
 
-  if (__afl_cmp_map->headers[k].type != CMP_TYPE_RTN) {
+  if (__afl_cmp_map->entries[k].type != CMP_TYPE_RTN) {
 
-    __afl_cmp_map->headers[k].type = CMP_TYPE_RTN;
-    __afl_cmp_map->headers[k].hits = 1;
-    __afl_cmp_map->headers[k].shape = len - 1;
+    __afl_cmp_map->entries[k].type = CMP_TYPE_RTN;
+    __afl_cmp_map->entries[k].hits = 1;
+    __afl_cmp_map->entries[k].shape = len - 1;
     hits = 0;
 
   } else {
 
-    hits = __afl_cmp_map->headers[k].hits++;
+    hits = __afl_cmp_map->entries[k].hits++;
 
-    if (__afl_cmp_map->headers[k].shape < len) {
+    if (__afl_cmp_map->entries[k].shape < len) {
 
-      __afl_cmp_map->headers[k].shape = len - 1;
+      __afl_cmp_map->entries[k].shape = len - 1;
 
     }
 
   }
 
   hits &= CMP_MAP_RTN_H - 1;
-  __builtin_memcpy(((struct cmpfn_operands *)__afl_cmp_map->log[k])[hits].v0,
-                   ptr1, len);
-  __builtin_memcpy(((struct cmpfn_operands *)__afl_cmp_map->log[k])[hits].v1,
-                   ptr2, len);
+  __builtin_memcpy(__afl_cmp_map->entries[k].log[hits].fn.v0, ptr1, len);
+  __builtin_memcpy(__afl_cmp_map->entries[k].log[hits].fn.v1, ptr2, len);
   // fprintf(stderr, "RTN3\n");
 
 }
@@ -2082,3 +2082,4 @@ void __afl_coverage_interesting(u8 val, u32 id) {
 }
 
 #undef write_error
+

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -189,7 +189,7 @@ static void send_forkserver_error(int error) {
 
 }
 
-static void* __afl_map(char * id_str, void * addr) {
+static void* __afl_map(char * id_str, size_t size, void * addr) {
   u8 *map = NULL;
 
   #ifdef USEMMAP
@@ -209,10 +209,10 @@ static void* __afl_map(char * id_str, void * addr) {
   if (addr == NULL) {
 
   map =
-      (u8 *)mmap(0, MAX_MAP_SIZE, PROT_READ, MAP_NORESERVE | MAP_SHARED, shm_fd, 0);
+      (u8 *)mmap(0, size, PROT_READ, MAP_NORESERVE | MAP_SHARED, shm_fd, 0);
   } else {
     map =
-      (u8 *)mmap(0, MAX_MAP_SIZE, PROT_READ, MAP_NORESERVE | MAP_FIXED_NOREPLACE | MAP_SHARED, shm_fd, 0);
+      (u8 *)mmap(0, size, PROT_READ, MAP_NORESERVE | MAP_FIXED_NOREPLACE | MAP_SHARED, shm_fd, 0);
   }
 
   if (map == MAP_FAILED) {
@@ -252,10 +252,10 @@ static void* __afl_map(char * id_str, void * addr) {
   return map;
 }
 
-void __afl_unmap(void * addr) {
+void __afl_unmap(void * addr, size_t size) {
 #ifdef USEMMAP
 
-    munmap((void *)addr, MAX_MAP_SIZE);
+    munmap((void *)addr, size);
 
 #else
 
@@ -278,7 +278,7 @@ static void __afl_map_shm_fuzz() {
 
   if (id_str) {
 
-    u8 *map = __afl_map(id_str, NULL);
+    u8 *map = __afl_map(id_str, MAX_MAP_SIZE, NULL);
 
     /* Whooooops. */
 
@@ -413,7 +413,7 @@ static void __afl_map_shm(void) {
 
 #endif
 
-    __afl_area_ptr = __afl_map(id_str, (void*)__afl_map_addr);
+    __afl_area_ptr = __afl_map(id_str, MAX_MAP_SIZE, (void*)__afl_map_addr);
 
     /* Write something into the bitmap so that even with low AFL_INST_RATIO,
        our parent doesn't give up on us. */
@@ -510,7 +510,7 @@ static void __afl_map_shm(void) {
 
     }
 
-    __afl_cmp_map = __afl_map(id_str, NULL);
+    __afl_cmp_map = __afl_map(id_str, MAX_MAP_SIZE, NULL);
 
     __afl_cmp_map_backup = __afl_cmp_map;
 
@@ -536,7 +536,7 @@ static void __afl_unmap_shm(void) {
 
   if (id_str) {
 
-    __afl_unmap(__afl_area_ptr);
+    __afl_unmap(__afl_area_ptr, MAX_MAP_SIZE);
 
   } else if ((!__afl_area_ptr || __afl_area_ptr == __afl_area_initial) &&
 
@@ -552,7 +552,7 @@ static void __afl_unmap_shm(void) {
 
   if (id_str) {
 
-    __afl_unmap(__afl_cmp_map);
+    __afl_unmap(__afl_cmp_map, MAX_MAP_SIZE);
     __afl_cmp_map = NULL;
 
   }

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -2008,7 +2008,8 @@ void __afl_coverage_discard() {
   memset(__afl_area_ptr_backup, 0, __afl_map_size);
   __afl_area_ptr_backup[0] = 1;
 
-  if (__afl_cmp_map) { memset(__afl_cmp_map, 0, sizeof(struct cmp_map)); }
+  size_t size = sizeof(struct cmp_entry) * __afl_map_size_addr->size;
+  if (__afl_cmp_map) { memset(__afl_cmp_map, 0, size); }
 
 }
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -1455,7 +1455,7 @@ void __cmplog_ins_hook1(uint8_t arg1, uint8_t arg2, uint8_t attr) {
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1486,7 +1486,7 @@ void __cmplog_ins_hook2(uint16_t arg1, uint16_t arg2, uint8_t attr) {
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1525,7 +1525,7 @@ void __cmplog_ins_hook4(uint32_t arg1, uint32_t arg2, uint8_t attr) {
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1564,7 +1564,7 @@ void __cmplog_ins_hook8(uint64_t arg1, uint64_t arg2, uint8_t attr) {
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1608,7 +1608,7 @@ void __cmplog_ins_hookN(uint128_t arg1, uint128_t arg2, uint8_t attr,
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1652,7 +1652,7 @@ void __cmplog_ins_hook16(uint128_t arg1, uint128_t arg2, uint8_t attr) {
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 
@@ -1758,7 +1758,7 @@ void __sanitizer_cov_trace_switch(uint64_t val, uint64_t *cases) {
 
     uintptr_t k = (uintptr_t)__builtin_return_address(0) + i;
     k = (k >> 4) ^ (k << 8);
-    k &= CMP_MAP_W - 1;
+    k &= __afl_map_size_addr->size - 1;
 
     u32 hits;
 
@@ -1860,7 +1860,7 @@ void __cmplog_rtn_hook(u8 *ptr1, u8 *ptr2) {
   // fprintf(stderr, "RTN2 %u\n", len);
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
   k = (k >> 4) ^ (k << 8);
-  k &= CMP_MAP_W - 1;
+  k &= __afl_map_size_addr->size - 1;
 
   u32 hits;
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2544,7 +2544,7 @@ void setup_testcase_shmem(afl_state_t *afl) {
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, afl->shm_fuzz->g_shm_file_path, 1);
 #else
-  u8 *shm_str = alloc_printf("%d", afl->shm_fuzz->shm_id);
+  u8 *shm_str = alloc_printf("%d", afl->shm_fuzz->shm.shm_id);
   setenv(SHM_FUZZ_ENV_VAR, shm_str, 1);
   ck_free(shm_str);
 #endif

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2458,7 +2458,8 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
   u8 r = 1;
   if (unlikely(!afl->pass_stats)) {
 
-    afl->pass_stats = ck_alloc(sizeof(struct afl_pass_stat) * CMP_MAP_W);
+    size_t cmp_map_size = sizeof(struct cmp_entry) * afl->shm.map_size_ptr->size;
+    afl->pass_stats = ck_alloc(cmp_map_size);
 
   }
 
@@ -2538,7 +2539,7 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
   }
 
   memcpy(afl->orig_cmp_map, afl->shm.cmp_map, cmp_map_size);
-  for (size_t i = 0; i < CMP_MAP_W; i++) {
+  for (size_t i = 0; i < afl->shm.map_size_ptr->size; i++) {
 
     memset(&afl->shm.cmp_map->entries[i], 0, offsetof(struct cmp_entry, log));
 
@@ -2590,7 +2591,7 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
 #endif
 
   u32 k;
-  for (k = 0; k < CMP_MAP_W; ++k) {
+  for (k = 0; k < afl->shm.map_size_ptr->size; ++k) {
 
     if (!afl->shm.cmp_map->entries[k].hits) { continue; }
 
@@ -2619,7 +2620,7 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
 
   }
 
-  for (k = 0; k < CMP_MAP_W; ++k) {
+  for (k = 0; k < afl->shm.map_size_ptr->size; ++k) {
 
     if (!afl->shm.cmp_map->entries[k].hits) { continue; }
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2514,7 +2514,8 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
   // Generate the cmplog data
 
   // manually clear the full cmp_map
-  memset(afl->shm.cmp_map, 0, sizeof(struct cmp_map));
+  size_t cmp_map_size = sizeof(struct cmp_entry) * afl->shm.map_size_ptr->size;
+  memset(afl->shm.cmp_map, 0, cmp_map_size);
   if (unlikely(common_fuzz_cmplog_stuff(afl, orig_buf, len))) {
 
     afl->queue_cur->colorized = CMPLOG_LVL_MAX;
@@ -2532,11 +2533,11 @@ u8 input_to_state_stage(afl_state_t *afl, u8 *orig_buf, u8 *buf, u32 len) {
 
   if (unlikely(!afl->orig_cmp_map)) {
 
-    afl->orig_cmp_map = ck_alloc_nozero(sizeof(struct cmp_map));
+    afl->orig_cmp_map = ck_alloc_nozero(cmp_map_size);
 
   }
 
-  memcpy(afl->orig_cmp_map, afl->shm.cmp_map, sizeof(struct cmp_map));
+  memcpy(afl->orig_cmp_map, afl->shm.cmp_map, cmp_map_size);
   for (size_t i = 0; i < CMP_MAP_W; i++) {
 
     memset(&afl->shm.cmp_map->entries[i], 0, offsetof(struct cmp_entry, log));

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -112,15 +112,15 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->cpu_aff = -1;                    /* Selected CPU core                */
 #endif                                                     /* HAVE_AFFINITY */
 
-  afl->virgin_bits = ck_alloc_no_commit(map_size);
-  afl->virgin_tmout = ck_alloc_no_commit(map_size);
-  afl->virgin_crash = ck_alloc_no_commit(map_size);
-  afl->var_bytes = ck_alloc_no_commit(map_size);
-  afl->top_rated = ck_alloc_no_commit(map_size * sizeof(void *));
-  afl->clean_trace = ck_alloc_no_commit(map_size);
-  afl->clean_trace_custom = ck_alloc_no_commit(map_size);
-  afl->first_trace = ck_alloc_no_commit(map_size);
-  afl->map_tmp_buf = ck_alloc_no_commit(map_size);
+  afl->virgin_bits = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->virgin_tmout = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->virgin_crash = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->var_bytes = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->top_rated = ck_alloc_no_commit(MAX_MAP_SIZE * sizeof(void *));
+  afl->clean_trace = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->clean_trace_custom = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->first_trace = ck_alloc_no_commit(MAX_MAP_SIZE);
+  afl->map_tmp_buf = ck_alloc_no_commit(MAX_MAP_SIZE);
 
   afl->fsrv.use_stdin = 1;
   afl->fsrv.map_size = map_size;

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -112,15 +112,15 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->cpu_aff = -1;                    /* Selected CPU core                */
 #endif                                                     /* HAVE_AFFINITY */
 
-  afl->virgin_bits = ck_alloc(map_size);
-  afl->virgin_tmout = ck_alloc(map_size);
-  afl->virgin_crash = ck_alloc(map_size);
-  afl->var_bytes = ck_alloc(map_size);
-  afl->top_rated = ck_alloc(map_size * sizeof(void *));
-  afl->clean_trace = ck_alloc(map_size);
-  afl->clean_trace_custom = ck_alloc(map_size);
-  afl->first_trace = ck_alloc(map_size);
-  afl->map_tmp_buf = ck_alloc(map_size);
+  afl->virgin_bits = ck_alloc_no_commit(map_size);
+  afl->virgin_tmout = ck_alloc_no_commit(map_size);
+  afl->virgin_crash = ck_alloc_no_commit(map_size);
+  afl->var_bytes = ck_alloc_no_commit(map_size);
+  afl->top_rated = ck_alloc_no_commit(map_size * sizeof(void *));
+  afl->clean_trace = ck_alloc_no_commit(map_size);
+  afl->clean_trace_custom = ck_alloc_no_commit(map_size);
+  afl->first_trace = ck_alloc_no_commit(map_size);
+  afl->map_tmp_buf = ck_alloc_no_commit(map_size);
 
   afl->fsrv.use_stdin = 1;
   afl->fsrv.map_size = map_size;
@@ -555,15 +555,15 @@ void afl_state_deinit(afl_state_t *afl) {
   afl_free(afl->in_scratch_buf);
   afl_free(afl->ex_buf);
 
-  ck_free(afl->virgin_bits);
-  ck_free(afl->virgin_tmout);
-  ck_free(afl->virgin_crash);
-  ck_free(afl->var_bytes);
-  ck_free(afl->top_rated);
-  ck_free(afl->clean_trace);
-  ck_free(afl->clean_trace_custom);
-  ck_free(afl->first_trace);
-  ck_free(afl->map_tmp_buf);
+  ck_free_no_commit(afl->virgin_bits);
+  ck_free_no_commit(afl->virgin_tmout);
+  ck_free_no_commit(afl->virgin_crash);
+  ck_free_no_commit(afl->var_bytes);
+  ck_free_no_commit(afl->top_rated);
+  ck_free_no_commit(afl->clean_trace);
+  ck_free_no_commit(afl->clean_trace_custom);
+  ck_free_no_commit(afl->first_trace);
+  ck_free_no_commit(afl->map_tmp_buf);
 
   list_remove(&afl_states, afl);
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1729,6 +1729,7 @@ int main(int argc, char **argv_orig, char **envp) {
       afl_shm_deinit(&afl->shm);
       afl->fsrv.map_size = new_map_size;
       afl->shm.map_size = new_map_size;
+      afl->shm.map_size_ptr->size = new_map_size;
       afl->fsrv.trace_bits = afl->shm.shm.map;
 
       setenv("AFL_NO_AUTODICT", "1", 1);  // loaded already
@@ -1760,6 +1761,8 @@ int main(int argc, char **argv_orig, char **envp) {
 
       afl->cmplog_fsrv.map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
       afl->shm.map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
+      afl->shm.map_size_ptr->size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
+      ;
       char vbuf[16];
       snprintf(vbuf, sizeof(vbuf), "%u", afl->cmplog_fsrv.map_size);
       setenv("AFL_MAP_SIZE", vbuf, 1);
@@ -1785,6 +1788,7 @@ int main(int argc, char **argv_orig, char **envp) {
       setenv("AFL_NO_AUTODICT", "1", 1);  // loaded already
       afl->fsrv.map_size = new_map_size;
       afl->shm.map_size = new_map_size;
+      afl->shm.map_size_ptr->size = new_map_size;
       afl->fsrv.trace_bits = afl->shm.shm.map;
 
       afl->cmplog_fsrv.trace_bits = afl->fsrv.trace_bits;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1697,17 +1697,6 @@ int main(int argc, char **argv_orig, char **envp) {
       afl->fsrv.frida_mode || afl->unicorn_mode) {
 
     map_size = afl->fsrv.map_size = MAP_SIZE;
-    afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
-    afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
-    afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
-    afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
-    afl->top_rated =
-        ck_realloc_no_commit(afl->top_rated, map_size * sizeof(void *));
-    afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
-    afl->clean_trace_custom =
-        ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
-    afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
-    afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
 
   }
 
@@ -1736,23 +1725,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes", new_map_size);
 
-      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
-      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
-      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
-      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
-      afl->top_rated =
-          ck_realloc_no_commit(afl->top_rated, MAX_MAP_SIZE * sizeof(void *));
-      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
-      afl->clean_trace_custom =
-          ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
-      afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
-      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
-
       afl_fsrv_kill(&afl->fsrv);
       afl_shm_deinit(&afl->shm);
       afl->fsrv.map_size = new_map_size;
-      afl->fsrv.trace_bits =
-          afl_shm_init(&afl->shm, new_map_size, afl->non_instrumented_mode);
+      afl->shm.map_size = new_map_size;
+      afl->fsrv.trace_bits = afl->shm.shm.map;
+
       setenv("AFL_NO_AUTODICT", "1", 1);  // loaded already
       afl_fsrv_start(&afl->fsrv, afl->argv, &afl->stop_soon,
                      afl->afl_env.afl_debug_child);
@@ -1796,18 +1774,6 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes due cmplog", new_map_size);
 
-      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
-      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
-      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
-      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
-      afl->top_rated =
-          ck_realloc_no_commit(afl->top_rated, MAX_MAP_SIZE * sizeof(void *));
-      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
-      afl->clean_trace_custom =
-          ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
-      afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
-      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
-
       afl_fsrv_kill(&afl->fsrv);
       afl_fsrv_kill(&afl->cmplog_fsrv);
       afl_shm_deinit(&afl->shm);
@@ -1816,8 +1782,10 @@ int main(int argc, char **argv_orig, char **envp) {
       map_size = new_map_size;
 
       setenv("AFL_NO_AUTODICT", "1", 1);  // loaded already
-      afl->fsrv.trace_bits =
-          afl_shm_init(&afl->shm, new_map_size, afl->non_instrumented_mode);
+      afl->fsrv.map_size = new_map_size;
+      afl->shm.map_size = new_map_size;
+      afl->fsrv.trace_bits = afl->shm.shm.map;
+
       afl->cmplog_fsrv.trace_bits = afl->fsrv.trace_bits;
       afl_fsrv_start(&afl->fsrv, afl->argv, &afl->stop_soon,
                      afl->afl_env.afl_debug_child);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1697,17 +1697,17 @@ int main(int argc, char **argv_orig, char **envp) {
       afl->fsrv.frida_mode || afl->unicorn_mode) {
 
     map_size = afl->fsrv.map_size = MAP_SIZE;
-    afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, map_size);
-    afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, map_size);
-    afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, map_size);
-    afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, map_size);
+    afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
+    afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
+    afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
+    afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
     afl->top_rated =
         ck_realloc_no_commit(afl->top_rated, map_size * sizeof(void *));
-    afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, map_size);
+    afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
     afl->clean_trace_custom =
-        ck_realloc_no_commit(afl->clean_trace_custom, map_size);
-    afl->first_trace = ck_realloc_no_commit(afl->first_trace, map_size);
-    afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, map_size);
+        ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
+    afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
+    afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
 
   }
 
@@ -1736,17 +1736,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes", new_map_size);
 
-      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, new_map_size);
-      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, new_map_size);
-      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, new_map_size);
-      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, new_map_size);
+      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
+      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
+      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
+      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
       afl->top_rated =
-          ck_realloc_no_commit(afl->top_rated, new_map_size * sizeof(void *));
-      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, new_map_size);
+          ck_realloc_no_commit(afl->top_rated, MAX_MAP_SIZE * sizeof(void *));
+      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
       afl->clean_trace_custom =
-          ck_realloc_no_commit(afl->clean_trace_custom, new_map_size);
-      afl->first_trace = ck_realloc_no_commit(afl->first_trace, new_map_size);
-      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, new_map_size);
+          ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
+      afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
+      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
 
       afl_fsrv_kill(&afl->fsrv);
       afl_shm_deinit(&afl->shm);
@@ -1796,17 +1796,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes due cmplog", new_map_size);
 
-      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, new_map_size);
-      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, new_map_size);
-      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, new_map_size);
-      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, new_map_size);
+      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, MAX_MAP_SIZE);
+      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, MAX_MAP_SIZE);
+      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, MAX_MAP_SIZE);
+      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, MAX_MAP_SIZE);
       afl->top_rated =
-          ck_realloc_no_commit(afl->top_rated, new_map_size * sizeof(void *));
-      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, new_map_size);
+          ck_realloc_no_commit(afl->top_rated, MAX_MAP_SIZE * sizeof(void *));
+      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, MAX_MAP_SIZE);
       afl->clean_trace_custom =
-          ck_realloc_no_commit(afl->clean_trace_custom, new_map_size);
-      afl->first_trace = ck_realloc_no_commit(afl->first_trace, new_map_size);
-      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, new_map_size);
+          ck_realloc_no_commit(afl->clean_trace_custom, MAX_MAP_SIZE);
+      afl->first_trace = ck_realloc_no_commit(afl->first_trace, MAX_MAP_SIZE);
+      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, MAX_MAP_SIZE);
 
       afl_fsrv_kill(&afl->fsrv);
       afl_fsrv_kill(&afl->cmplog_fsrv);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1697,15 +1697,17 @@ int main(int argc, char **argv_orig, char **envp) {
       afl->fsrv.frida_mode || afl->unicorn_mode) {
 
     map_size = afl->fsrv.map_size = MAP_SIZE;
-    afl->virgin_bits = ck_realloc(afl->virgin_bits, map_size);
-    afl->virgin_tmout = ck_realloc(afl->virgin_tmout, map_size);
-    afl->virgin_crash = ck_realloc(afl->virgin_crash, map_size);
-    afl->var_bytes = ck_realloc(afl->var_bytes, map_size);
-    afl->top_rated = ck_realloc(afl->top_rated, map_size * sizeof(void *));
-    afl->clean_trace = ck_realloc(afl->clean_trace, map_size);
-    afl->clean_trace_custom = ck_realloc(afl->clean_trace_custom, map_size);
-    afl->first_trace = ck_realloc(afl->first_trace, map_size);
-    afl->map_tmp_buf = ck_realloc(afl->map_tmp_buf, map_size);
+    afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, map_size);
+    afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, map_size);
+    afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, map_size);
+    afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, map_size);
+    afl->top_rated =
+        ck_realloc_no_commit(afl->top_rated, map_size * sizeof(void *));
+    afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, map_size);
+    afl->clean_trace_custom =
+        ck_realloc_no_commit(afl->clean_trace_custom, map_size);
+    afl->first_trace = ck_realloc_no_commit(afl->first_trace, map_size);
+    afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, map_size);
 
   }
 
@@ -1734,17 +1736,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes", new_map_size);
 
-      afl->virgin_bits = ck_realloc(afl->virgin_bits, new_map_size);
-      afl->virgin_tmout = ck_realloc(afl->virgin_tmout, new_map_size);
-      afl->virgin_crash = ck_realloc(afl->virgin_crash, new_map_size);
-      afl->var_bytes = ck_realloc(afl->var_bytes, new_map_size);
+      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, new_map_size);
+      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, new_map_size);
+      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, new_map_size);
+      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, new_map_size);
       afl->top_rated =
-          ck_realloc(afl->top_rated, new_map_size * sizeof(void *));
-      afl->clean_trace = ck_realloc(afl->clean_trace, new_map_size);
+          ck_realloc_no_commit(afl->top_rated, new_map_size * sizeof(void *));
+      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, new_map_size);
       afl->clean_trace_custom =
-          ck_realloc(afl->clean_trace_custom, new_map_size);
-      afl->first_trace = ck_realloc(afl->first_trace, new_map_size);
-      afl->map_tmp_buf = ck_realloc(afl->map_tmp_buf, new_map_size);
+          ck_realloc_no_commit(afl->clean_trace_custom, new_map_size);
+      afl->first_trace = ck_realloc_no_commit(afl->first_trace, new_map_size);
+      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, new_map_size);
 
       afl_fsrv_kill(&afl->fsrv);
       afl_shm_deinit(&afl->shm);
@@ -1794,17 +1796,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
       OKF("Re-initializing maps to %u bytes due cmplog", new_map_size);
 
-      afl->virgin_bits = ck_realloc(afl->virgin_bits, new_map_size);
-      afl->virgin_tmout = ck_realloc(afl->virgin_tmout, new_map_size);
-      afl->virgin_crash = ck_realloc(afl->virgin_crash, new_map_size);
-      afl->var_bytes = ck_realloc(afl->var_bytes, new_map_size);
+      afl->virgin_bits = ck_realloc_no_commit(afl->virgin_bits, new_map_size);
+      afl->virgin_tmout = ck_realloc_no_commit(afl->virgin_tmout, new_map_size);
+      afl->virgin_crash = ck_realloc_no_commit(afl->virgin_crash, new_map_size);
+      afl->var_bytes = ck_realloc_no_commit(afl->var_bytes, new_map_size);
       afl->top_rated =
-          ck_realloc(afl->top_rated, new_map_size * sizeof(void *));
-      afl->clean_trace = ck_realloc(afl->clean_trace, new_map_size);
+          ck_realloc_no_commit(afl->top_rated, new_map_size * sizeof(void *));
+      afl->clean_trace = ck_realloc_no_commit(afl->clean_trace, new_map_size);
       afl->clean_trace_custom =
-          ck_realloc(afl->clean_trace_custom, new_map_size);
-      afl->first_trace = ck_realloc(afl->first_trace, new_map_size);
-      afl->map_tmp_buf = ck_realloc(afl->map_tmp_buf, new_map_size);
+          ck_realloc_no_commit(afl->clean_trace_custom, new_map_size);
+      afl->first_trace = ck_realloc_no_commit(afl->first_trace, new_map_size);
+      afl->map_tmp_buf = ck_realloc_no_commit(afl->map_tmp_buf, new_map_size);
 
       afl_fsrv_kill(&afl->fsrv);
       afl_fsrv_kill(&afl->cmplog_fsrv);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1759,6 +1759,7 @@ int main(int argc, char **argv_orig, char **envp) {
         !afl->afl_env.afl_skip_bin_check) {
 
       afl->cmplog_fsrv.map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
+      afl->shm.map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
       char vbuf[16];
       snprintf(vbuf, sizeof(vbuf), "%u", afl->cmplog_fsrv.map_size);
       setenv("AFL_MAP_SIZE", vbuf, 1);

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -62,96 +62,11 @@
 
 static list_t shm_list = {.element_prealloc_count = 0};
 
-/* Get rid of shared memory. */
-
-void afl_shm_deinit(sharedmem_t *shm) {
-
-  if (shm == NULL) { return; }
-  list_remove(&shm_list, shm);
-  if (shm->shmemfuzz_mode) {
-
-    unsetenv(SHM_FUZZ_ENV_VAR);
-
-  } else {
-
-    unsetenv(SHM_ENV_VAR);
-
-  }
-
-#ifdef USEMMAP
-  if (shm->map != NULL) {
-
-    munmap(shm->map, shm->map_size);
-    shm->map = NULL;
-
-  }
-
-  if (shm->g_shm_fd != -1) {
-
-    close(shm->g_shm_fd);
-    shm->g_shm_fd = -1;
-
-  }
-
-  if (shm->g_shm_file_path[0]) {
-
-    shm_unlink(shm->g_shm_file_path);
-    shm->g_shm_file_path[0] = 0;
-
-  }
-
-  if (shm->cmplog_mode) {
-
-    unsetenv(CMPLOG_SHM_ENV_VAR);
-
-    if (shm->cmp_map != NULL) {
-
-      munmap(shm->cmp_map, shm->map_size);
-      shm->map = NULL;
-
-    }
-
-    if (shm->cmplog_g_shm_fd != -1) {
-
-      close(shm->cmplog_g_shm_fd);
-      shm->cmplog_g_shm_fd = -1;
-
-    }
-
-    if (shm->cmplog_g_shm_file_path[0]) {
-
-      shm_unlink(shm->cmplog_g_shm_file_path);
-      shm->cmplog_g_shm_file_path[0] = 0;
-
-    }
-
-  }
-
-#else
-  shmctl(shm->shm_id, IPC_RMID, NULL);
-  if (shm->cmplog_mode) { shmctl(shm->cmplog_shm_id, IPC_RMID, NULL); }
-#endif
-
-  shm->map = NULL;
-
-}
-
-/* Configure shared memory.
-   Returns a pointer to shm->map for ease of use.
-*/
-
-u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
-                 unsigned char non_instrumented_mode) {
-
-  shm->map_size = 0;
-
-  shm->map = NULL;
-  shm->cmp_map = NULL;
+static void afl_shm_alloc(sharedmem_alloc_t *shm, size_t size) {
 
 #ifdef USEMMAP
 
   shm->g_shm_fd = -1;
-  shm->cmplog_g_shm_fd = -1;
 
   /* ======
   generate random file name for multi instance
@@ -186,85 +101,106 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
 
   }
 
-  /* If somebody is asking us to fuzz instrumented binaries in non-instrumented
-     mode, we don't want them to detect instrumentation, since we won't be
-     sending fork server commands. This should be replaced with better
-     auto-detection later on, perhaps? */
-
-  if (!non_instrumented_mode) setenv(SHM_ENV_VAR, shm->g_shm_file_path, 1);
-
   if (shm->map == (void *)-1 || !shm->map) PFATAL("mmap() failed");
-
-  if (shm->cmplog_mode) {
-
-    snprintf(shm->cmplog_g_shm_file_path, L_tmpnam, "/afl_cmplog_%d_%ld",
-             getpid(), random());
-
-    /* create the shared memory segment as if it was a file */
-    shm->cmplog_g_shm_fd =
-        shm_open(shm->cmplog_g_shm_file_path,
-                 O_CREAT | O_RDWR | O_EXCL | MAP_NORESERVE, DEFAULT_PERMISSION);
-    if (shm->cmplog_g_shm_fd == -1) { PFATAL("shm_open() failed"); }
-
-    /* configure the size of the shared memory segment */
-    if (ftruncate(shm->cmplog_g_shm_fd, MAX_MAP_SIZE)) {
-
-      PFATAL("setup_shm(): cmplog ftruncate() failed");
-
-    }
-
-    /* map the shared memory segment to the address space of the process */
-    shm->cmp_map = mmap(0, MAX_MAP_SIZE, PROT_READ | PROT_WRITE,
-                        MAP_SHARED | MAP_NORESERVE, shm->cmplog_g_shm_fd, 0);
-    if (shm->cmp_map == MAP_FAILED) {
-
-      close(shm->cmplog_g_shm_fd);
-      shm->cmplog_g_shm_fd = -1;
-      shm_unlink(shm->cmplog_g_shm_file_path);
-      shm->cmplog_g_shm_file_path[0] = 0;
-      PFATAL("mmap() failed");
-
-    }
-
-    /* If somebody is asking us to fuzz instrumented binaries in
-       non-instrumented mode, we don't want them to detect instrumentation,
-       since we won't be sending fork server commands. This should be replaced
-       with better auto-detection later on, perhaps? */
-
-    if (!non_instrumented_mode)
-      setenv(CMPLOG_SHM_ENV_VAR, shm->cmplog_g_shm_file_path, 1);
-
-    if (shm->cmp_map == (void *)-1 || !shm->cmp_map)
-      PFATAL("cmplog mmap() failed");
-
-  }
-
 #else
-  u8 *shm_str;
-
   shm->shm_id =
       shmget(IPC_PRIVATE, MAX_MAP_SIZE,
              IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION | SHM_NORESERVE);
   if (shm->shm_id < 0) { PFATAL("shmget() failed"); }
 
-  if (shm->cmplog_mode) {
+  shm->map = shmat(shm->shm_id, NULL, 0);
 
-    /* TODO!!! */
-    shm->cmplog_shm_id = shmget(IPC_PRIVATE, sizeof(struct cmp_map),
-                                IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION);
+  if (shm->map == (void *)-1 || !shm->map) {
 
-    if (shm->cmplog_shm_id < 0) {
+    shmctl(shm->shm_id, IPC_RMID, NULL);  // do not leak shmem
 
-      shmctl(shm->shm_id, IPC_RMID, NULL);  // do not leak shmem
-      PFATAL("shmget() failed");
-
-    }
+    PFATAL("shmat() failed");
 
   }
 
+#endif
+  shm->size = size;
+
+}
+
+static void afl_shm_free(sharedmem_alloc_t *shm) {
+
+#ifdef USEMMAP
+  if (shm->map != NULL) {
+
+    munmap(shm->map, shm->map_size);
+    shm->map = NULL;
+
+  }
+
+  if (shm->g_shm_fd != -1) {
+
+    close(shm->g_shm_fd);
+    shm->g_shm_fd = -1;
+
+  }
+
+  if (shm->g_shm_file_path[0]) {
+
+    shm_unlink(shm->g_shm_file_path);
+    shm->g_shm_file_path[0] = 0;
+
+  }
+
+#else
+  shmctl(shm->shm_id, IPC_RMID, NULL);
+#endif
+
+  shm->map = NULL;
+  shm->size = 0;
+
+}
+
+/* Get rid of shared memory. */
+
+void afl_shm_deinit(sharedmem_t *shm) {
+
+  if (shm == NULL) { return; }
+  list_remove(&shm_list, shm);
+  if (shm->shmemfuzz_mode) {
+
+    unsetenv(SHM_FUZZ_ENV_VAR);
+
+  } else {
+
+    unsetenv(SHM_ENV_VAR);
+
+  }
+
+  afl_shm_free(&shm->shm);
+
+  if (shm->cmplog_mode) { afl_shm_free(&shm->cmplog_shm); }
+
+}
+
+/* Configure shared memory.
+   Returns a pointer to shm->map for ease of use.
+*/
+
+u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
+                 unsigned char non_instrumented_mode) {
+
+  afl_shm_alloc(&shm->shm, MAX_MAP_SIZE);
+  shm->map = shm->shm.map;
+  shm->map_size = map_size;
+
+  if (shm->cmplog_mode) {
+
+    afl_shm_alloc(&shm->cmplog_shm, sizeof(struct cmp_map));
+    shm->cmp_map = (struct cmp_map *)shm->cmplog_shm.map;
+
+  }
+
+  u8 *shm_str;
+
   if (!non_instrumented_mode) {
 
-    shm_str = alloc_printf("%d", shm->shm_id);
+    shm_str = alloc_printf("%d", shm->shm.shm_id);
 
     /* If somebody is asking us to fuzz instrumented binaries in
        non-instrumented mode, we don't want them to detect instrumentation,
@@ -279,7 +215,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
 
   if (shm->cmplog_mode && !non_instrumented_mode) {
 
-    shm_str = alloc_printf("%d", shm->cmplog_shm_id);
+    shm_str = alloc_printf("%d", shm->cmplog_shm.shm_id);
 
     setenv(CMPLOG_SHM_ENV_VAR, shm_str, 1);
 
@@ -287,44 +223,9 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
 
   }
 
-  shm->map = shmat(shm->shm_id, NULL, 0);
-
-  if (shm->map == (void *)-1 || !shm->map) {
-
-    shmctl(shm->shm_id, IPC_RMID, NULL);  // do not leak shmem
-
-    if (shm->cmplog_mode) {
-
-      shmctl(shm->cmplog_shm_id, IPC_RMID, NULL);  // do not leak shmem
-
-    }
-
-    PFATAL("shmat() failed");
-
-  }
-
-  if (shm->cmplog_mode) {
-
-    shm->cmp_map = shmat(shm->cmplog_shm_id, NULL, 0);
-
-    if (shm->cmp_map == (void *)-1 || !shm->cmp_map) {
-
-      shmctl(shm->shm_id, IPC_RMID, NULL);  // do not leak shmem
-
-      shmctl(shm->cmplog_shm_id, IPC_RMID, NULL);  // do not leak shmem
-
-      PFATAL("shmat() failed");
-
-    }
-
-  }
-
-#endif
-
-  shm->map_size = map_size;
   list_append(&shm_list, shm);
 
-  return shm->map;
+  return shm->shm.map;
 
 }
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -189,11 +189,10 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
   afl_shm_alloc(&shm->shm, MAX_MAP_SIZE);
 
   afl_shm_alloc(&shm->mapsize_shm, sizeof(struct map_size));
-  shm->map_size_ptr = (struct map_size*)shm->mapsize_shm.map;
+  shm->map_size_ptr = (struct map_size *)shm->mapsize_shm.map;
 
   shm->map_size = map_size;
   shm->map_size_ptr->size = map_size;
-
 
   if (shm->cmplog_mode) {
 
@@ -214,6 +213,12 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
        with better auto-detection later on, perhaps? */
 
     setenv(SHM_ENV_VAR, shm_str, 1);
+
+    ck_free(shm_str);
+
+    shm_str = alloc_printf("%d", shm->mapsize_shm.shm_id);
+
+    setenv(SHM_SIZE_ENV_VAR, shm_str, 1);
 
     ck_free(shm_str);
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -186,7 +186,6 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
                  unsigned char non_instrumented_mode) {
 
   afl_shm_alloc(&shm->shm, MAX_MAP_SIZE);
-  shm->map = shm->shm.map;
   shm->map_size = map_size;
 
   if (shm->cmplog_mode) {

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -202,8 +202,8 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
 
     /* create the shared memory segment as if it was a file */
     shm->cmplog_g_shm_fd =
-        shm_open(shm->cmplog_g_shm_file_path, O_CREAT | O_RDWR | O_EXCL,
-                 DEFAULT_PERMISSION);
+        shm_open(shm->cmplog_g_shm_file_path,
+                 O_CREAT | O_RDWR | O_EXCL | MAP_NORESERVE, DEFAULT_PERMISSION);
     if (shm->cmplog_g_shm_fd == -1) { PFATAL("shm_open() failed"); }
 
     /* configure the size of the shared memory segment */
@@ -243,7 +243,8 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
   u8 *shm_str;
 
   shm->shm_id =
-      shmget(IPC_PRIVATE, map_size, IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION);
+      shmget(IPC_PRIVATE, map_size,
+             IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION | SHM_NORESERVE);
   if (shm->shm_id < 0) { PFATAL("shmget() failed"); }
 
   if (shm->cmplog_mode) {

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -167,15 +167,15 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
   if (shm->g_shm_fd == -1) { PFATAL("shm_open() failed"); }
 
   /* configure the size of the shared memory segment */
-  if (ftruncate(shm->g_shm_fd, map_size)) {
+  if (ftruncate(shm->g_shm_fd, MAX_MAP_SIZE)) {
 
     PFATAL("setup_shm(): ftruncate() failed");
 
   }
 
   /* map the shared memory segment to the address space of the process */
-  shm->map =
-      mmap(0, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm->g_shm_fd, 0);
+  shm->map = mmap(0, MAX_MAP_SIZE, PROT_READ | PROT_WRITE,
+                  MAP_SHARED | MAP_NORESERVE, shm->g_shm_fd, 0);
   if (shm->map == MAP_FAILED) {
 
     close(shm->g_shm_fd);
@@ -207,15 +207,15 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
     if (shm->cmplog_g_shm_fd == -1) { PFATAL("shm_open() failed"); }
 
     /* configure the size of the shared memory segment */
-    if (ftruncate(shm->cmplog_g_shm_fd, map_size)) {
+    if (ftruncate(shm->cmplog_g_shm_fd, MAX_MAP_SIZE)) {
 
       PFATAL("setup_shm(): cmplog ftruncate() failed");
 
     }
 
     /* map the shared memory segment to the address space of the process */
-    shm->cmp_map = mmap(0, map_size, PROT_READ | PROT_WRITE, MAP_SHARED,
-                        shm->cmplog_g_shm_fd, 0);
+    shm->cmp_map = mmap(0, MAX_MAP_SIZE, PROT_READ | PROT_WRITE,
+                        MAP_SHARED | MAP_NORESERVE, shm->cmplog_g_shm_fd, 0);
     if (shm->cmp_map == MAP_FAILED) {
 
       close(shm->cmplog_g_shm_fd);
@@ -243,12 +243,13 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
   u8 *shm_str;
 
   shm->shm_id =
-      shmget(IPC_PRIVATE, map_size,
+      shmget(IPC_PRIVATE, MAX_MAP_SIZE,
              IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION | SHM_NORESERVE);
   if (shm->shm_id < 0) { PFATAL("shmget() failed"); }
 
   if (shm->cmplog_mode) {
 
+    /* TODO!!! */
     shm->cmplog_shm_id = shmget(IPC_PRIVATE, sizeof(struct cmp_map),
                                 IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION);
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -173,6 +173,7 @@ void afl_shm_deinit(sharedmem_t *shm) {
   }
 
   afl_shm_free(&shm->shm);
+  afl_shm_free(&shm->mapsize_shm);
 
   if (shm->cmplog_mode) { afl_shm_free(&shm->cmplog_shm); }
 
@@ -186,7 +187,13 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
                  unsigned char non_instrumented_mode) {
 
   afl_shm_alloc(&shm->shm, MAX_MAP_SIZE);
+
+  afl_shm_alloc(&shm->mapsize_shm, sizeof(struct map_size));
+  shm->map_size_ptr = (struct map_size*)shm->mapsize_shm.map;
+
   shm->map_size = map_size;
+  shm->map_size_ptr->size = map_size;
+
 
   if (shm->cmplog_mode) {
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -191,7 +191,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
 
   if (shm->cmplog_mode) {
 
-    afl_shm_alloc(&shm->cmplog_shm, sizeof(struct cmp_map));
+    afl_shm_alloc(&shm->cmplog_shm, MAX_MAP_SIZE);
     shm->cmp_map = (struct cmp_map *)shm->cmplog_shm.map;
 
   }

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -82,15 +82,15 @@ static void afl_shm_alloc(sharedmem_alloc_t *shm, size_t size) {
   if (shm->g_shm_fd == -1) { PFATAL("shm_open() failed"); }
 
   /* configure the size of the shared memory segment */
-  if (ftruncate(shm->g_shm_fd, MAX_MAP_SIZE)) {
+  if (ftruncate(shm->g_shm_fd, size)) {
 
     PFATAL("setup_shm(): ftruncate() failed");
 
   }
 
   /* map the shared memory segment to the address space of the process */
-  shm->map = mmap(0, MAX_MAP_SIZE, PROT_READ | PROT_WRITE,
-                  MAP_SHARED | MAP_NORESERVE, shm->g_shm_fd, 0);
+  shm->map = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_NORESERVE,
+                  shm->g_shm_fd, 0);
   if (shm->map == MAP_FAILED) {
 
     close(shm->g_shm_fd);
@@ -104,7 +104,7 @@ static void afl_shm_alloc(sharedmem_alloc_t *shm, size_t size) {
   if (shm->map == (void *)-1 || !shm->map) PFATAL("mmap() failed");
 #else
   shm->shm_id =
-      shmget(IPC_PRIVATE, MAX_MAP_SIZE,
+      shmget(IPC_PRIVATE, size,
              IPC_CREAT | IPC_EXCL | DEFAULT_PERMISSION | SHM_NORESERVE);
   if (shm->shm_id < 0) { PFATAL("shmget() failed"); }
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1086,7 +1086,7 @@ int main(int argc, char **argv_orig, char **envp) {
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);
 #else
-  u8 *shm_str = alloc_printf("%d", shm_fuzz->shm_id);
+  u8 *shm_str = alloc_printf("%d", shm_fuzz->shm.shm_id);
   setenv(SHM_FUZZ_ENV_VAR, shm_str, 1);
   ck_free(shm_str);
 #endif

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -192,7 +192,7 @@ static void at_exit_handler(void) {
 
   if (remove_shm) {
 
-    if (shm.map) afl_shm_deinit(&shm);
+    if (shm.shm.map) afl_shm_deinit(&shm);
     if (fsrv->use_shmem_fuzz) deinit_shmem(fsrv, shm_fuzz);
 
   }

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1192,7 +1192,7 @@ int main(int argc, char **argv_orig, char **envp) {
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);
 #else
-  u8 *shm_str = alloc_printf("%d", shm_fuzz->shm_id);
+  u8 *shm_str = alloc_printf("%d", shm_fuzz->shm.shm_id);
   setenv(SHM_FUZZ_ENV_VAR, shm_str, 1);
   ck_free(shm_str);
 #endif

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -198,7 +198,7 @@ static void at_exit_handler(void) {
 
   if (remove_shm) {
 
-    if (shm.map) afl_shm_deinit(&shm);
+    if (shm.shm.map) afl_shm_deinit(&shm);
     if (fsrv->use_shmem_fuzz) deinit_shmem(fsrv, shm_fuzz);
 
   }


### PR DESCRIPTION
**DO NOT MERGE**

This PR is an experiment to test whether dynamically changing the map size based upon the contents of the buckets can help a target application reduce the number of hash collisions. The function `reconsider_map_size` contains the logic for deciding when to increase the map size (which may or may not be very good).

- All shared memory maps are now 256Mb in size (an adjustable constant which might not be amazing on 32-bit platforms), but are marked as `MAP_NORESERVE` or similar.
- The shared memory code has been refactored to greatly reduce duplication and complexity.
- The use of large non-reserved maps means that they don't have to be re-allocated if the size is changed, so this code has been removed.
- The cmplog structure was organised so that there were `n` headers, followed by `n` operands. This obviously won't allow us to change the value of `n` without changing the structure definition. We therefore re-organise this data so that each header is followed immediately by its operands.
- The code for mapping the shared memory regions in afl-compiler-rt.o.c has similarly been refactored to reduce duplication.
- An addiitonal shared memory segment has been created which contains only the size of the mapping (this size dictates the number of buckets for edges as well as for cmplog and the various supporting structures and temporary values which they use during their calculations). Accodingly the cmplog structure is modified to use a zero length array and this map size is used to calculate its actual size instead of `sizeof`.
- The code in FRIDA which is updating the cmplog map and generating edges, similarly must read the dynamic size from the shared memory region rather than using a constant. This means that the which the shift operations of the edge id calculationcan still be completed at compile (instrumentation) time, due to prefetching the masking of this value must be carried out at runtime. Or otherwise we must discard our prefetched blocks (perhaps the map size will stabilize as we stop finding new paths, so the performance trade-off will be worthwhile), but wholesale invalidation of prefetched blocks isn't supported in FRIDA for now.
- Lastly some logic has been added to adjust the size of the map every `n` runs (where `n` is 10 for testing and probably should be much larger) and update the necessary variables given some (possibly shoddy) reasoning about the contents of the map.
- Note that on the tests I have run, the conditional logic doesn't result in the size of the map being increased, (maybe 64kb is enough, who knew), but when hard coding the resize, it seems to work successfully.

And that's all there is to it. The size of the map can be changed dynamically based upon how densely populated it is.

Note that this branch is called `dynamic-map`, the original branch `dynamic-map` attempted to add the size of the map to the beginning of the shared memory itself. But this proved to be a horror show with code changes required everywhere, and was duly adandoned.