### PR TITLE
Use FIFOs instead of hacky sleep code to pass messages in afl-plot

### DIFF
--- a/afl-plot
+++ b/afl-plot
@@ -196,14 +196,15 @@ exit 1
 fi
 
 mkdir -p "$outputdir/tmp"
+mkfifo "$outputdir/tmp/win_ids"
 afl-plot-ui > "$outputdir/tmp/win_ids" &
 
-sleep 0.5
+W_IDS=$(cat $outputdir/tmp/win_ids)
 
-W_ID1=$(cat $outputdir/tmp/win_ids | head -1)
-W_ID2=$(cat $outputdir/tmp/win_ids | head -2 | tail -1)
-W_ID3=$(cat $outputdir/tmp/win_ids | head -3 | tail -1)
-W_ID4=$(cat $outputdir/tmp/win_ids | tail -1)
+W_ID1=$(echo "$W_IDS" | head -1)
+W_ID2=$(echo "$W_IDS" | head -2 | tail -1)
+W_ID3=$(echo "$W_IDS" | head -3 | tail -1)
+W_ID4=$(echo "$W_IDS" | tail -1)
 
 echo "[*] Generating plots..."
 

--- a/afl-plot
+++ b/afl-plot
@@ -195,11 +195,17 @@ exit 1
 
 fi
 
-mkdir -p "$outputdir/tmp"
-mkfifo "$outputdir/tmp/win_ids"
-afl-plot-ui > "$outputdir/tmp/win_ids" &
+mkdir -p "$outputdir/.tmp"
+rm -f "$outputdir/.tmp/win_ids"
+mkfifo "$outputdir/.tmp/win_ids" || exit 1
 
-W_IDS=$(cat $outputdir/tmp/win_ids)
+afl-plot-ui > "$outputdir/.tmp/win_ids" &
+W_IDS=$(cat "$outputdir/.tmp/win_ids")
+
+rm -f "$outputdir/.tmp/win_ids"
+if [ -z "$(ls -A $outputdir/.tmp)" ]; then
+	rm -rf "$outputdir/.tmp"
+fi
 
 W_ID1=$(echo "$W_IDS" | head -1)
 W_ID2=$(echo "$W_IDS" | head -2 | tail -1)
@@ -265,12 +271,6 @@ _EOF_
 ) | gnuplot 2> /dev/null &
 
 sleep 1
-
-rm "$outputdir/tmp/win_ids"
-
-if [ -z "$(ls -A $outputdir/tmp)" ]; then
-	rm -r "$outputdir/tmp"
-fi
 
 else
 


### PR DESCRIPTION
FIFOs (named pipes) are more reliable and appropriate for the task of passing messages. We can also remove the sleep period and rely on the fact that `cat` will only end once the name pipe's stream is closed.