### PR TITLE
Add tutorials to /docs/tutorials.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The following branches exist:
   stability
 * [dev](https://github.com/AFLplusplus/AFLplusplus/tree/dev): development state
   of AFL++ - bleeding edge and you might catch a checkout which does not compile
-  or has a bug. **We only accept PRs (push requests) for the 'dev' branch!**
+  or has a bug. **We only accept PRs (pull requests) for the 'dev' branch!**
 * (any other): experimental branches to work on specific features or testing new
   functionality or changes.
 
@@ -163,7 +163,7 @@ This can be your way to support and contribute to AFL++ - extend it to do
 something cool.
 
 For everyone who wants to contribute (and send pull requests), please read our
-[contributing guidelines](CONTRIBUTING.md) before your submit.
+[contributing guidelines](CONTRIBUTING.md) before you submit.
 
 ## Special thanks
 
@@ -223,7 +223,7 @@ Thank you! (For people sending pull requests - please add yourself to this list
     Josephine Calliotte                   Konrad Welc
     Thomas Rooijakkers                    David Carlier
     Ruben ten Hove                        Joey Jiao
-    fuzzah
+    fuzzah                                @intrigus-lgtm
   ```
 
 </details>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,10 +58,10 @@ If you find an interesting or important question missing, submit it via
 
   A program contains `functions`, `functions` contain the compiled machine code.
   The compiled machine code in a `function` can be in a single or many `basic
-  blocks`. A `basic block` is the largest possible number of subsequent machine
-  code instructions that has exactly one entry point (which can be be entered by
-  multiple other basic blocks) and runs linearly without branching or jumping to
-  other addresses (except at the end).
+  blocks`. A `basic block` is the **largest possible number of subsequent machine
+  code instructions** that has **exactly one entry point** (which can be be entered by
+  multiple other basic blocks) and runs linearly **without branching or jumping to
+  other addresses** (except at the end).
 
   ```
   function() {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -191,7 +191,7 @@ If you find an interesting or important question missing, submit it via
   AFL++ comes with several power schedules, initially ported from [AFLFast](https://github.com/mboehme/aflfast)
   however modified to be more effective and several more modes added.
 
-  The most effective modes are '-p fast` (default) and `-p explore`.
+  The most effective modes are `-p fast` (default) and `-p explore`.
 
   If you fuzz with several parallel afl-fuzz instances, then it is beneficial
   to assign a different schedule to each instance, however the majority should

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,7 +12,7 @@ docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus
 ```
 
 This image is automatically generated when a push to the stable repo happens.
-You will find your target source code in /src in the container.
+You will find your target source code in `/src` in the container.
 
 If you want to build AFL++ yourself, you have many options. The easiest choice
 is to build and install everything:
@@ -33,8 +33,8 @@ sudo make install
 It is recommended to install the newest available gcc, clang and llvm-dev
 possible in your distribution!
 
-Note that "make distrib" also builds FRIDA mode, QEMU mode, unicorn_mode
-and more. If you just want plain AFL++, then do "make all". If you want
+Note that `make distrib` also builds FRIDA mode, QEMU mode, unicorn_mode
+and more. If you just want plain AFL++, then do `make all`. If you want
 some assisting tooling compiled but are not interested in binary-only targets
 then instead choose:
 

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -116,7 +116,7 @@ allows you to define network state with different type of data packets.
 
 ### Improving stability
 
-For fuzzing a 100% stable target that covers all edges is the best case. A 90%
+For fuzzing, a 100% stable target that covers all edges is the best case. A 90%
 stable target that covers all edges is, however, better than a 100% stable
 target that ignores 10% of the edges.
 

--- a/docs/important_changes.md
+++ b/docs/important_changes.md
@@ -12,11 +12,11 @@ With AFL++ 4.00, we introduced the following changes from previous behaviors:
   * better naming for several fields in the UI
 
 With AFL++ 3.15, we introduced the following changes from previous behaviors:
-  * afl-cmin and afl-showmap -Ci now descent into subdirectories like afl-fuzz
+  * afl-cmin and afl-showmap -Ci now descend into subdirectories like afl-fuzz
     -i does (but note that afl-cmin.bash does not)
 
 With AFL++ 3.14, we introduced the following changes from previous behaviors:
-  * afl-fuzz: deterministic fuzzing it not a default for -M main anymore
+  * afl-fuzz: deterministic fuzzing is not a default for -M main anymore
   * afl-cmin/afl-showmap -i now descends into subdirectories (afl-cmin.bash,
     however, does not)
 
@@ -44,9 +44,9 @@ behaviors and defaults:
     * if neither -M or -S is specified, `-S default` is assumed, so more fuzzers
       can easily be added later
     * `-i` input directory option now descends into subdirectories. It also does
-      not fatal on crashes and too large files, instead it skips them and uses
+      not fail on crashes and too large files, instead it skips them and uses
       them for splicing mutations
-    * -m none is now default, set memory limits (in MB) with, e.g., -m 250
+    * -m none is now the default, set memory limits (in MB) with, e.g., -m 250
     * deterministic fuzzing is now disabled by default (unless using -M) and can
       be enabled with -D
     * a caching of test cases can now be performed and can be modified by

--- a/unicorn_mode/README.md
+++ b/unicorn_mode/README.md
@@ -96,9 +96,9 @@ As for the QEMU-based instrumentation, unicornafl comes with a sub-instruction b
 
 The options that enable Unicorn CompareCoverage are the same used for QEMU.
 This will split up each multi-byte compare to give feedback for each correct byte.
-AFL_COMPCOV_LEVEL=1 is to instrument comparisons with only immediate values.
+`AFL_COMPCOV_LEVEL=1` is to instrument comparisons with only immediate values.
 
-AFL_COMPCOV_LEVEL=2 instruments all comparison instructions.
+`AFL_COMPCOV_LEVEL=2` instruments all comparison instructions.
 
 Comparison instructions are currently instrumented only for the x86, x86_64 and ARM targets.
 

--- a/utils/libdislocator/README.md
+++ b/utils/libdislocator/README.md
@@ -27,9 +27,9 @@ heap-related security bugs in several ways:
     AFL_LD_HARD_FAIL).
 
   - Optionally, in platforms supporting it, huge pages can be used by passing
-    USEHUGEPAGE=1 to make.
+    `USEHUGEPAGE=1` to make.
 
-  - Size alignment to `max_align_t` can be enforced with AFL_ALIGNED_ALLOC=1. In
+  - Size alignment to `max_align_t` can be enforced with `AFL_ALIGNED_ALLOC=1`. In
     this case, a tail canary is inserted in the padding bytes at the end of the
     allocated zone. This reduce the ability of libdislocator to detect
     off-by-one bugs but also it make slibdislocator compliant to the C standard.

--- a/utils/libtokencap/README.md
+++ b/utils/libtokencap/README.md
@@ -31,7 +31,7 @@ require AFL-instrumented binaries to work.
 
 To use the library, you *need* to make sure that your fuzzing target is compiled
 with -fno-builtin and is linked dynamically. If you wish to automate the first
-part without mucking with CFLAGS in Makefiles, you can set AFL_NO_BUILTIN=1
+part without mucking with CFLAGS in Makefiles, you can set `AFL_NO_BUILTIN=1`
 when using afl-gcc. This setting specifically adds the following flags:
 
 ```


### PR DESCRIPTION
Found really interesting tutorial to be added:
https://i.blackhat.com/USA-19/Wednesday/us-19-Metzman-Going-Beyond-Coverage-Guided-Fuzzing-With-Structured-Fuzzing.pdf
https://blog.adacore.com/advanced-fuzz-testing-with-aflplusplus-3-00
https://www.youtube.com/playlist?list=PLa-iO6ehPFJiAJBW8AR8VWFPpGFYRvfeR - https://fuzzinglabs.com/blackbox-fuzzing-binary-fuzzing-afl-qemu/
https://airbus-cyber-security.com/fuzzing-exotic-arch-with-afl-using-ghidra-emulator/
https://bananamafia.dev/post/gb-fuzz/
https://www.ryanliptak.com/blog/fuzzing-zig-code/
https://fluidattacks.com/blog/fuzzing-sudo/
https://blog.karatos.in/a?ID=01650-357cd1ce-d8ef-4cf3-aef0-f8221f30ba25
https://mmmds.pl/cherokee-revisited-with-AFL/