### PR TITLE
Add llvm 14 compat

### DIFF
--- a/instrumentation/afl-llvm-lto-instrumentation.so.cc
+++ b/instrumentation/afl-llvm-lto-instrumentation.so.cc
@@ -242,7 +242,11 @@ bool AFLLTOPass::runOnModule(Module &M) {
 
     // the instrument file list check
     AttributeList Attrs = F.getAttributes();
+#if LLVM_VERSION_MAJOR >= 14
+    if (Attrs.hasAttributeAtIndex(-1, StringRef("skipinstrument"))) {
+#else
     if (Attrs.hasAttribute(-1, StringRef("skipinstrument"))) {
+#endif
 
       if (debug)
         fprintf(stderr,

--- a/instrumentation/afl-llvm-lto-instrumentlist.so.cc
+++ b/instrumentation/afl-llvm-lto-instrumentlist.so.cc
@@ -118,8 +118,14 @@ bool AFLcheckIfInstrument::runOnModule(Module &M) {
       AttributeList Attrs = F.getAttributes();
       AttrBuilder   NewAttrs;
       NewAttrs.addAttribute("skipinstrument");
+#if LLVM_VERSION_MAJOR >= 14
+      F.setAttributes(
+          Attrs.addAttributesAtIndex(Ctx, AttributeList::FunctionIndex,
+                                     NewAttrs));
+#else
       F.setAttributes(
           Attrs.addAttributes(Ctx, AttributeList::FunctionIndex, NewAttrs));
+#endif
 
     }
 


### PR DESCRIPTION
add/hasAttribute(s) were renamed add/hasAttribute(s)AtIndex in llvm 14


Note I didn't actually get to test this yet and just fixed build error for now, but the comment string in the header is the same so these are most likely drop in replacements.
In particular I don't see `hasAttribute(-1, ...)` as -1 being a valid index meaning anywhere? So it might make sense to convert this one to hasAttrSomewhere if that's what was intended, but I honestly have no idea what any of this does so I'll leave that to you.