### PR TITLE
Remove redundant if statement in afl-cc

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1921,9 +1921,7 @@ int main(int argc, char **argv, char **envp) {
       // ptr = instrument_mode_string[instrument_mode];
       // }
 
-    } else if (instrument_mode == INSTRUMENT_LTO ||
-
-               instrument_mode == INSTRUMENT_CLASSIC) {
+    } else if (instrument_mode == INSTRUMENT_CLASSIC) {
 
       lto_mode = 1;
 


### PR DESCRIPTION
When `instrument_mode == INSTRUMENT_LTO`, control always passes to the first if statement, and it seems correct too.