### PR TITLE
Fix memory leak in libfuzzer custom mutator

### DIFF
--- a/custom_mutators/libfuzzer/FuzzerLoop.cpp
+++ b/custom_mutators/libfuzzer/FuzzerLoop.cpp
@@ -1086,6 +1086,7 @@ ATTRIBUTE_INTERFACE size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size,
                                             size_t MaxSize) {
 
   assert(fuzzer::F);
+  fuzzer::F->GetMD().StartMutationSequence();
   size_t r = fuzzer::F->GetMD().DefaultMutate(Data, Size, MaxSize);
 #ifdef  INTROSPECTION
   introspection_ptr = fuzzer::F->GetMD().WriteMutationSequence();


### PR DESCRIPTION
Hi,

I noticed that the libFuzzer custom mutator has a memory leak. If I let my fuzzer run over night, my system ran out of memory and AFL++ stopped fuzzing.

The problem is that every time libFuzzer generates an input, libFuzzer's 'MutationDispatcher::MutateImpl' function appends the mutation to the 'CurrentMutatorSequence' array, and this array is never reset.

The standalone libFuzzer resets the CurrentMutatorSequence after each generated input in the Fuzzer::MutateAndTestOne function via the 'MD.StartMutationSequence();' call. The AFL++ custom mutator does not call Fuzzer::MutateAndTestOne -- it calls LLVMFuzzerMutate() directly in the afl_custom_fuzz function.

This PR fixes this issue by calling StartMutationSequence() in the LLVMFuzzerMutate function to reset the CurrentMutatorSequence.