### PR TITLE
Fix memory leak in libprotobuf-mutator-example

### DIFF
--- a/custom_mutators/libprotobuf-mutator-example/lpm_aflpp_custom_mutator_input.cc
+++ b/custom_mutators/libprotobuf-mutator-example/lpm_aflpp_custom_mutator_input.cc
@@ -99,10 +99,12 @@ extern "C" size_t afl_custom_fuzz(MyMutator *mutator, // return value from afl_c
     std::string s = ProtoToData(*p);
     // Copy to a new buffer ( mutated_out )
     size_t mutated_size = s.size() <= max_size ? s.size() : max_size; // check if raw data's size is larger than max_size
-    uint8_t *mutated_out = new uint8_t[mutated_size+1];
-    memcpy(mutated_out, s.c_str(), mutated_size); // copy the mutated data
+
+    delete mutator->mutated_out;
+    mutator->mutated_out = new uint8_t[mutated_size+1];
+    memcpy(mutator->mutated_out, s.c_str(), mutated_size); // copy the mutated data
     // Assign the mutated data and return mutated_size
-    *out_buf = mutated_out;
+    *out_buf = mutator->mutated_out;
     return mutated_size;
 }
 

--- a/custom_mutators/libprotobuf-mutator-example/lpm_aflpp_custom_mutator_input.h
+++ b/custom_mutators/libprotobuf-mutator-example/lpm_aflpp_custom_mutator_input.h
@@ -2,4 +2,6 @@
 #include "test.pb.h"
 
 class MyMutator : public protobuf_mutator::Mutator {
+public:
+    uint8_t *mutated_out = nullptr; 
 };


### PR DESCRIPTION
Since `afl_custom_fuzz` do not free the memory of `out_buf` , there maybe a memory leak in example code.