### PR TITLE
fix check again clang asan lib to work on mac and linux

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -339,7 +339,7 @@ static void fasan_check_afl_preload(char *afl_preload) {
   char * separator = strchr(afl_preload, ':');
   size_t first_preload_len = PATH_MAX;
   char * basename;
-  char   clang_runtime_prefix[] = "libclang_rt.asan-";
+  char   clang_runtime_prefix[] = "libclang_rt.asan";
 
   if (separator != NULL && (separator - afl_preload) < PATH_MAX) {
 


### PR DESCRIPTION
Just change the path checked slightly and it works on both platforms :)