### PR TITLE
Wrong map size when a realloc happens

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1706,7 +1706,7 @@ int main(int argc, char **argv_orig, char **envp) {
   if (afl->non_instrumented_mode || afl->fsrv.qemu_mode ||
       afl->fsrv.frida_mode || afl->unicorn_mode) {
 
-    map_size = afl->fsrv.map_size = MAP_SIZE;
+    map_size = afl->fsrv.real_map_size = afl->fsrv.map_size = MAP_SIZE;
     afl->virgin_bits = ck_realloc(afl->virgin_bits, map_size);
     afl->virgin_tmout = ck_realloc(afl->virgin_tmout, map_size);
     afl->virgin_crash = ck_realloc(afl->virgin_crash, map_size);


### PR DESCRIPTION
`virgin_bits` is allocated at src/afl-fuzz-state.c:115

```C
  afl->virgin_bits = ck_alloc(map_size);
  afl->virgin_tmout = ck_alloc(map_size);
  afl->virgin_crash = ck_alloc(map_size);
```

But a `realloc` may happen at src/afl-fuzz.c:1706

```C
  if (afl->non_instrumented_mode || afl->fsrv.qemu_mode ||
      afl->fsrv.frida_mode || afl->unicorn_mode) {

    map_size = afl->fsrv.map_size = MAP_SIZE;
    afl->virgin_bits = ck_realloc(afl->virgin_bits, map_size);
    afl->virgin_tmout = ck_realloc(afl->virgin_tmout, map_size);
    afl->virgin_crash = ck_realloc(afl->virgin_crash, map_size);
```

Then an OOB access happens if we enable debug at src/afl-fuzz-stats.c:337

```C
  if (afl->debug) {

    u32 i = 0;
    fprintf(f, "virgin_bytes     :");
    for (i = 0; i < afl->fsrv.map_size; i++) {

      if (afl->virgin_bits[i] != 0xff) {

        fprintf(f, " %u[%02x]", i, afl->virgin_bits[i]);

      }

    }

    fprintf(f, "\n");
    fprintf(f, "var_bytes        :");
    for (i = 0; i < afl->fsrv.map_size; i++) {

      if (afl->var_bytes[i]) { fprintf(f, " %u", i); }

    }

    fprintf(f, "\n");

  }
```

This PR fixes the OOB access.