### PR TITLE
Fix LeakSanitizer Usage.

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -105,7 +105,8 @@ fairly broad use of environment variables instead:
       within your program at a certain point (such as at the end of an
       `__AFL_LOOP()`), you can run the macro  `__AFL_LEAK_CHECK();` which will
       cause an abort if any memory is leaked (you can combine this with the
-      `LSAN_OPTIONS=...` suppression option to suppress some known leaks).
+      `__AFL_LSAN_OFF();` and `__AFL_LSAN_ON();` macros to avoid checking for
+      memory leaks from memory allocated between these two calls.
     - `AFL_USE_MSAN=1` - activates the memory sanitizer (uninitialized memory)
     - `AFL_USE_TSAN=1` - activates the thread sanitizer to find thread race
       conditions

--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -201,7 +201,10 @@ The following sanitizers have built-in support in AFL++:
   security issue, but for developers this can be very valuable. Note that unlike
   the other sanitizers above this needs `__AFL_LEAK_CHECK();` added to all areas
   of the target source code where you find a leak check necessary! Enabled with
-  `export AFL_USE_LSAN=1` before compiling.
+  `export AFL_USE_LSAN=1` before compiling. To ignore the memory-leaking check
+  for certain allocations, `__AFL_LSAN_OFF();` can be used before memory is 
+  allocated, and `__AFL_LSAN_OFF;` afterwards. Memory allocated between these
+  two macros will not be checked for memory leaks.
 
 It is possible to further modify the behavior of the sanitizers at run-time by
 setting `ASAN_OPTIONS=...`, `LSAN_OPTIONS` etc. - the available parameters can

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -878,7 +878,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
     cc_params[cc_par_cnt++] = "-includesanitizer/lsan_interface.h";
     cc_params[cc_par_cnt++] = "-D__AFL_LEAK_CHECK()={if(__lsan_do_recoverable_leak_check() > 0) _exit(23); }";
     cc_params[cc_par_cnt++] = "-D__AFL_LSAN_OFF()=__lsan_disable();";
-    cc_params[cc_par_cnt++] = "-D__AFL_LSAN_ON()=__lsan_disable();";
+    cc_params[cc_par_cnt++] = "-D__AFL_LSAN_ON()=__lsan_enable();";
 
 
   }

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -876,7 +876,10 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
     cc_params[cc_par_cnt++] = "-fsanitize=leak";
     cc_params[cc_par_cnt++] = "-includesanitizer/lsan_interface.h";
-    cc_params[cc_par_cnt++] = "-D__AFL_LEAK_CHECK()=__lsan_do_leak_check()";
+    cc_params[cc_par_cnt++] = "-D__AFL_LEAK_CHECK()={if(__lsan_do_recoverable_leak_check() > 0) _exit(23); }";
+    cc_params[cc_par_cnt++] = "-D__AFL_LSAN_OFF()=__lsan_disable();";
+    cc_params[cc_par_cnt++] = "-D__AFL_LSAN_ON()=__lsan_disable();";
+
 
   }
 


### PR DESCRIPTION
Previously, __lsan_do_leak_check() was run when using __AFL_LEAK_CHECK,
however this was the incorrect function to use. According to the
documentation: "Subsequent calls to this function will have no effect
and end-of-process leak check will not run".
This meant that if the memory did not leak on the first usage of
__AFL_LEAK_CHECK, subsquent calls to this macro would never do anything.

Likewise, it is not possible to use an LSAN suppression list with
symbolize=0, so instead __lsan_disable and __lsan_enable are used to
'ignore' certain memory allocations where needed.