### PR TITLE
fixed potential UAF with custom mutator havoc after realloc

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -2057,7 +2057,7 @@ havoc_stage:
               temp_len = new_len;
               if (out_buf != custom_havoc_buf) {
 
-                afl_realloc(AFL_BUF_PARAM(out), temp_len);
+                out_buf = afl_realloc(AFL_BUF_PARAM(out), temp_len);
                 if (unlikely(!afl->out_buf)) { PFATAL("alloc"); }
                 memcpy(out_buf, custom_havoc_buf, temp_len);
 


### PR DESCRIPTION
If the custom mutator triggers a reallocation, then `out_buf` can become a dangling pointer. The subsequent `memcpy` is then a UAF. Updating the local `out_buf` to be equal to the reallocated buffer fixes this issue.

*edit:* clarification for documentation purposes: `out_buf` is a local variable and not the same as `afl->out_buf` (which was updated). The problem was basically that `out_buf` and `afl->out_buf` was not kept in sync.