### PR TITLE
coresight_mode: Change to use https for submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/NixOS/patchelf.git
 [submodule "coresight_mode/coresight-trace"]
 	path = coresight_mode/coresight-trace
-	url = git@github.com:RICSecLab/coresight-trace.git
+	url = https://github.com/RICSecLab/coresight-trace.git


### PR DESCRIPTION
Regarding the git submodule URLs issue reported in https://github.com/AFLplusplus/AFLplusplus/pull/1156#issuecomment-974496817, this PR changes the URLs to use HTTPS instead of SSH.