### PR TITLE
Coverage fixes

### DIFF
--- a/frida_mode/frida.map
+++ b/frida_mode/frida.map
@@ -26,6 +26,7 @@
     js_api_set_prefetch_backpatch_disable;
     js_api_set_prefetch_disable;
     js_api_set_stalker_callback;
+    js_api_set_stalker_ic_entries;
     js_api_set_stats_file;
     js_api_set_stats_interval;
     js_api_set_stderr;

--- a/frida_mode/src/instrument/instrument_coverage.c
+++ b/frida_mode/src/instrument/instrument_coverage.c
@@ -13,7 +13,7 @@
 char *instrument_coverage_filename = NULL;
 
 static int         coverage_fd = -1;
-static int         coverage_pipes[2] = {0};
+static int         coverage_pipes[2] = {-1, -1};
 static uint64_t    coverage_last_start = 0;
 static GHashTable *coverage_hash = NULL;
 static GArray *    coverage_modules = NULL;
@@ -353,11 +353,15 @@ void instrument_coverage_init(void) {
 
 void instrument_coverage_start(uint64_t address) {
 
+  if (instrument_coverage_filename == NULL) { return; }
+
   coverage_last_start = address;
 
 }
 
 void instrument_coverage_end(uint64_t address) {
+
+  if (instrument_coverage_filename == NULL) { return; }
 
   coverage_data_t data = {
 


### PR DESCRIPTION
Fixes to coverage:
- Don't break reading from STDIN by writing to uninitialized fd 0 when not enabled.
- Use `instrument_coverage_print` in preference to `OKF` since the later doesn't seem to flush when we rip the process down.
- Change how coverage finds modules to deal with problems encountered when an executable module is itself also mapped as a flat file.