### PR TITLE
Removed loading of "paths_total" property from stats file

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -146,10 +146,6 @@ void load_stats_file(afl_state_t *afl) {
           if (!strcmp(keystring, "execs_done        "))
             afl->fsrv.total_execs = strtoull(lptr, &nptr, 10);
           break;
-        case 10:
-          if (!strcmp(keystring, "paths_total       "))
-            afl->queued_paths = strtoul(lptr, &nptr, 10);
-          break;
         case 12:
           if (!strcmp(keystring, "paths_found       "))
             afl->queued_discovered = strtoul(lptr, &nptr, 10);


### PR DESCRIPTION
When running `afl-fuzz` with `AFL_AUTORESUME=1` and/or if the input directory is specified as `-`, the property `paths_total` should *not* be read from the `fuzzer_stats` file by `load_stats_file()`. 

This is because:

- Prior to calling `load_stats_file()`, `afl-fuzz` has already set the value of `afl->queued_paths` by parsing the `queue/` folder and loaded the queued seeds into `afl->queue_buf`. 
- It is redundant to read the value of `afl->queued_paths` again from the `fuzzer_stats` file (and overwrite its value). 
- Consider the following scenario:
  - The user runs a fuzzing experiment and stops it after some time.
  - The user modifies the `queue/` folder by culling/minimizing the queued seeds.
  - The user does not update the `fuzzer_stats` file.
  - The user continues the fuzzing experiment by setting `AFL_AUTORESUME=1`.
  - As a result, the read value of `afl->queued_paths` and the *actual number of queued seeds* will be inconsistent.
  - Since the read value of `afl->queued_paths` is larger than the *actual number of queued seeds*, an out-of-bounds access on the array `afl->queue_buf` will take place.