### PR TITLE
afl-cc: fix incorrect CLANGPP_BIN

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -395,7 +395,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
           snprintf(llvm_fullpath, sizeof(llvm_fullpath), "%s/clang",
                    LLVM_BINDIR);
         else
-          snprintf(llvm_fullpath, sizeof(llvm_fullpath), CLANGPP_BIN);
+          snprintf(llvm_fullpath, sizeof(llvm_fullpath), CLANG_BIN);
         alt_cc = llvm_fullpath;
 
       }


### PR DESCRIPTION
A minor bug slipped in on a probably not-often used path.

This caused CMake to complain that the c compiler was set to C++ mode,
causing the CMake configuration step to fail for all c targets.

aflplusplus was built with

```shell
make source-only -j8 LLVM_BINDIR="" AFL_REAL_LD=`which ld.lld`
```

(I'm setting LLVM_BINDIR to the empty string since it's making assumptions that don't hold on nixpkgs, and getting the binaries from PATH seems to work better).
