### PR TITLE
Fix index of cmp_map->log[key].

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1017,7 +1017,8 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
         MSG_ULIMIT_USAGE
         " /path/to/fuzzed_app )\n\n"
 
-        "      Tip: you can use https://jwilk.net/software/recidivm to quickly\n"
+        "      Tip: you can use https://jwilk.net/software/recidivm to "
+        "quickly\n"
         "      estimate the required amount of virtual memory for the "
         "binary.\n\n"
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -1669,7 +1669,7 @@ static u8 cmp_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u8 *cbuf,
     for (j = 0; j < i; ++j) {
 
       if (afl->shm.cmp_map->log[key][j].v0 == o->v0 &&
-          afl->shm.cmp_map->log[key][i].v1 == o->v1) {
+          afl->shm.cmp_map->log[key][j].v1 == o->v1) {
 
         goto cmp_fuzz_next_iter;
 


### PR DESCRIPTION

In my understanding, the index of log[key] should be j at src/afl-fuzz-redqueen.c:1672,  otherwise the condition at line 1672 will always be true.