### PR TITLE
fix stack-use-after-return in libfuzzer custom mutator

### DIFF
--- a/custom_mutators/libfuzzer/libfuzzer.inc
+++ b/custom_mutators/libfuzzer/libfuzzer.inc
@@ -2,7 +2,7 @@
 
 extern "C" ATTRIBUTE_INTERFACE void
 LLVMFuzzerMyInit(int (*Callback)(const uint8_t *Data, size_t Size), unsigned int Seed) {
-  Random Rand(Seed);
+  auto *Rand = new Random(Seed);
   FuzzingOptions Options;
   Options.Verbosity = 3;
   Options.MaxLen = 1024000;
@@ -30,7 +30,7 @@ LLVMFuzzerMyInit(int (*Callback)(const uint8_t *Data, size_t Size), unsigned int
   struct EntropicOptions Entropic;
   Entropic.Enabled = Options.Entropic;
   EF = new ExternalFunctions();
-  auto *MD = new MutationDispatcher(Rand, Options);
+  auto *MD = new MutationDispatcher(*Rand, Options);
   auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
   auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
 }


### PR DESCRIPTION
Hi, 

I use a fork of AFL++'s custom mutators in one of my projects. While working on this project, I noticed that in some fuzzing runs, the libFuzzer custom mutator did not mutate any inputs. After debugging the libFuzzer custom mutator code, I found that in some fuzzing runs, libFuzzer's PRNG always returns zero. And in this case, zero means that libFuzzer does not mutate the input.

The reason for this issue is that libFuzzer's PRNG class instance is allocated on the stack in the LLVMFuzzerMyInit function. This PRNG instance is used after the LLVMFuzzerMyInit function returns. AddressSanitizer calls this a Stack Use After Return bug. A future function call/stack frame can overwrite the internal state of the PRNG and mess it up.

This PR fixes this bug by allocating the PRNG instance on the heap.

I compiled AFL++ and the libFuzzer custom mutator with AddressSanitizer to confirm that this is a Stack Use After Return bug:
~~~
➜  ASAN_OPTIONS="detect_stack_use_after_return=1:abort_on_error=1:symbolize=0" AFL_CUSTOM_MUTATOR_LIBRARY="../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so" ../AFLplusplus-3.14c/afl-fuzz -i i -o o ./a.out      
[+] Loaded environment variable AFL_CUSTOM_MUTATOR_LIBRARY with value ../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so
afl-fuzz++3.14c based on afl by Michal Zalewski and a large online community
[+] afl++ is maintained by Marc "van Hauser" Heuse, Heiko "hexcoder" Eißfeldt, Andrea Fioraldi and Dominik Maier
[+] afl++ is open source, get it at https://github.com/AFLplusplus/AFLplusplus
[+] NOTE: This is v3.x which changes defaults and behaviours - see README.md
[+] Loaded environment variable ASAN_OPTIONS with value detect_stack_use_after_return=1:abort_on_error=1:symbolize=0
[+] No -M/-S set, autoconfiguring for "-S default"
[*] Getting to work...
[+] Using exponential power schedule (FAST)
[+] Enabled testcache with 50 MB
[*] Checking core_pattern...
[!] WARNING: Could not check CPU scaling governor
[+] You have 4 CPU cores and 2 runnable tasks (utilization: 50%).
[+] Try parallel jobs - see /usr/local/share/doc/afl/parallel_fuzzing.md.
[*] Setting up output directories...
[+] Output directory exists but deemed OK to reuse.
[*] Deleting old session data...
[+] Output dir cleanup successful.
[*] Checking CPU core loadout...
[+] Found a free CPU core, try binding to #0.
[*] Loading custom mutator library from '../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so'...
[*] optional symbol 'afl_custom_fuzz_count' not found.
[*] optional symbol 'afl_custom_post_process' not found.
[*] optional symbol 'afl_custom_init_trim' not found.
[*] optional symbol 'afl_custom_trim' not found.
[*] optional symbol 'afl_custom_post_trim' not found.
[*] optional symbol 'afl_custom_havoc_mutation' not found.
[*] optional symbol 'afl_custom_havoc_mutation_probability' not found.
[*] optional symbol 'afl_custom_queue_get' not found.
[*] optional symbol 'afl_custom_queue_new_entry' not found
[*] Symbol 'afl_custom_describe' not found.
[+] Custom mutator '../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so' installed successfully.
[*] Scanning 'i'...
[+] Loaded a total of 1 seeds.
[*] Creating hard links for all input files...
[*] Validating target binary...
[*] Spinning up the fork server...
[+] All right - fork server is up.
[*] No auto-generated dictionary tokens to reuse.
[*] Attempting dry run with 'id:000000,time:0,orig:i'...
    len = 2, map size = 5, exec speed = 3932 us
[+] All test cases processed.
[+] Here are some useful stats:

    Test case count : 1 favored, 0 variable, 0 ignored, 1 total
       Bitmap range : 5 to 5 bits (average: 5.00 bits)
        Exec timing : 3932 to 3932 us (average: 3932 us)

[*] No -t option specified, so I'll use exec timeout of 20 ms.
[+] All set and ready to roll!
=================================================================
==558426==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f84a109d820 at pc 0x7f8497a6b822 bp 0x7ffdb1e91610 sp 0x7ffdb1e91608
READ of size 8 at 0x7f84a109d820 thread T0
    #0 0x7f8497a6b821  (../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so+0xc7821)
    #1 0x7f8497a837d1  (../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so+0xdf7d1)
    #2 0x4e1af3  (/home/user/AFL++/AFLplusplus-3.14c/afl-fuzz+0x4e1af3)
    #3 0x4f5d9d  (/home/user/AFL++/AFLplusplus-3.14c/afl-fuzz+0x4f5d9d)
    #4 0x50f5e1  (/home/user/AFL++/AFLplusplus-3.14c/afl-fuzz+0x50f5e1)
    #5 0x7f84a42730b2  (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #6 0x41d73d  (/home/user/AFL++/AFLplusplus-3.14c/afl-fuzz+0x41d73d)

Address 0x7f84a109d820 is located in stack of thread T0 at offset 32 in frame
    #0 0x7f84979f7bbf  (../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so+0x53bbf)

  This frame has 5 object(s):
    [32, 40) 'Rand' (line 5) <== Memory access at offset 32 is inside this variable
    [64, 592) 'Options' (line 6)
    [720, 751) 'Entropic1.sroa.5' (line 31)
    [784, 816) 'agg.tmp'
    [848, 1376) 'agg.tmp20'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-return (../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so+0xc7821) 
Shadow bytes around the buggy address:
  0x0ff11420bab0: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bac0: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bad0: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bae0: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420baf0: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
=>0x0ff11420bb00: f5 f5 f5 f5[f5]f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bb10: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bb20: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bb30: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bb40: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x0ff11420bb50: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==558426==ABORTING
[1]    558426 abort      ASAN_OPTIONS="detect_stack_use_after_return=1:abort_on_error=1:symbolize=0" =

~~~

I think you need clang-11/llvm-11 or newer for the detect_stack_use_after_return=1 ASAN feature.

Tested on this system:
~~~
AFL++ 3.14c

➜  clang-11 --version
Ubuntu clang version 11.0.0-2~ubuntu20.04.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

➜  lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.3 LTS
Release:        20.04
Codename:       focal
~~~

To compile AFL++ and the custom mutator with ASAN I used the following commands:

Compile AFL++ with ASAN with clang-11:
~~~
CC=clang-11 CXX=clang++-11 CFLAGS="-fsanitize=address" CXXFLAGS="-fsanitize=address" make source-only CC=clang-11 CXX=clang++-11 CFLAGS="-fsanitize=address" CXXFLAGS="-fsanitize=address"
~~~

Compile custom mutator:
in custom_mutators/honggfuzz/Makefile:
~~~
- add '-fsanitize=address' to the CFLAGS
- add '-lstdc++' to the line '$(CXX) $(CFLAGS) -I../../include -I. -shared -o libfuzzer-mutator.so *.o -lstdc++'
- in custom_mutators/honggfuzz, compile with 'CXX=clang-11 make'
~~~

Fuzz binary. 
a.out can be any binary.
~~~
ASAN_OPTIONS="detect_stack_use_after_return=1:abort_on_error=1:symbolize=0" AFL_CUSTOM_MUTATOR_LIBRARY="../AFLplusplus-3.14c/custom_mutators/libfuzzer/libfuzzer-mutator.so" ../AFLplusplus-3.14c/afl-fuzz -i i -o o ./a.out
~~~

If you need more info, I'm happy to help :)