### PR TITLE
Fix build for the LLVM pass for LLVM >= 13

### DIFF
--- a/instrumentation/compare-transform-pass.so.cc
+++ b/instrumentation/compare-transform-pass.so.cc
@@ -80,11 +80,13 @@ class CompareTransform : public ModulePass {
 
   }
 
+#if LLVM_MAJOR < 11
 #if LLVM_VERSION_MAJOR >= 4
   StringRef getPassName() const override {
 
 #else
   const char *getPassName() const override {
+#endif
 #endif
 
 #if LLVM_MAJOR >= 11                                /* use new pass manager */


### PR DESCRIPTION
Due to change of inheritance for more modern LLVM versions, the overridable
members are not the same.