### PR TITLE
Change afl to AFL in *.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 1. You have verified that the issue to be present in the current `dev` branch
 2. Please supply the command line options and relevant environment variables, e.g. a copy-paste of the contents of `out/default/fuzzer_setup`
 
-Thank you for making afl++ better!
+Thank you for making AFL++ better!
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# American Fuzzy Lop plus plus (afl++)
+# American Fuzzy Lop plus plus (AFL++)
 
   <img align="right" src="https://raw.githubusercontent.com/andreafioraldi/AFLplusplus-website/master/static/logo_256x256.png" alt="AFL++ Logo">
 
@@ -8,7 +8,7 @@
 
   Repository: [https://github.com/AFLplusplus/AFLplusplus](https://github.com/AFLplusplus/AFLplusplus)
 
-  afl++ is maintained by:
+  AFL++ is maintained by:
 
   * Marc "van Hauser" Heuse <mh@mh-sec.de>,
   * Heiko "hexcoder-" Eißfeldt <heiko.eissfeldt@hexco.de>,
@@ -17,36 +17,36 @@
 
   Originally developed by Michał "lcamtuf" Zalewski.
 
-  afl++ is a superior fork to Google's afl - more speed, more and better
+  AFL++ is a superior fork to Google's AFL - more speed, more and better
   mutations, more and better instrumentation, custom module support, etc.
 
-  If you want to use afl++ for your academic work, check the [papers page](https://aflplus.plus/papers/)
+  If you want to use AFL++ for your academic work, check the [papers page](https://aflplus.plus/papers/)
   on the website. To cite our work, look at the [Cite](#cite) section.
   For comparisons use the fuzzbench `aflplusplus` setup, or use `afl-clang-fast`
   with `AFL_LLVM_CMPLOG=1`.
 
-## Major behaviour changes in afl++ 3.00 onwards:
+## Major behaviour changes in AFL++ 3.00 onwards:
 
-With afl++ 3.13-3.20 we introduce frida_mode (-O) to have an alternative for
+With AFL++ 3.13-3.20 we introduce frida_mode (-O) to have an alternative for
 binary-only fuzzing. It is slower than Qemu mode but works on MacOS, Android,
 iOS etc.
 
-With afl++ 3.15 we introduced the following changes from previous behaviours:
+With AFL++ 3.15 we introduced the following changes from previous behaviours:
   * Also -M main mode does not do deterministic fuzzing by default anymore
   * afl-cmin and afl-showmap -Ci now descent into subdirectories like
     afl-fuzz -i does (but note that afl-cmin.bash does not)
 
-With afl++ 3.14 we introduced the following changes from previous behaviours:
+With AFL++ 3.14 we introduced the following changes from previous behaviours:
   * afl-fuzz: deterministic fuzzing it not a default for -M main anymore
   * afl-cmin/afl-showmap -i now descends into subdirectories (afl-cmin.bash
     however does not)
 
-With afl++ 3.10 we introduced the following changes from previous behaviours:
+With AFL++ 3.10 we introduced the following changes from previous behaviours:
   * The '+' feature of the '-t' option now means to  auto-calculate the timeout
     with the value given being the maximum timeout. The original meaning of
     "skipping timeouts instead of abort" is now inherent to the -t option.
 
-With afl++ 3.00 we introduced changes that break some previous afl and afl++
+With AFL++ 3.00 we introduced changes that break some previous AFL and AFL++
 behaviours and defaults:
   * There are no llvm_mode and gcc_plugin subdirectories anymore and there is
     only one compiler: afl-cc. All previous compilers now symlink to this one.
@@ -82,18 +82,18 @@ behaviours and defaults:
 ## Contents
 
   1. [Features](#important-features-of-afl)
-  2. [How to compile and install afl++](#building-and-installing-afl)
+  2. [How to compile and install AFL++](#building-and-installing-afl)
   3. [How to fuzz a target](#how-to-fuzz-with-afl)
   4. [Fuzzing binary-only targets](#fuzzing-binary-only-targets)
-  5. [Good examples and writeups of afl++ usages](#good-examples-and-writeups)
+  5. [Good examples and writeups of AFL++ usages](#good-examples-and-writeups)
   6. [CI Fuzzing](#ci-fuzzing)
   7. [Branches](#branches)
   8. [Want to help?](#help-wanted)
-  9. [Detailed help and description of afl++](#challenges-of-guided-fuzzing)
+  9. [Detailed help and description of AFL++](#challenges-of-guided-fuzzing)
 
-## Important features of afl++
+## Important features of AFL++
 
-  afl++ supports llvm from 3.8 up to version 12, very fast binary fuzzing with QEMU 5.1
+  AFL++ supports llvm from 3.8 up to version 12, very fast binary fuzzing with QEMU 5.1
   with laf-intel and redqueen, frida mode, unicorn mode, gcc plugin, full *BSD,
   Mac OS, Solaris and Android support and much, much, much more.
 
@@ -136,7 +136,7 @@ behaviours and defaults:
   * QBDI mode to fuzz android native libraries via Quarkslab's [QBDI](https://github.com/QBDI/QBDI) framework
   * Frida and ptrace mode to fuzz binary-only libraries, etc.
 
-  So all in all this is the best-of afl that is out there :-)
+  So all in all this is the best-of AFL that is out there :-)
 
   For new versions and additional information, check out:
   [https://github.com/AFLplusplus/AFLplusplus](https://github.com/AFLplusplus/AFLplusplus)
@@ -151,9 +151,9 @@ behaviours and defaults:
 
   The following branches exist:
 
-  * [stable/trunk](https://github.com/AFLplusplus/AFLplusplus/) : stable state of afl++ - it is synced from dev from time to
+  * [stable/trunk](https://github.com/AFLplusplus/AFLplusplus/) : stable state of AFL++ - it is synced from dev from time to
     time when we are satisfied with its stability
-  * [dev](https://github.com/AFLplusplus/AFLplusplus/tree/dev) : development state of afl++ - bleeding edge and you might catch a
+  * [dev](https://github.com/AFLplusplus/AFLplusplus/tree/dev) : development state of AFL++ - bleeding edge and you might catch a
     checkout which does not compile or has a bug. *We only accept PRs in dev!!*
   * [release](https://github.com/AFLplusplus/AFLplusplus/tree/release) : the latest release
   * (any other) : experimental branches to work on specific features or testing
@@ -175,9 +175,9 @@ We have an idea list in [docs/ideas.md](docs/ideas.md).
 For everyone who wants to contribute (and send pull requests) please read
 [CONTRIBUTING.md](CONTRIBUTING.md) before your submit.
 
-## Building and installing afl++
+## Building and installing AFL++
 
-An easy way to install afl++ with everything compiled is available via docker:
+An easy way to install AFL++ with everything compiled is available via docker:
 You can use the [Dockerfile](Dockerfile) (which has gcc-10 and clang-11 -
 hence afl-clang-lto is available!) or just pull directly from the docker hub:
 ```shell
@@ -187,7 +187,7 @@ docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus
 This image is automatically generated when a push to the stable repo happens.
 You will find your target source code in /src in the container.
 
-If you want to build afl++ yourself you have many options.
+If you want to build AFL++ yourself you have many options.
 The easiest choice is to build and install everything:
 
 ```shell
@@ -205,7 +205,7 @@ It is recommended to install the newest available gcc, clang and llvm-dev
 possible in your distribution!
 
 Note that "make distrib" also builds instrumentation, qemu_mode, unicorn_mode and
-more. If you just want plain afl++ then do "make all", however compiling and
+more. If you just want plain AFL++ then do "make all", however compiling and
 using at least instrumentation is highly recommended for much better results -
 hence in this case
 
@@ -216,7 +216,7 @@ is what you should choose.
 
 These build targets exist:
 
-* all: just the main afl++ binaries
+* all: just the main AFL++ binaries
 * binary-only: everything for binary-only fuzzing: qemu_mode, unicorn_mode, libdislocator, libtokencap
 * source-only: everything for source code fuzzing: instrumentation, libdislocator, libtokencap
 * distrib: everything (for both binary-only and source code fuzzing)
@@ -230,7 +230,7 @@ These build targets exist:
 * help: shows these build options
 
 [Unless you are on Mac OS X](https://developer.apple.com/library/archive/qa/qa1118/_index.html) you can also build statically linked versions of the 
-afl++ binaries by passing the STATIC=1 argument to make:
+AFL++ binaries by passing the STATIC=1 argument to make:
 
 ```shell
 make STATIC=1
@@ -264,14 +264,14 @@ Here are some good writeups to show how to effectively use AFL++:
 
 If you are interested in fuzzing structured data (where you define what the
 structure is), these links have you covered:
- * Superion for afl++: [https://github.com/adrian-rt/superion-mutator](https://github.com/adrian-rt/superion-mutator)
- * libprotobuf for afl++: [https://github.com/P1umer/AFLplusplus-protobuf-mutator](https://github.com/P1umer/AFLplusplus-protobuf-mutator)
+ * Superion for AFL++: [https://github.com/adrian-rt/superion-mutator](https://github.com/adrian-rt/superion-mutator)
+ * libprotobuf for AFL++: [https://github.com/P1umer/AFLplusplus-protobuf-mutator](https://github.com/P1umer/AFLplusplus-protobuf-mutator)
  * libprotobuf raw: [https://github.com/bruce30262/libprotobuf-mutator_fuzzing_learning/tree/master/4_libprotobuf_aflpp_custom_mutator](https://github.com/bruce30262/libprotobuf-mutator_fuzzing_learning/tree/master/4_libprotobuf_aflpp_custom_mutator)
- * libprotobuf for old afl++ API: [https://github.com/thebabush/afl-libprotobuf-mutator](https://github.com/thebabush/afl-libprotobuf-mutator)
+ * libprotobuf for old AFL++ API: [https://github.com/thebabush/afl-libprotobuf-mutator](https://github.com/thebabush/afl-libprotobuf-mutator)
 
 If you find other good ones, please send them to us :-)
 
-## How to fuzz with afl++
+## How to fuzz with AFL++
 
 The following describes how to fuzz with a target if source code is available.
 If you have a binary-only target please skip to [#Instrumenting binary-only apps](#Instrumenting binary-only apps)
@@ -287,9 +287,9 @@ Fuzzing source code is a three-step process.
 
 ### 1. Instrumenting that target
 
-#### a) Selecting the best afl++ compiler for instrumenting the target
+#### a) Selecting the best AFL++ compiler for instrumenting the target
 
-afl++ comes with a central compiler `afl-cc` that incorporates various different
+AFL++ comes with a central compiler `afl-cc` that incorporates various different
 kinds of compiler targets and and instrumentation options.
 The following evaluation flow will help you to select the best possible.
 
@@ -339,7 +339,7 @@ You can select the mode for the afl-cc compiler by:
 MODE can be one of: LTO (afl-clang-lto*), LLVM (afl-clang-fast*), GCC_PLUGIN
 (afl-g*-fast) or GCC (afl-gcc/afl-g++) or CLANG(afl-clang/afl-clang++).
 
-Because no afl specific command-line options are accepted (beside the
+Because no AFL specific command-line options are accepted (beside the
 --afl-MODE command), the compile-time tools make fairly broad use of environment
 variables, which can be listed with `afl-cc -hh` or by reading [docs/env_variables.md](docs/env_variables.md).
 
@@ -347,7 +347,7 @@ variables, which can be listed with `afl-cc -hh` or by reading [docs/env_variabl
 
 The following options are available when you instrument with LTO mode (afl-clang-fast/afl-clang-lto):
 
- * Splitting integer, string, float and switch comparisons so afl++ can easier
+ * Splitting integer, string, float and switch comparisons so AFL++ can easier
    solve these. This is an important option if you do not have a very good
    and large input corpus. This technique is called laf-intel or COMPCOV.
    To use this set the following environment variable before compiling the
@@ -355,7 +355,7 @@ The following options are available when you instrument with LTO mode (afl-clang
    You can read more about this in [instrumentation/README.laf-intel.md](instrumentation/README.laf-intel.md)
  * A different technique (and usually a better one than laf-intel) is to
    instrument the target so that any compare values in the target are sent to
-   afl++ which then tries to put these values into the fuzzing data at different
+   AFL++ which then tries to put these values into the fuzzing data at different
    locations. This technique is very fast and good - if the target does not
    transform input data before comparison. Therefore this technique is called
    `input to state` or `redqueen`.
@@ -388,7 +388,7 @@ time less effective. See:
  * [instrumentation/README.ctx.md](instrumentation/README.ctx.md)
  * [instrumentation/README.ngram.md](instrumentation/README.ngram.md)
 
-afl++ performs "never zero" counting in its bitmap. You can read more about this
+AFL++ performs "never zero" counting in its bitmap. You can read more about this
 here:
  * [instrumentation/README.neverzero.md](instrumentation/README.neverzero.md)
 
@@ -403,7 +403,7 @@ This is enough because a use-after-free bug will be picked up, e.g. by
 ASAN (address sanitizer) anyway when syncing to other fuzzing instances,
 so not all fuzzing instances need to be instrumented with ASAN.
 
-The following sanitizers have built-in support in afl++:
+The following sanitizers have built-in support in AFL++:
   * ASAN = Address SANitizer, finds memory corruption vulnerabilities like
     use-after-free, NULL pointer dereference, buffer overruns, etc.
     Enabled with `export AFL_USE_ASAN=1` before compiling.
@@ -457,13 +457,13 @@ by eliminating these checks within these AFL specific blocks:
 #endif
 ```
 
-All afl++ compilers will set this preprocessor definition automatically.
+All AFL++ compilers will set this preprocessor definition automatically.
 
 #### e) Instrument the target
 
 In this step the target source code is compiled so that it can be fuzzed.
 
-Basically you have to tell the target build system that the selected afl++
+Basically you have to tell the target build system that the selected AFL++
 compiler is used. Also - if possible - you should always configure the
 build system such that the target is compiled statically and not dynamically.
 How to do this is described below.
@@ -474,13 +474,13 @@ Then build the target. (Usually with `make`)
 
 1. sometimes configure and build systems are fickle and do not like
    stderr output (and think this means a test failure) - which is something
-   afl++ likes to do to show statistics. It is recommended to disable afl++
+   AFL++ likes to do to show statistics. It is recommended to disable AFL++
    instrumentation reporting via `export AFL_QUIET=1`.
 
 2. sometimes configure and build systems error on warnings - these should be
    disabled (e.g. `--disable-werror` for some configure scripts).
 
-3. in case the configure/build system complains about afl++'s compiler and
+3. in case the configure/build system complains about AFL++'s compiler and
    aborts then set `export AFL_NOOPT=1` which will then just behave like the
    real compiler. This option has to be unset again before building the target!
 
@@ -504,12 +504,12 @@ described in [instrumentation/README.lto.md](instrumentation/README.lto.md).
 
 ##### meson
 
-For meson you have to set the afl++ compiler with the very first command!
+For meson you have to set the AFL++ compiler with the very first command!
 `CC=afl-cc CXX=afl-c++ meson`
 
 ##### other build systems or if configure/cmake didn't work
 
-Sometimes cmake and configure do not pick up the afl++ compiler, or the
+Sometimes cmake and configure do not pick up the AFL++ compiler, or the
 ranlib/ar that is needed - because this was just not foreseen by the developer
 of the target. Or they have non-standard options. Figure out if there is a 
 non-standard way to set this, otherwise set up the build normally and edit the
@@ -525,7 +525,7 @@ This variant requires the usage of afl-clang-lto, afl-clang-fast or afl-gcc-fast
 
 It is the so-called `persistent mode`, which is much, much faster but
 requires that you code a source file that is specifically calling the target
-functions that you want to fuzz, plus a few specific afl++ functions around
+functions that you want to fuzz, plus a few specific AFL++ functions around
 it. See [instrumentation/README.persistent_mode.md](instrumentation/README.persistent_mode.md) for details.
 
 Basically if you do not fuzz a target in persistent mode then you are just
@@ -534,7 +534,7 @@ doing it for a hobby and not professionally :-).
 #### g) libfuzzer fuzzer harnesses with LLVMFuzzerTestOneInput()
 
 libfuzzer `LLVMFuzzerTestOneInput()` harnesses are the defacto standard
-for fuzzing, and they can be used with afl++ (and honggfuzz) as well!
+for fuzzing, and they can be used with AFL++ (and honggfuzz) as well!
 Compiling them is as simple as:
 ```
 afl-clang-fast++ -fsanitize=fuzzer -o harness harness.cpp targetlib.a
@@ -566,7 +566,7 @@ normal data it receives and processes to a file and use these.
 
 #### b) Making the input corpus unique
 
-Use the afl++ tool `afl-cmin` to remove inputs from the corpus that do not
+Use the AFL++ tool `afl-cmin` to remove inputs from the corpus that do not
 produce a new path in the target.
 
 Put all files from step a) into one directory, e.g. INPUTS.
@@ -678,7 +678,7 @@ failure handling in the target.
 Play around with various -m values until you find one that safely works for all
 your input seeds (if you have good ones and then double or quadrouple that.
 
-By default afl-fuzz never stops fuzzing. To terminate afl++ simply press Control-C
+By default afl-fuzz never stops fuzzing. To terminate AFL++ simply press Control-C
 or send a signal SIGINT. You can limit the number of executions or approximate runtime
 in seconds with options also.
 
@@ -693,7 +693,7 @@ All labels are explained in [docs/status_screen.md](docs/status_screen.md).
 If you want to seriously fuzz then use as many cores/threads as possible to
 fuzz your target.
 
-On the same machine - due to the design of how afl++ works - there is a maximum
+On the same machine - due to the design of how AFL++ works - there is a maximum
 number of CPU cores/threads that are useful, use more and the overall performance
 degrades instead. This value depends on the target, and the limit is between 32
 and 64 cores per machine.
@@ -734,7 +734,7 @@ If you have a large corpus, a corpus from a previous run or are fuzzing in
 a CI, then also set `export AFL_CMPLOG_ONLY_NEW=1` and `export AFL_FAST_CAL=1`.
 
 You can also use different fuzzers.
-If you are using afl spinoffs or afl conforming fuzzers, then just use the
+If you are using AFL spinoffs or AFL conforming fuzzers, then just use the
 same -o directory and give it a unique `-S` name.
 Examples are:
  * [Fuzzolic](https://github.com/season-lab/fuzzolic)
@@ -747,7 +747,7 @@ Examples are:
 
 A long list can be found at [https://github.com/Microsvuln/Awesome-AFL](https://github.com/Microsvuln/Awesome-AFL)
 
-However you can also sync afl++ with honggfuzz, libfuzzer with `-entropic=1`, etc.
+However you can also sync AFL++ with honggfuzz, libfuzzer with `-entropic=1`, etc.
 Just show the main fuzzer (-M) with the `-F` option where the queue/work
 directory of a different fuzzer is, e.g. `-F /src/target/honggfuzz`.
 Using honggfuzz (with `-n 1` or `-n 2`) and libfuzzer in parallel is highly
@@ -794,7 +794,7 @@ There is a more complex and configurable script in `utils/distributed_fuzzing`.
 
 #### d) The status of the fuzz campaign
 
-afl++ comes with the `afl-whatsup` script to show the status of the fuzzing
+AFL++ comes with the `afl-whatsup` script to show the status of the fuzzing
 campaign.
 
 Just supply the directory that afl-fuzz is given with the -o option and
@@ -886,7 +886,7 @@ This is basically all you need to know to professionally run fuzzing campaigns.
 If you want to know more, the rest of this README and the tons of texts in
 [docs/](docs/) will have you covered.
 
-Note that there are also a lot of tools out there that help fuzzing with afl++
+Note that there are also a lot of tools out there that help fuzzing with AFL++
 (some might be deprecated or unsupported):
 
 Speeding up fuzzing:
@@ -938,7 +938,7 @@ campaigns as these are much shorter runnings.
     initial corpus as this very likely has been done for them already.
   * Keep the generated corpus, use afl-cmin and reuse it every time!
 
-2. Additionally randomize the afl++ compilation options, e.g.
+2. Additionally randomize the AFL++ compilation options, e.g.
   * 40% for `AFL_LLVM_CMPLOG`
   * 10% for `AFL_LLVM_LAF_ALL`
 
@@ -954,12 +954,12 @@ campaigns as these are much shorter runnings.
    `-M` enables old queue handling etc. which is good for a fuzzing campaign but
    not good for short CI runs.
 
-How this can look like can e.g. be seen at afl++'s setup in Google's [oss-fuzz](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/compile_afl)
+How this can look like can e.g. be seen at AFL++'s setup in Google's [oss-fuzz](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/compile_afl)
 and [clusterfuzz](https://github.com/google/clusterfuzz/blob/master/src/python/bot/fuzzers/afl/launcher.py).
 
 ## Fuzzing binary-only targets
 
-When source code is *NOT* available, afl++ offers various support for fast,
+When source code is *NOT* available, AFL++ offers various support for fast,
 on-the-fly instrumentation of black-box binaries. 
 
 If you do not have to use Unicorn the following setup is recommended to use
@@ -1013,7 +1013,7 @@ less conducive to parallelization.
 
 ### Unicorn
 
-For non-Linux binaries you can use afl++'s unicorn mode which can emulate
+For non-Linux binaries you can use AFL++'s unicorn mode which can emulate
 anything you want - for the price of speed and user written scripts.
 See [unicorn_mode](unicorn_mode/README.md).
 
@@ -1215,13 +1215,13 @@ can be operated in a very simple way:
 
 The tool works with crashing and non-crashing test cases alike. In the crash
 mode, it will happily accept instrumented and non-instrumented binaries. In the
-non-crashing mode, the minimizer relies on standard afl++ instrumentation to make
+non-crashing mode, the minimizer relies on standard AFL++ instrumentation to make
 the file simpler without altering the execution path.
 
 The minimizer accepts the -m, -t, -f and @@ syntax in a manner compatible with
 afl-fuzz.
 
-Another tool in afl++ is the afl-analyze tool. It takes an input
+Another tool in AFL++ is the afl-analyze tool. It takes an input
 file, attempts to sequentially flip bytes, and observes the behavior of the
 tested program. It then color-codes the input based on which sections appear to
 be critical, and which are not; while not bulletproof, it can often offer quick
@@ -1264,7 +1264,7 @@ tasks, fuzzing may put a strain on your hardware and on the OS. In particular:
     for something to blow up.
 
   - Targeted programs may end up erratically grabbing gigabytes of memory or
-    filling up disk space with junk files. afl++ tries to enforce basic memory
+    filling up disk space with junk files. AFL++ tries to enforce basic memory
     limits, but can't prevent each and every possible mishap. The bottom line
     is that you shouldn't be fuzzing on systems where the prospect of data loss
     is not an acceptable risk.
@@ -1293,7 +1293,7 @@ tasks, fuzzing may put a strain on your hardware and on the OS. In particular:
 
 Here are some of the most important caveats for AFL:
 
-  - afl++ detects faults by checking for the first spawned process dying due to
+  - AFL++ detects faults by checking for the first spawned process dying due to
     a signal (SIGSEGV, SIGABRT, etc). Programs that install custom handlers for
     these signals may need to have the relevant code commented out. In the same
     vein, faults in child processes spawned by the fuzzed target may evade
@@ -1329,7 +1329,7 @@ Beyond this, see INSTALL for platform-specific tips.
 
 ## Special thanks
 
-Many of the improvements to the original afl and afl++ wouldn't be possible
+Many of the improvements to the original AFL and AFL++ wouldn't be possible
 without feedback, bug reports, or patches from:
 
 ```
@@ -1413,7 +1413,7 @@ Bibtex:
 Questions? Concerns? Bug reports? The contributors can be reached via
 [https://github.com/AFLplusplus/AFLplusplus](https://github.com/AFLplusplus/AFLplusplus)
 
-There is also a mailing list for the afl/afl++ project; to join, send a mail to
+There is also a mailing list for the AFL/AFL++ project; to join, send a mail to
 <afl-users+subscribe@googlegroups.com>. Or, if you prefer to browse archives
 first, try: [https://groups.google.com/group/afl-users](https://groups.google.com/group/afl-users)
 

--- a/custom_mutators/README.md
+++ b/custom_mutators/README.md
@@ -1,6 +1,6 @@
 # Custom Mutators
 
-Custom mutators enhance and alter the mutation strategies of afl++.
+Custom mutators enhance and alter the mutation strategies of AFL++.
 For further information and documentation on how to write your own, read [the docs](../docs/custom_mutators.md).
 
 ## Examples
@@ -11,9 +11,9 @@ The `./examples` folder contains examples for custom mutators in python and C.
 
 In `./rust`, you will find rust bindings, including a simple example in `./rust/example` and an example for structured fuzzing, based on lain, in`./rust/example_lain`.
 
-## The afl++ Grammar Mutator
+## The AFL++ Grammar Mutator
 
-If you use git to clone afl++, then the following will incorporate our
+If you use git to clone AFL++, then the following will incorporate our
 excellent grammar custom mutator:
 ```sh
 git submodule update --init
@@ -40,7 +40,7 @@ Multiple custom mutators can be used by separating their paths with `:` in the e
 
 ### Superion Mutators
 
-Adrian Tiron ported the Superion grammar fuzzer to afl++, it is WIP and
+Adrian Tiron ported the Superion grammar fuzzer to AFL++, it is WIP and
 requires cmake (among other things):
 [https://github.com/adrian-rt/superion-mutator](https://github.com/adrian-rt/superion-mutator)
 
@@ -52,8 +52,8 @@ transforms protobuf raw:
 https://github.com/bruce30262/libprotobuf-mutator_fuzzing_learning/tree/master/4_libprotobuf_aflpp_custom_mutator
 
 has a transform function you need to fill for your protobuf format, however
-needs to be ported to the updated afl++ custom mutator API (not much work):
+needs to be ported to the updated AFL++ custom mutator API (not much work):
 https://github.com/thebabush/afl-libprotobuf-mutator
 
-same as above but is for current afl++:
+same as above but is for current AFL++:
 https://github.com/P1umer/AFLplusplus-protobuf-mutator

--- a/custom_mutators/honggfuzz/README.md
+++ b/custom_mutators/honggfuzz/README.md
@@ -1,7 +1,7 @@
 # custum mutator: honggfuzz mangle
 
 this is the honggfuzz mutator in mangle.c as a custom mutator
-module for afl++. It is the original mangle.c, mangle.h and honggfuzz.h
+module for AFL++. It is the original mangle.c, mangle.h and honggfuzz.h
 with a lot of mocking around it :-)
 
 just type `make` to build

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -82,7 +82,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
     - on a crashing seed potentially the wrong input was disabled
     - added AFL_EXIT_ON_SEED_ISSUES env that will exit if a seed in
       -i dir crashes the target or results in a timeout. By default
-      afl++ ignores these and uses them for splicing instead.
+      AFL++ ignores these and uses them for splicing instead.
     - added AFL_EXIT_ON_TIME env that will make afl-fuzz exit fuzzing
       after no new paths have been found for n seconds
     - when AFL_FAST_CAL is set a variable path will now be calibrated
@@ -236,7 +236,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - Updated utils/afl_frida to be 5% faster, 7% on x86_x64
   - Added `AFL_KILL_SIGNAL` env variable (thanks @v-p-b)
   - @Edznux added a nice documentation on how to use rpc.statsd with
-    afl++ in docs/rpc_statsd.md, thanks!
+    AFL++ in docs/rpc_statsd.md, thanks!
 
 ### Version ++3.00c (release)
   - llvm_mode/ and gcc_plugin/ moved to instrumentation/
@@ -292,7 +292,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - custom mutators
     - added a new custom mutator: symcc -> https://github.com/eurecom-s3/symcc/
     - added a new custom mutator: libfuzzer that integrates libfuzzer mutations
-    - Our afl++ Grammar-Mutator is now better integrated into custom_mutators/
+    - Our AFL++ Grammar-Mutator is now better integrated into custom_mutators/
     - added INTROSPECTION support for custom modules
     - python fuzz function was not optional, fixed
     - some python mutator speed improvements
@@ -303,7 +303,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
 
 
 ### Version ++2.68c (release)
-  - added the GSoC excellent afl++ grammar mutator by Shengtuo to our
+  - added the GSoC excellent AFL++ grammar mutator by Shengtuo to our
     custom_mutators/ (see custom_mutators/README.md) - or get it here:
     https://github.com/AFLplusplus/Grammar-Mutator
   - a few QOL changes for Apple and its outdated gmake
@@ -326,12 +326,12 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - llvm_mode:
     - ported SanCov to LTO, and made it the default for LTO. better
       instrumentation locations
-    - Further llvm 12 support (fast moving target like afl++ :-) )
+    - Further llvm 12 support (fast moving target like AFL++ :-) )
     - deprecated LLVM SKIPSINGLEBLOCK env environment
 
 
 ### Version ++2.67c (release)
-  - Support for improved afl++ snapshot module:
+  - Support for improved AFL++ snapshot module:
     https://github.com/AFLplusplus/AFL-Snapshot-LKM
   - Due to the instrumentation needing more memory, the initial memory sizes
     for -m have been increased
@@ -433,7 +433,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
     files/stdin) - 10-100% performance increase
   - General support for 64 bit PowerPC, RiscV, Sparc etc.
   - fix afl-cmin.bash
-  - slightly better performance compilation options for afl++ and targets
+  - slightly better performance compilation options for AFL++ and targets
   - fixed afl-gcc/afl-as that could break on fast systems reusing pids in
     the same second
   - added lots of dictionaries from oss-fuzz, go-fuzz and Jakub Wilk
@@ -446,7 +446,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - afl-fuzz:
      - AFL_MAP_SIZE was not working correctly
      - better python detection
-     - an old, old bug in afl that would show negative stability in rare
+     - an old, old bug in AFL that would show negative stability in rare
        circumstances is now hopefully fixed
      - AFL_POST_LIBRARY was deprecated, use AFL_CUSTOM_MUTATOR_LIBRARY
        instead (see docs/custom_mutators.md)
@@ -505,8 +505,8 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - extended forkserver: map_size and more information is communicated to
     afl-fuzz (and afl-fuzz acts accordingly)
   - new environment variable: AFL_MAP_SIZE to specify the size of the shared map
-  - if AFL_CC/AFL_CXX is set but empty afl compilers did fail, fixed
-    (this bug is in vanilla afl too)
+  - if AFL_CC/AFL_CXX is set but empty AFL compilers did fail, fixed
+    (this bug is in vanilla AFL too)
   - added NO_PYTHON flag to disable python support when building afl-fuzz
   - more refactoring
 
@@ -520,7 +520,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - all:
     - big code changes to make afl-fuzz thread-safe so afl-fuzz can spawn
       multiple fuzzing threads in the future or even become a library
-    - afl basic tools now report on the environment variables picked up
+    - AFL basic tools now report on the environment variables picked up
     - more tools get environment variable usage info in the help output
     - force all output to stdout (some OK/SAY/WARN messages were sent to
       stdout, some to stderr)
@@ -669,7 +669,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - qemu and unicorn download scripts now try to download until the full
     download succeeded. f*ckin travis fails downloading 40% of the time!
   - more support for Android (please test!)
-  - added the few Android stuff we didnt have already from Google afl repository
+  - added the few Android stuff we didnt have already from Google AFL repository
   - removed unnecessary warnings
 
 
@@ -717,7 +717,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
 
   - big code refactoring:
     * all includes are now in include/
-    * all afl sources are now in src/ - see src/README.md
+    * all AFL sources are now in src/ - see src/README.md
     * afl-fuzz was split up in various individual files for including
       functionality in other programs (e.g. forkserver, memory map, etc.)
       for better readability.
@@ -733,7 +733,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
   - fix building on *BSD (thanks to tobias.kortkamp for the patch)
   - fix for a few features to support different map sized than 2^16
   - afl-showmap: new option -r now shows the real values in the buckets (stock
-    afl never did), plus shows tuple content summary information now
+    AFL never did), plus shows tuple content summary information now
   - small docu updates
   - NeverZero counters for QEMU
   - NeverZero counters for Unicorn
@@ -776,7 +776,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
     debugging
   - added -V time and -E execs option to better comparison runs, runs afl-fuzz
     for a specific time/executions.
-  - added a -s seed switch to allow afl run with a fixed initial
+  - added a -s seed switch to allow AFL run with a fixed initial
     seed that is not updated. This is good for performance and path discovery
     tests as the random numbers are deterministic then
   - llvm_mode LAF_... env variables can now be specified as AFL_LLVM_LAF_...
@@ -1597,7 +1597,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
 ### Version 1.63b:
 
   - Updated cgroups_asan/ with a new version from Sam, made a couple changes
-    to streamline it and keep parallel afl instances in separate groups.
+    to streamline it and keep parallel AFL instances in separate groups.
 
   - Fixed typos, thanks to Jakub Wilk.
 
@@ -2395,7 +2395,7 @@ sending a mail to <afl-users+subscribe@googlegroups.com>.
 
   - Added AFL_KEEP_ASSEMBLY for easier troubleshooting.
 
-  - Added an override for AFL_USE_ASAN if set at afl compile time. Requested by
+  - Added an override for AFL_USE_ASAN if set at AFL compile time. Requested by
     Hanno Boeck.
 
 ### Version 0.79b:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,8 +1,8 @@
-# Frequently asked questions about afl++
+# Frequently asked questions about AFL++
 
 ## Contents
 
-  * [What is the difference between afl and afl++?](#what-is-the-difference-between-afl-and-afl)
+  * [What is the difference between AFL and AFL++?](#what-is-the-difference-between-afl-and-afl)
   * [I got a weird compile error from clang](#i-got-a-weird-compile-error-from-clang)
   * [How to improve the fuzzing speed?](#how-to-improve-the-fuzzing-speed)
   * [How do I fuzz a network service?](#how-do-i-fuzz-a-network-service)
@@ -14,7 +14,7 @@
 If you find an interesting or important question missing, submit it via
 [https://github.com/AFLplusplus/AFLplusplus/issues](https://github.com/AFLplusplus/AFLplusplus/issues)
 
-## What is the difference between afl and afl++?
+## What is the difference between AFL and AFL++?
 
 American Fuzzy Lop (AFL) was developed by Michał "lcamtuf" Zalewski starting in
 2013/2014, and when he left Google end of 2017 he stopped developing it.
@@ -24,13 +24,13 @@ it is only accepting PRs from the community and is not developing enhancements
 anymore.
 
 In the second quarter of 2019, 1 1/2 year later when no further development of
-AFL had happened and it became clear there would none be coming, afl++
+AFL had happened and it became clear there would none be coming, AFL++
 was born, where initially community patches were collected and applied
 for bug fixes and enhancements. Then from various AFL spin-offs - mostly academic
 research - features were integrated. This already resulted in a much advanced
 AFL.
 
-Until the end of 2019 the afl++ team had grown to four active developers which
+Until the end of 2019 the AFL++ team had grown to four active developers which
 then implemented their own research and features, making it now by far the most
 flexible and feature rich guided fuzzer available as open source.
 And in independent fuzzing benchmarks it is one of the best fuzzers available,
@@ -52,15 +52,15 @@ clang-13: note: diagnostic msg:
 ********************
 ```
 Then this means that your OS updated the clang installation from an upgrade
-package and because of that the afl++ llvm plugins do not match anymore.
+package and because of that the AFL++ llvm plugins do not match anymore.
 
-Solution: `git pull ; make clean install` of afl++
+Solution: `git pull ; make clean install` of AFL++
 
 ## How to improve the fuzzing speed?
 
   1. Use [llvm_mode](../instrumentation/README.llvm.md): afl-clang-lto (llvm >= 11) or afl-clang-fast (llvm >= 9 recommended)
   2. Use [persistent mode](../instrumentation/README.persistent_mode.md) (x2-x20 speed increase)
-  3. Use the [afl++ snapshot module](https://github.com/AFLplusplus/AFL-Snapshot-LKM) (x2 speed increase)
+  3. Use the [AFL++ snapshot module](https://github.com/AFLplusplus/AFL-Snapshot-LKM) (x2 speed increase)
   4. If you do not use shmem persistent mode, use `AFL_TMPDIR` to put the input file directory on a tempfs location, see [docs/env_variables.md](docs/env_variables.md)
   5. Improve Linux kernel performance: modify `/etc/default/grub`, set `GRUB_CMDLINE_LINUX_DEFAULT="ibpb=off ibrs=off kpti=off l1tf=off mds=off mitigations=off no_stf_barrier noibpb noibrs nopcid nopti nospec_store_bypass_disable nospectre_v1 nospectre_v2 pcid=off pti=off spec_store_bypass_disable=off spectre_v2=off stf_barrier=off"`; then `update-grub` and `reboot` (warning: makes the system less secure)
   6. Running on an `ext2` filesystem with `noatime` mount option will be a bit faster than on any other journaling filesystem
@@ -86,7 +86,7 @@ and perform binary fuzzing) you can also use a shared library with AFL_PRELOAD
 to emulate the network. This is also much faster than the real network would be.
 See [utils/socket_fuzzing/](../utils/socket_fuzzing/).
 
-There is an outdated afl++ branch that implements networking if you are
+There is an outdated AFL++ branch that implements networking if you are
 desperate though: [https://github.com/AFLplusplus/AFLplusplus/tree/networking](https://github.com/AFLplusplus/AFLplusplus/tree/networking) - 
 however a better option is AFLnet ([https://github.com/aflnet/aflnet](https://github.com/aflnet/aflnet))
 which allows you to define network state with different type of data packets.
@@ -158,7 +158,7 @@ reaction to timing, etc. then in some of the re-executions with the same data
 the edge coverage result will be different accross runs.
 Those edges that change are then flagged "unstable".
 
-The more "unstable" edges, the more difficult for afl++ to identify valid new
+The more "unstable" edges, the more difficult for AFL++ to identify valid new
 paths.
 
 A value above 90% is usually fine and a value above 80% is also still ok, and

--- a/docs/binaryonly_fuzzing.md
+++ b/docs/binaryonly_fuzzing.md
@@ -1,12 +1,12 @@
-# Fuzzing binary-only programs with afl++
+# Fuzzing binary-only programs with AFL++
 
-  afl++, libfuzzer and others are great if you have the source code, and
+  AFL++, libfuzzer and others are great if you have the source code, and
   it allows for very fast and coverage guided fuzzing.
 
   However, if there is only the binary program and no source code available,
   then standard `afl-fuzz -n` (non-instrumented mode) is not effective.
 
-  The following is a description of how these binaries can be fuzzed with afl++.
+  The following is a description of how these binaries can be fuzzed with AFL++.
 
 
 ## TL;DR:
@@ -39,7 +39,7 @@
   Note that there is also honggfuzz: [https://github.com/google/honggfuzz](https://github.com/google/honggfuzz)
   which now has a qemu_mode, but its performance is just 1.5% ...
 
-  As it is included in afl++ this needs no URL.
+  As it is included in AFL++ this needs no URL.
 
   If you like to code a customized fuzzer without much work, we highly
   recommend to check out our sister project libafl which will support QEMU
@@ -56,12 +56,12 @@
   frida-gum via utils/afl_frida/, you will have to write a harness to
   call the target function in the library, use afl-frida.c as a template.
 
-  Both come with afl++ so this needs no URL.
+  Both come with AFL++ so this needs no URL.
 
   You can also perform remote fuzzing with frida, e.g. if you want to fuzz
   on iPhone or Android devices, for this you can use
   [https://github.com/ttdennis/fpicker/](https://github.com/ttdennis/fpicker/)
-  as an intermediate that uses afl++ for fuzzing.
+  as an intermediate that uses AFL++ for fuzzing.
 
   If you like to code a customized fuzzer without much work, we highly
   recommend to check out our sister project libafl which supports Frida too:
@@ -74,7 +74,7 @@
   Wine mode can run Win32 PE binaries with the QEMU instrumentation.
   It needs Wine, python3 and the pefile python package installed.
 
-  As it is included in afl++ this needs no URL.
+  As it is included in AFL++ this needs no URL.
 
 
 ## UNICORN
@@ -83,10 +83,10 @@
   In contrast to QEMU, Unicorn does not offer a full system or even userland
   emulation. Runtime environment and/or loaders have to be written from scratch,
   if needed. On top, block chaining has been removed. This means the speed boost
-  introduced in  the patched QEMU Mode of afl++ cannot simply be ported over to
+  introduced in  the patched QEMU Mode of AFL++ cannot simply be ported over to
   Unicorn. For further information, check out [unicorn_mode/README.md](../unicorn_mode/README.md).
 
-  As it is included in afl++ this needs no URL.
+  As it is included in AFL++ this needs no URL.
 
 
 ## AFL UNTRACER
@@ -153,7 +153,7 @@
   As a result, the overall speed decrease is about 70-90% (depending on
   the implementation and other factors).
 
-  There are two afl intel-pt implementations:
+  There are two AFL intel-pt implementations:
 
   1. [https://github.com/junxzm1990/afl-pt](https://github.com/junxzm1990/afl-pt)
      => this needs Ubuntu 14.04.05 without any updates and the 4.4 kernel.
@@ -175,7 +175,7 @@
   the ARM chip is difficult too.
   My guess is that it is slower than Qemu, but faster than Intel PT.
 
-  If anyone finds any coresight implementation for afl please ping me: vh@thc.org
+  If anyone finds any coresight implementation for AFL please ping me: vh@thc.org
 
 
 ## PIN & DYNAMORIO

--- a/docs/custom_mutators.md
+++ b/docs/custom_mutators.md
@@ -21,7 +21,7 @@ fuzzing by using libraries that perform mutations according to a given grammar.
 
 The custom mutator is passed to `afl-fuzz` via the `AFL_CUSTOM_MUTATOR_LIBRARY`
 or `AFL_PYTHON_MODULE` environment variable, and must export a fuzz function.
-Now afl also supports multiple custom mutators which can be specified in the same `AFL_CUSTOM_MUTATOR_LIBRARY` environment variable like this.
+Now AFL also supports multiple custom mutators which can be specified in the same `AFL_CUSTOM_MUTATOR_LIBRARY` environment variable like this.
 ```bash
 export AFL_CUSTOM_MUTATOR_LIBRARY="full/path/to/mutator_first.so;full/path/to/mutator_second.so"
 ```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,9 +1,9 @@
-# Restructure afl++'s documentation
+# Restructure AFL++'s documentation
 
 ## About us
 
 We are dedicated to everything around fuzzing, our main and most well known
-contribution is the fuzzer `afl++` which is part of all major Unix
+contribution is the fuzzer `AFL++` which is part of all major Unix
 distributions (e.g. Debian, Arch, FreeBSD, etc.) and is deployed on Google's
 oss-fuzz and clusterfuzz. It is rated the top fuzzer on Google's fuzzbench.
 
@@ -11,27 +11,27 @@ We are four individuals from Europe supported by a large community.
 
 All our tools are open source.
 
-## About the afl++ fuzzer project
+## About the AFL++ fuzzer project
 
-afl++ inherited it's documentation from the original Google afl project.
+AFL++ inherited it's documentation from the original Google AFL project.
 Since then it has been massively improved - feature and performance wise -
 and although the documenation has likewise been continued it has grown out
 of proportion.
 The documentation is done by non-natives to the English language, plus
 none of us has a writer background.
 
-We see questions on afl++ usage on mailing lists (e.g. afl-users), discord
+We see questions on AFL++ usage on mailing lists (e.g. afl-users), discord
 channels, web forums and as issues in our repository.
 
-This only increases as afl++ has been on the top of Google's fuzzbench
+This only increases as AFL++ has been on the top of Google's fuzzbench
 statistics (which measures the performance of fuzzers) and is now being
 integrated in Google's oss-fuzz and clusterfuzz - and is in many Unix
 packaging repositories, e.g. Debian, FreeBSD, etc.
 
-afl++ now has 44 (!) documentation files with 13k total lines of content.
+AFL++ now has 44 (!) documentation files with 13k total lines of content.
 This is way too much.
 
-Hence afl++ needs a complete overhaul of it's documentation, both on a 
+Hence AFL++ needs a complete overhaul of it's documentation, both on a 
 organisation/structural level as well as the content.
 
 Overall the following actions have to be performed:
@@ -44,9 +44,9 @@ Overall the following actions have to be performed:
   * The documents have been written and modified by a lot of different people,
     most of them non-native English speaker. Hence an overall review where
     parts should be rewritten has to be performed and then the rewrite done.
-  * Create a cheat-sheet for a very short best-setup build and run of afl++
+  * Create a cheat-sheet for a very short best-setup build and run of AFL++
   * Pictures explain more than 1000 words. We need at least 4 images that
-    explain the workflow with afl++:
+    explain the workflow with AFL++:
       - the build workflow
       - the fuzzing workflow
       - the fuzzing campaign management workflow
@@ -65,8 +65,8 @@ us.
 
 ## Metrics
 
-afl++ is a the highest performant fuzzer publicly available - but is also the
-most feature rich and complex. With the publicity of afl++' success and
+AFL++ is a the highest performant fuzzer publicly available - but is also the
+most feature rich and complex. With the publicity of AFL++' success and
 deployment in Google projects internally and externally and availability as
 a package on most Linux distributions we see more and more issues being
 created and help requests on our Discord channel that would not be
@@ -75,7 +75,7 @@ is unrealistic.
 
 We expect the the new documenation after this project to be cleaner, easier
 accessible and lighter to digest by our users, resulting in much less
-help requests. On the other hand the amount of users using afl++ should
+help requests. On the other hand the amount of users using AFL++ should
 increase as well as it will be more accessible which would also increase
 questions again - but overall resulting in a reduction of help requests.
 
@@ -103,7 +103,7 @@ graphics (but again - this is basically just guessing).
 Technical Writer                                              10000$
 Volunteer stipends                                                0$ (waved)
 T-Shirts for the top 10 contributors and helpers to this documentation project:
-	10 afl++ logo t-shirts 		20$ each		200$
+	10 AFL++ logo t-shirts 		20$ each		200$
 	10 shipping cost of t-shirts    10$ each		100$
 
 Total: 10.300$
@@ -118,5 +118,5 @@ We have no experience with a technical writer, but we will support that person
 with video calls, chats, emails and messaging, provide all necessary information
 and write technical contents that is required for the success of this project.
 It is clear to us that a technical writer knows how to write, but cannot know
-the technical details in a complex tooling like in afl++. This guidance, input,
+the technical details in a complex tooling like in AFL++. This guidance, input,
 etc. has to come from us.

--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -11,7 +11,7 @@
 
 ## 1) Settings for all compilers
 
-Starting with afl++ 3.0 there is only one compiler: afl-cc
+Starting with AFL++ 3.0 there is only one compiler: afl-cc
 To select the different instrumentation modes this can be done by
   1. passing the --afl-MODE command line option to the compiler
   2. or using a symlink to afl-cc: afl-gcc, afl-g++, afl-clang, afl-clang++,
@@ -23,10 +23,10 @@ To select the different instrumentation modes this can be done by
 (afl-g*-fast) or `GCC` (afl-gcc/afl-g++).
 
 Because (with the exception of the --afl-MODE command line option) the
-compile-time tools do not accept afl specific command-line options, they
+compile-time tools do not accept AFL specific command-line options, they
 make fairly broad use of environmental variables instead:
 
-  - Some build/configure scripts break with afl++ compilers. To be able to
+  - Some build/configure scripts break with AFL++ compilers. To be able to
     pass them, do:
 ```
        export CC=afl-cc
@@ -37,7 +37,7 @@ make fairly broad use of environmental variables instead:
        make
 ```
 
-  - Most afl tools do not print any output if stdout/stderr are redirected.
+  - Most AFL tools do not print any output if stdout/stderr are redirected.
     If you want to get the output into a file then set the `AFL_DEBUG`
     environment variable.
     This is sadly necessary for various build processes which fail otherwise.
@@ -149,7 +149,7 @@ Then there are a few specific features that are only available in instrumentatio
   This is a different kind way of instrumentation: first it compiles all
     code in LTO (link time optimization) and then performs an edge inserting
     instrumentation which is 100% collision free (collisions are a big issue
-    in afl and afl-like instrumentations). This is performed by using
+    in AFL and AFL-like instrumentations). This is performed by using
     afl-clang-lto/afl-clang-lto++ instead of afl-clang-fast, but is only
     built if LLVM 11 or newer is used.
 
@@ -167,7 +167,7 @@ Then there are a few specific features that are only available in instrumentatio
      or which functions were touched by an input.
    - `AFL_LLVM_MAP_ADDR` sets the fixed map address to a different address than
      the default `0x10000`. A value of 0 or empty sets the map address to be
-     dynamic (the original afl way, which is slower)
+     dynamic (the original AFL way, which is slower)
    - `AFL_LLVM_MAP_DYNAMIC` sets the shared memory address to be dynamic
    - `AFL_LLVM_LTO_STARTID` sets the starting location ID for the instrumentation.
      This defaults to 1
@@ -480,11 +480,11 @@ checks or alter some of the more exotic semantics of the tool:
     allows you to add tags to your fuzzing instances. This is especially useful when running
     multiple instances (`-M/-S` for example). Applied tags are `banner` and `afl_version`.
     `banner` corresponds to the name of the fuzzer provided through `-M/-S`.
-    `afl_version` corresponds to the currently running afl version (e.g `++3.0c`).
+    `afl_version` corresponds to the currently running AFL version (e.g `++3.0c`).
     Default (empty/non present) will add no tags to the metrics.
     See [rpc_statsd.md](rpc_statsd.md) for more information.
 
-  - Setting `AFL_CRASH_EXITCODE` sets the exit code afl treats as crash.
+  - Setting `AFL_CRASH_EXITCODE` sets the exit code AFL treats as crash.
     For example, if `AFL_CRASH_EXITCODE='-1'` is set, each input resulting
     in an `-1` return code (i.e. `exit(-1)` got called), will be treated
     as if a crash had ocurred.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,4 +1,4 @@
-# Ideas for afl++
+# Ideas for AFL++
 
 In the following, we describe a variety of ideas that could be implemented
 for future AFL++ versions.

--- a/docs/parallel_fuzzing.md
+++ b/docs/parallel_fuzzing.md
@@ -27,7 +27,7 @@ will not be able to use that input to guide their work.
 To help with this problem, afl-fuzz offers a simple way to synchronize test
 cases on the fly.
 
-Note that afl++ has AFLfast's power schedules implemented.
+Note that AFL++ has AFLfast's power schedules implemented.
 It is therefore a good idea to use different power schedules if you run
 several instances in parallel. See [power_schedules.md](power_schedules.md)
 
@@ -116,7 +116,7 @@ distribute the deterministic fuzzing across. Note that if you boot up fewer
 fuzzers than indicated by the second number passed to -M, you may end up with
 poor coverage.
 
-## 4) Syncing with non-afl fuzzers or independant instances
+## 4) Syncing with non-AFL fuzzers or independant instances
 
 A -M main node can be told with the `-F other_fuzzer_queue_directory` option
 to sync results from other fuzzers, e.g. libfuzzer or honggfuzz.

--- a/docs/status_screen.md
+++ b/docs/status_screen.md
@@ -35,7 +35,7 @@ american fuzzy lop ++3.01a (default) [fast] {0}
 
 The top line shows you which mode afl-fuzz is running in
 (normal: "american fuzy lop", crash exploration mode: "peruvian rabbit mode")
-and the version of afl++.
+and the version of AFL++.
 Next to the version is the banner, which, if not set with -T by hand, will
 either show the binary name being fuzzed, or the -M/-S main/secondary name for
 parallel fuzzing.
@@ -409,7 +409,7 @@ directory. This includes:
   - `edges_found`       - how many edges have been found
   - `var_byte_count`    - how many edges are non-deterministic
   - `afl_banner`        - banner text (e.g. the target name)
-  - `afl_version`       - the version of afl used
+  - `afl_version`       - the version of AFL used
   - `target_mode`       - default, persistent, qemu, unicorn, non-instrumented
   - `command_line`      - full command line used for the fuzzing session
 

--- a/instrumentation/README.instrument_list.md
+++ b/instrumentation/README.instrument_list.md
@@ -1,4 +1,4 @@
-# Using afl++ with partial instrumentation
+# Using AFL++ with partial instrumentation
 
   This file describes two different mechanisms to selectively instrument
   only specific parts in the target.
@@ -13,7 +13,7 @@ the program, leaving the rest uninstrumented. This helps to focus the fuzzer
 on the important parts of the program, avoiding undesired noise and
 disturbance by uninteresting code being exercised.
 
-For this purpose, "partial instrumentation" support is provided by afl++ that
+For this purpose, "partial instrumentation" support is provided by AFL++ that
 allows to specify what should be instrumented and what not.
 
 Both mechanisms can be used together.
@@ -100,7 +100,7 @@ exists somewhere else in the project directories.
 You can also specify function names. Note that for C++ the function names
 must be mangled to match! `nm` can print these names.
 
-afl++ is able to identify whether an entry is a filename or a function.
+AFL++ is able to identify whether an entry is a filename or a function.
 However if you want to be sure (and compliant to the sancov allow/blocklist
 format), you can specify source file entries like this:
 ```

--- a/instrumentation/README.laf-intel.md
+++ b/instrumentation/README.laf-intel.md
@@ -7,7 +7,7 @@ His blog [Circumventing Fuzzing Roadblocks with Compiler Transformations]
 (https://lafintel.wordpress.com/) and gitlab repo [laf-llvm-pass]
 (https://gitlab.com/laf-intel/laf-llvm-pass/)
 describe some code transformations that
-help afl++ to enter conditional blocks, where conditions consist of
+help AFL++ to enter conditional blocks, where conditions consist of
 comparisons of large values.
 
 ## Usage

--- a/instrumentation/README.lto.md
+++ b/instrumentation/README.lto.md
@@ -19,7 +19,7 @@ This version requires a current llvm 11+ compiled from the github master.
 
 ## Introduction and problem description
 
-A big issue with how afl/afl++ works is that the basic block IDs that are
+A big issue with how AFL/AFL++ works is that the basic block IDs that are
 set during compilation are random - and hence naturally the larger the number
 of instrumented locations, the higher the number of edge collisions are in the
 map. This can result in not discovering new paths and therefore degrade the

--- a/instrumentation/README.out_of_line.md
+++ b/instrumentation/README.out_of_line.md
@@ -1,4 +1,4 @@
-## Using afl++ without inlined instrumentation
+## Using AFL++ without inlined instrumentation
 
   This file describes how you can disable inlining of instrumentation.
 

--- a/instrumentation/README.persistent_mode.md
+++ b/instrumentation/README.persistent_mode.md
@@ -2,7 +2,7 @@
 
 ## 1) Introduction
 
-In persistent mode, afl++ fuzzes a target multiple times
+In persistent mode, AFL++ fuzzes a target multiple times
 in a single process, instead of forking a new process for each fuzz execution.
 This is the most effective way to fuzz, as the speed can easily
 be x10 or x20 times faster without any disadvanges.

--- a/qemu_mode/libcompcov/README.md
+++ b/qemu_mode/libcompcov/README.md
@@ -1,4 +1,4 @@
-# strcmp() / memcmp() CompareCoverage library for afl++ QEMU
+# strcmp() / memcmp() CompareCoverage library for AFL++ QEMU
 
   Written by Andrea Fioraldi <andreafioraldi@gmail.com>
 

--- a/unicorn_mode/README.md
+++ b/unicorn_mode/README.md
@@ -2,13 +2,13 @@
 
 The idea and much of the original implementation comes from Nathan Voss <njvoss299@gmail.com>.
 
-The port to afl++ is by Dominik Maier <mail@dmnk.co>.
+The port to AFL++ is by Dominik Maier <mail@dmnk.co>.
 
 The CompareCoverage and NeverZero counters features are by Andrea Fioraldi <andreafioraldi@gmail.com>.
 
 ## 1) Introduction
 
-The code in ./unicorn_mode allows you to build the (Unicorn Engine)[https://github.com/unicorn-engine/unicorn] with afl support.
+The code in ./unicorn_mode allows you to build the (Unicorn Engine)[https://github.com/unicorn-engine/unicorn] with AFL support.
 This means, you can run anything that can be emulated in unicorn and obtain instrumentation
 output for black-box, closed-source binary code snippets. This mechanism 
 can be then used by afl-fuzz to stress-test targets that couldn't be built 
@@ -24,7 +24,7 @@ For some pointers for more advanced emulation, take a look at [BaseSAFE](https:/
 
 ### Building AFL++'s Unicorn Mode
 
-First, make afl++ as usual.
+First, make AFL++ as usual.
 Once that completes successfully you need to build and add in the Unicorn Mode 
 features:
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -38,7 +38,7 @@ Here's a quick overview of the stuff you can find in this directory:
   - crash_triage         - a very rudimentary example of how to annotate crashes
                            with additional gdb metadata.
 
-  - custom_mutators      - examples for the afl++ custom mutator interface in
+  - custom_mutators      - examples for the AFL++ custom mutator interface in
                            C and Python. Note: They were moved to
                            ../custom_mutators/examples/
 
@@ -61,7 +61,7 @@ Here's a quick overview of the stuff you can find in this directory:
   - qemu_persistent_hook - persistent mode support module for qemu.
 
   - socket_fuzzing       - a LD_PRELOAD library 'redirects' a socket to stdin
-                           for fuzzing access with afl++
+                           for fuzzing access with AFL++
 
 Note that the minimize_corpus.sh tool has graduated from the utils/
 directory and is now available as ../afl-cmin. The LLVM mode has likewise

--- a/utils/aflpp_driver/README.md
+++ b/utils/aflpp_driver/README.md
@@ -1,4 +1,4 @@
-# afl++ drivers
+# AFL++ drivers
 
 ## aflpp_driver
 

--- a/utils/argv_fuzzing/README.md
+++ b/utils/argv_fuzzing/README.md
@@ -1,6 +1,6 @@
 # argvfuzz
 
-afl supports fuzzing file inputs or stdin. When source is available,
+AFL supports fuzzing file inputs or stdin. When source is available,
 `argv-fuzz-inl.h` can be used to change `main()` to build argv from stdin.
 
 `argvfuzz` tries to provide the same functionality for binaries. When loaded

--- a/utils/defork/README.md
+++ b/utils/defork/README.md
@@ -8,4 +8,4 @@ the target will belive it is running as the child, post-fork.
 This is defork.c from the amazing preeny project
 https://github.com/zardus/preeny
 
-It is altered for afl++ to work with its fork-server: the initial fork will go through, the second fork will be blocked.
+It is altered for AFL++ to work with its fork-server: the initial fork will go through, the second fork will be blocked.

--- a/utils/qbdi_mode/README.md
+++ b/utils/qbdi_mode/README.md
@@ -1,7 +1,7 @@
 # qbdi-based binary-only instrumentation for afl-fuzz
 
 NOTE: this code is outdated and first would need to be adapted to the current
-afl++ versions first.
+AFL++ versions first.
 Try frida_mode/ or fpicker [https://github.com/ttdennis/fpicker/](https://github.com/ttdennis/fpicker/) first, maybe they suite your need.
 
 ## 1) Introduction

--- a/utils/socket_fuzzing/README.md
+++ b/utils/socket_fuzzing/README.md
@@ -8,4 +8,4 @@ a network socket.
 This is desock_dup.c from the amazing preeny project
 https://github.com/zardus/preeny
 
-It is packaged in afl++ to have it at hand if needed
+It is packaged in AFL++ to have it at hand if needed


### PR DESCRIPTION
Changes in *.md files:
- afl++ > AFL++ (acronym)
- afl > AFL (compare https://github.com/google/AFL)

Excluded from changes:
- source code
- function names
- paths (folder and file names)
- URLs