### PR TITLE
Changes to strip unused symbols from afl-frida-trace.so

### DIFF
--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -19,13 +19,14 @@ CFLAGS+=-fPIC \
 		-g \
 		-O3 \
 		-funroll-loops \
+		-ffunction-sections \
 
 RT_CFLAGS:=-Wno-unused-parameter \
 		   -Wno-sign-compare \
 		   -Wno-unused-function \
 		   -Wno-unused-result \
 		   -Wno-int-to-pointer-cast \
-		   -Wno-pointer-sign \
+		   -Wno-pointer-sign
 
 LDFLAGS+=-shared \
 		 -lpthread \
@@ -64,7 +65,10 @@ else
 ifdef DEBUG
  RT_CFLAGS:=$(RT_CFLAGS) -Wno-prio-ctor-dtor
 endif
-LDFLAGS+=-z noexecstack
+LDFLAGS+=	-z noexecstack \
+			-Wl,--gc-sections \
+			-Wl,--exclude-libs,ALL
+LDSCRIPT:=-Wl,--version-script=$(PWD)frida.map
 endif
 
 ifeq "$(shell uname)" "Linux"
@@ -164,7 +168,7 @@ $(AFL_COMPILER_RT_OBJ): $(AFL_COMPILER_RT_SRC)
 $(JS_SRC): $(JS) | $(BUILD_DIR)
 	cd $(JS_DIR) && xxd -i $(JS_NAME) $@
 
-$(JS_OBJ): $(JS_SRC)
+$(JS_OBJ): $(JS_SRC) GNUmakefile
 	$(CC) \
 		$(CFLAGS) \
 		-I $(ROOT)include \
@@ -197,6 +201,7 @@ $(FRIDA_TRACE): $(GUM_DEVIT_LIBRARY) $(GUM_DEVIT_HEADER) $(OBJS) $(JS_OBJ) $(AFL
 		$(GUM_DEVIT_LIBRARY) \
 		$(AFL_COMPILER_RT_OBJ) \
 		$(LDFLAGS) \
+		$(LDSCRIPT) \
 		-o $@ \
 
 	cp -v $(FRIDA_TRACE) $(ROOT)

--- a/frida_mode/frida.map
+++ b/frida_mode/frida.map
@@ -1,0 +1,33 @@
+{
+  global:
+    __afl_fuzz_len;
+    __afl_fuzz_ptr;
+    __afl_sharedmem_fuzzing;
+    afl_frida_start;
+    js_api_add_exclude_range;
+    js_api_add_include_range;
+    js_api_done;
+    js_api_error;
+    js_api_set_debug_maps;
+    js_api_set_entrypoint;
+    js_api_set_instrument_debug_file;
+    js_api_set_instrument_libraries;
+    js_api_set_instrument_no_optimize;
+    js_api_set_instrument_trace;
+    js_api_set_instrument_trace_unique;
+    js_api_set_persistent_address;
+    js_api_set_persistent_count;
+    js_api_set_persistent_debug;
+    js_api_set_persistent_hook;
+    js_api_set_persistent_return;
+    js_api_set_prefetch_disable;
+    js_api_set_stalker_callback;
+    js_api_set_stats_file;
+    js_api_set_stats_interval;
+    js_api_set_stats_transitions;
+    js_api_set_stderr;
+    js_api_set_stdout;
+
+  local:
+    *;
+};

--- a/frida_mode/hook/hook.c
+++ b/frida_mode/hook/hook.c
@@ -5,8 +5,8 @@
 
 #if defined(__x86_64__)
 
-void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
-                         uint32_t input_buf_len) {
+__attribute__((visibility("default"))) void afl_persistent_hook(
+    GumCpuContext *regs, uint8_t *input_buf, uint32_t input_buf_len) {
 
   memcpy((void *)regs->rdi, input_buf, input_buf_len);
   regs->rsi = input_buf_len;
@@ -15,8 +15,8 @@ void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
 
 #elif defined(__i386__)
 
-void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
-                         uint32_t input_buf_len) {
+__attribute__((visibility("default"))) void afl_persistent_hook(
+    GumCpuContext *regs, uint8_t *input_buf, uint32_t input_buf_len) {
 
   void **esp = (void **)regs->esp;
   void * arg1 = esp[0];
@@ -28,8 +28,8 @@ void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
 
 #elif defined(__aarch64__)
 
-void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
-                         uint32_t input_buf_len) {
+__attribute__((visibility("default"))) void afl_persistent_hook(
+    GumCpuContext *regs, uint8_t *input_buf, uint32_t input_buf_len) {
 
   memcpy((void *)regs->x[0], input_buf, input_buf_len);
   regs->x[1] = input_buf_len;
@@ -40,7 +40,7 @@ void afl_persistent_hook(GumCpuContext *regs, uint8_t *input_buf,
   #pragma error "Unsupported architecture"
 #endif
 
-int afl_persistent_hook_init(void) {
+__attribute__((visibility("default"))) int afl_persistent_hook_init(void) {
 
   // 1 for shared memory input (faster), 0 for normal input (you have to use
   // read(), input_buf will be NULL)

--- a/frida_mode/many-linux/Dockerfile
+++ b/frida_mode/many-linux/Dockerfile
@@ -18,7 +18,7 @@ RUN git checkout dev
 WORKDIR /AFLplusplus/frida_mode
 ENV CFLAGS="\
     -DADDR_NO_RANDOMIZE=0x0040000 \
-    -D_POSIX_C_SOURCE=200809L \
     -Wno-implicit-function-declaration \
     "
+ENV CXX=$CC
 RUN make

--- a/frida_mode/many-linux/GNUmakefile
+++ b/frida_mode/many-linux/GNUmakefile
@@ -15,6 +15,7 @@ $(BUILD_DIR):
 
 clean:
 	rm -rf $(BUILD_DIR)
+	docker images --filter 'dangling=true' -q --no-trunc | xargs -L1 docker rmi --force
 
 shell:
 	docker run -ti --rm many-afl-frida /bin/bash

--- a/frida_mode/src/js/js_api.c
+++ b/frida_mode/src/js/js_api.c
@@ -9,142 +9,153 @@
 #include "ranges.h"
 #include "stats.h"
 #include "util.h"
-
-void js_api_done() {
+__attribute__((visibility("default"))) void js_api_done() {
 
   js_done = TRUE;
 
 }
 
-void js_api_error(char *msg) {
+__attribute__((visibility("default"))) void js_api_error(char *msg) {
 
   FATAL("%s", msg);
 
 }
 
-void js_api_set_entrypoint(void *address) {
+__attribute__((visibility("default"))) void js_api_set_entrypoint(
+    void *address) {
 
   entry_point = GPOINTER_TO_SIZE(address);
 
 }
 
-void js_api_set_persistent_address(void *address) {
+__attribute__((visibility("default"))) void js_api_set_persistent_address(
+    void *address) {
 
   persistent_start = GPOINTER_TO_SIZE(address);
 
 }
 
-void js_api_set_persistent_return(void *address) {
+__attribute__((visibility("default"))) void js_api_set_persistent_return(
+    void *address) {
 
   persistent_ret = GPOINTER_TO_SIZE(address);
 
 }
 
-void js_api_set_persistent_count(uint64_t count) {
+__attribute__((visibility("default"))) void js_api_set_persistent_count(
+    uint64_t count) {
 
   persistent_count = count;
 
 }
 
-void js_api_set_persistent_debug() {
+__attribute__((visibility("default"))) void js_api_set_persistent_debug() {
 
   persistent_debug = TRUE;
 
 }
 
-void js_api_set_debug_maps() {
+__attribute__((visibility("default"))) void js_api_set_debug_maps() {
 
   ranges_debug_maps = TRUE;
 
 }
 
-void js_api_add_include_range(void *address, gsize size) {
+__attribute__((visibility("default"))) void js_api_add_include_range(
+    void *address, gsize size) {
 
   GumMemoryRange range = {.base_address = GUM_ADDRESS(address), .size = size};
   ranges_add_include(&range);
 
 }
 
-void js_api_add_exclude_range(void *address, gsize size) {
+__attribute__((visibility("default"))) void js_api_add_exclude_range(
+    void *address, gsize size) {
 
   GumMemoryRange range = {.base_address = GUM_ADDRESS(address), .size = size};
   ranges_add_exclude(&range);
 
 }
 
-void js_api_set_instrument_libraries() {
+__attribute__((visibility("default"))) void js_api_set_instrument_libraries() {
 
   ranges_inst_libs = TRUE;
 
 }
 
-void js_api_set_instrument_debug_file(char *path) {
+__attribute__((visibility("default"))) void js_api_set_instrument_debug_file(
+    char *path) {
 
   instrument_debug_filename = g_strdup(path);
 
 }
 
-void js_api_set_prefetch_disable(void) {
+__attribute__((visibility("default"))) void js_api_set_prefetch_disable(void) {
 
   prefetch_enable = FALSE;
 
 }
 
-void js_api_set_instrument_no_optimize(void) {
+__attribute__((visibility("default"))) void js_api_set_instrument_no_optimize(
+    void) {
 
   instrument_optimize = FALSE;
 
 }
 
-void js_api_set_instrument_trace(void) {
+__attribute__((visibility("default"))) void js_api_set_instrument_trace(void) {
 
   instrument_tracing = TRUE;
 
 }
 
-void js_api_set_instrument_trace_unique(void) {
+__attribute__((visibility("default"))) void js_api_set_instrument_trace_unique(
+    void) {
 
   instrument_unique = TRUE;
 
 }
 
-void js_api_set_stdout(char *file) {
+__attribute__((visibility("default"))) void js_api_set_stdout(char *file) {
 
   output_stdout = g_strdup(file);
 
 }
 
-void js_api_set_stderr(char *file) {
+__attribute__((visibility("default"))) void js_api_set_stderr(char *file) {
 
   output_stderr = g_strdup(file);
 
 }
 
-void js_api_set_stats_file(char *file) {
+__attribute__((visibility("default"))) void js_api_set_stats_file(char *file) {
 
   stats_filename = g_strdup(file);
 
 }
 
-void js_api_set_stats_interval(uint64_t interval) {
+__attribute__((visibility("default"))) void js_api_set_stats_interval(
+    uint64_t interval) {
 
   stats_interval = interval;
 
 }
 
-void js_api_set_stats_transitions() {
+__attribute__((visibility("default"))) void js_api_set_stats_transitions() {
 
   stats_transitions = TRUE;
 
 }
 
-void js_api_set_persistent_hook(void *address) {
+__attribute__((visibility("default"))) void js_api_set_persistent_hook(
+    void *address) {
 
   persistent_hook = address;
 
 }
 
-void js_api_set_stalker_callback(const js_api_stalker_callback_t callback) {
+__attribute__((visibility("default"))) void js_api_set_stalker_callback(
+    const js_api_stalker_callback_t callback) {
 
   js_user_callback = callback;
 

--- a/frida_mode/src/main.c
+++ b/frida_mode/src/main.c
@@ -163,7 +163,7 @@ static void afl_print_env(void) {
 
 }
 
-void afl_frida_start(void) {
+__attribute__((visibility("default"))) void afl_frida_start(void) {
 
   afl_print_cmdline();
   afl_print_env();


### PR DESCRIPTION
Changes to strip unused symbols from afl-frida-trace.so and hance remove v8 and its dependency on C++. This reduces it's size from 50M to 30M, but more importantly has a significant impact on portability when building for `many-linux`.