### PR TITLE
Fix null ptr de-reference of unresolved symbols on early init

### DIFF
--- a/qemu_mode/libcompcov/libcompcov.so.c
+++ b/qemu_mode/libcompcov/libcompcov.so.c
@@ -41,6 +41,13 @@
   #error "Sorry, this library is Linux-specific for now!"
 #endif                                                        /* !__linux__ */
 
+#ifndef likely
+#  define likely(x)       __builtin_expect((!!(x)),1)
+#endif
+#ifndef unlikely
+#  define unlikely(x)     __builtin_expect((!!(x)),0)
+#endif
+
 /* Change this value to tune the compare coverage */
 
 #define MAX_CMP_LENGTH 32
@@ -199,6 +206,7 @@ static u8 __compcov_is_in_bound(const void *ptr) {
 
 int strcmp(const char *str1, const char *str2) {
 
+  if (unlikely(!__libc_strcmp)) { __libc_strcmp = dlsym(RTLD_NEXT, "strcmp"); }
   void *retaddr = __builtin_return_address(0);
 
   if (__compcov_is_in_bound(retaddr) &&
@@ -227,6 +235,7 @@ int strcmp(const char *str1, const char *str2) {
 
 int strncmp(const char *str1, const char *str2, size_t len) {
 
+  if (unlikely(!__libc_strncmp)) { __libc_strncmp = dlsym(RTLD_NEXT, "strncmp"); }
   void *retaddr = __builtin_return_address(0);
 
   if (__compcov_is_in_bound(retaddr) &&
@@ -256,6 +265,7 @@ int strncmp(const char *str1, const char *str2, size_t len) {
 
 int strcasecmp(const char *str1, const char *str2) {
 
+  if (unlikely(!__libc_strcasecmp)) { __libc_strncasecmp = dlsym(RTLD_NEXT, "strcasecmp"); }
   void *retaddr = __builtin_return_address(0);
 
   if (__compcov_is_in_bound(retaddr) &&
@@ -286,6 +296,7 @@ int strcasecmp(const char *str1, const char *str2) {
 
 int strncasecmp(const char *str1, const char *str2, size_t len) {
 
+  if (unlikely(!__libc_strncasecmp)) { __libc_strncasecmp = dlsym(RTLD_NEXT, "strncasecmp"); }
   void *retaddr = __builtin_return_address(0);
 
   if (__compcov_is_in_bound(retaddr) &&
@@ -317,6 +328,7 @@ int strncasecmp(const char *str1, const char *str2, size_t len) {
 
 int memcmp(const void *mem1, const void *mem2, size_t len) {
 
+  if (unlikely(!__libc_memcmp)) { __libc_memcmp = dlsym(RTLD_NEXT, "memcmp"); }
   void *retaddr = __builtin_return_address(0);
 
   if (__compcov_is_in_bound(retaddr) &&


### PR DESCRIPTION
When libcompcov preloaded to the environment of complicated programs - it crash other libs.

![изображение](https://user-images.githubusercontent.com/62266948/134841059-7eaab2f4-a2a6-4dbf-9aa8-063e58c71c45.png)
As you can see from crash back-trace `memcmp()` pointed to by zero.
![изображение](https://user-images.githubusercontent.com/62266948/134841135-efee6c41-1438-4315-9cd7-6ef0eb41b241.png)

So, whole process crashes even before `_start`.

This patch should fix that.