### PR TITLE
Fixes to handling DSOs by name

### DIFF
--- a/frida_mode/src/ranges.c
+++ b/frida_mode/src/ranges.c
@@ -145,11 +145,13 @@ static void convert_name_token(gchar *token, GumMemoryRange *range) {
 
 static void convert_token(gchar *token, GumMemoryRange *range) {
 
-  if (g_strrstr(token, "-")) {
+  if (g_str_has_prefix(token, "0x")) {
 
     convert_address_token(token, range);
 
-  } else {
+  }
+
+  else {
 
     convert_name_token(token, range);
 
@@ -509,6 +511,13 @@ void ranges_config(void) {
   if (getenv("AFL_FRIDA_DEBUG_MAPS") != NULL) { ranges_debug_maps = TRUE; }
   if (getenv("AFL_INST_LIBS") != NULL) { ranges_inst_libs = TRUE; }
 
+  if (ranges_debug_maps) {
+
+    gum_process_enumerate_ranges(GUM_PAGE_NO_ACCESS, print_ranges_callback,
+                                 NULL);
+
+  }
+
   include_ranges = collect_ranges("AFL_FRIDA_INST_RANGES");
   exclude_ranges = collect_ranges("AFL_FRIDA_EXCLUDE_RANGES");
 
@@ -521,13 +530,6 @@ void ranges_init(void) {
   GArray *       step2;
   GArray *       step3;
   GArray *       step4;
-
-  if (ranges_debug_maps) {
-
-    gum_process_enumerate_ranges(GUM_PAGE_NO_ACCESS, print_ranges_callback,
-                                 NULL);
-
-  }
 
   OKF("Ranges - Instrument libraries [%c]", ranges_inst_libs ? 'X' : ' ');
 


### PR DESCRIPTION
Because of the hyphen, exclusions such as `AFL_FRIDA_EXCLUDE_RANGES=libc-2.31.so` were incorrectly being processed as numeric ranges. The selection criteria for numeric ranges versus libraries has been changed. Also, the printing of the address map when `AFL_FRIDA_DEBUG_MAPS` is set has been brought forward so that it is still displayed if the selected ranges fail validation to aid in debugging.