### PR TITLE
Clean up references to notes_for_asan.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,8 +1322,7 @@ Here are some of the most important caveats for AFL:
     `AFL_CUSTOM_MUTATOR_LIBRARY`
 
   - There are some unfortunate trade-offs with ASAN and 64-bit binaries. This
-    isn't due to any specific fault of afl-fuzz; see [docs/notes_for_asan.md](docs/notes_for_asan.md)
-    for tips.
+    isn't due to any specific fault of afl-fuzz.
 
   - There is no direct support for fuzzing network services, background
     daemons, or interactive apps that require UI interaction to work. You may

--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -55,8 +55,7 @@ make fairly broad use of environmental variables instead:
     overridden.
 
   - Setting `AFL_USE_ASAN` automatically enables ASAN, provided that your
-    compiler supports it. Note that fuzzing with ASAN is mildly challenging
-    - see [notes_for_asan.md](notes_for_asan.md).
+    compiler supports it.
 
     (You can also enable MSAN via `AFL_USE_MSAN`; ASAN and MSAN come with the
     same gotchas; the modes are mutually exclusive. UBSAN can be enabled


### PR DESCRIPTION
Hi,

I only edited two docs-related files and I'm note sure what to do about the other files with the broken reference: https://github.com/AFLplusplus/AFLplusplus/search?q=notes_for_asan