### PR TITLE
fix include to build on Mac

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -37,6 +37,7 @@
 
 #ifdef __APPLE__
   #include <sys/qos.h>
+  #include <pthread/qos.h>
 #endif
 
 #ifdef PROFILING


### PR DESCRIPTION
add an extra include for `<pthread/qos.h>` on Mac, which fixes include issue