### PR TITLE
Fix "havoc_mutations" not working in Python module

### DIFF
--- a/src/afl-fuzz-python.c
+++ b/src/afl-fuzz-python.c
@@ -445,6 +445,10 @@ struct custom_mutator *load_custom_mutator_py(afl_state_t *afl,
 
   /* Initialize the custom mutator */
   init_py(afl, py_mutator, rand_below(afl, 0xFFFFFFFF));
+  
+  mutator->stacked_custom = (mutator && mutator->afl_custom_havoc_mutation);
+  mutator->stacked_custom_prob =
+      6;  // like one of the default mutations in havoc
 
   return mutator;
 


### PR DESCRIPTION
The Python module of custom mutator was loaded without initializing the variables stacked_custom and stacked_custom_prob. This caused the havoc_mutation and havoc_mutation_probability APIs not to work. So I wrote a fix referring to "afl-fuzz-mutators.c".