### PR TITLE
Add missing backticks (`)

### DIFF
--- a/unicorn_mode/README.md
+++ b/unicorn_mode/README.md
@@ -96,9 +96,9 @@ As for the QEMU-based instrumentation, unicornafl comes with a sub-instruction b
 
 The options that enable Unicorn CompareCoverage are the same used for QEMU.
 This will split up each multi-byte compare to give feedback for each correct byte.
-AFL_COMPCOV_LEVEL=1 is to instrument comparisons with only immediate values.
+`AFL_COMPCOV_LEVEL=1` is to instrument comparisons with only immediate values.
 
-AFL_COMPCOV_LEVEL=2 instruments all comparison instructions.
+`AFL_COMPCOV_LEVEL=2` instruments all comparison instructions.
 
 Comparison instructions are currently instrumented only for the x86, x86_64 and ARM targets.
 

--- a/utils/libdislocator/README.md
+++ b/utils/libdislocator/README.md
@@ -27,9 +27,9 @@ heap-related security bugs in several ways:
     AFL_LD_HARD_FAIL).
 
   - Optionally, in platforms supporting it, huge pages can be used by passing
-    USEHUGEPAGE=1 to make.
+    `USEHUGEPAGE=1` to make.
 
-  - Size alignment to `max_align_t` can be enforced with AFL_ALIGNED_ALLOC=1. In
+  - Size alignment to `max_align_t` can be enforced with `AFL_ALIGNED_ALLOC=1`. In
     this case, a tail canary is inserted in the padding bytes at the end of the
     allocated zone. This reduce the ability of libdislocator to detect
     off-by-one bugs but also it make slibdislocator compliant to the C standard.

--- a/utils/libtokencap/README.md
+++ b/utils/libtokencap/README.md
@@ -31,7 +31,7 @@ require AFL-instrumented binaries to work.
 
 To use the library, you *need* to make sure that your fuzzing target is compiled
 with -fno-builtin and is linked dynamically. If you wish to automate the first
-part without mucking with CFLAGS in Makefiles, you can set AFL_NO_BUILTIN=1
+part without mucking with CFLAGS in Makefiles, you can set `AFL_NO_BUILTIN=1`
 when using afl-gcc. This setting specifically adds the following flags:
 
 ```


### PR DESCRIPTION
Some env variables missing ` around them.