### PR TITLE
Include cmake in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ env NO_ARCH_OPT 1
 RUN apt-get update && \
     apt-get -y install --no-install-suggests --no-install-recommends \
     automake \
+    cmake \
+    meson \
     ninja-build \
     bison flex \
     build-essential \


### PR DESCRIPTION
The README contains an examples how afl can be used with cmake, but
cmake is not included in the Dockerfile. Thus, when running afl using
docker, one cannot invoke cmake from within the container.

This commit adds cmake to the list of packages in the Dockerfile that
are installed when the docker image is generated.