### PR TITLE
Fix Shm trim bug and OOB accesses during Redqueen mutations.

### DIFF
--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2136,7 +2136,7 @@ static u8 rtn_extend_encoding(afl_state_t *afl, u8 entry,
 
       if ((i % 2)) {
 
-        if (len > idx + i && is_hex(orig_buf + idx + i)) {
+        if (len > idx + i + 1 && is_hex(orig_buf + idx + i)) {
 
           fromhex += 2;
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2323,7 +2323,7 @@ static u8 rtn_extend_encoding(afl_state_t *afl, u8 entry,
         if (unlikely(its_fuzz(afl, buf, len, status))) { return 1; }
         // fprintf(stderr, "RTN ATTEMPT fromhex %u result %u\n", fromhex,
         // *status);
-        memcpy(buf + idx + i, save + i, i + 1 + off);
+        memcpy(buf + idx, save, i + 1 + off);
 
       }
 

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -232,7 +232,7 @@ static void write_with_gap(afl_state_t *afl, u8 *mem, u32 len, u32 skip_at,
 
       memcpy(afl->fsrv.shmem_fuzz, mem, skip_at);
 
-      memcpy(afl->fsrv.shmem_fuzz, mem + skip_at + skip_len, tail_len);
+      memcpy(afl->fsrv.shmem_fuzz + skip_at, mem + skip_at + skip_len, tail_len);
 
     }
 


### PR DESCRIPTION
* In shared memory mode the trim stage would copy the second memory region on top of the first (instead of after it).


The OOB accesses were found after observing fuzzer crashes due to heap corruption:

* As part of `rtn_extend_encoding`, the call to `is_hex` can read one byte out of bounds. ASAN output:
```
READ of size 1 at 0x604000000231 thread T0
    #0 0x4cc593  (afl-fuzz+0x4cc593) # is_hex
    #1 0x4cb1b4  (afl-fuzz+0x4cb1b4) # rtn_extend_encoding @ if (len > idx + i && is_hex(orig_buf + idx + i))
    #2 0x4c9e26  (afl-fuzz+0x4c9e26)
    #3 0x4c53da  (afl-fuzz+0x4c53da)
    #4 0x4e99a1  (afl-fuzz+0x4e99a1)
    #5 0x5061fa  (afl-fuzz+0x5061fa)
    #6 0x51cfcd  (afl-fuzz+0x51cfcd)
```

The patch adjust the bounds check to ensure there are at least two bytes in bounds.

* The second bug is a `memcpy` where an incorrect offset is added to the destination address.

```
WRITE of size 16 at 0x616000004d8d thread T0
    #0 0x49423f  (afl-fuzz+0x49423f)  # memcpy
    #1 0x4cc19a  (afl-fuzz+0x4cc19a)  # rtn_extended_encoding @ memcpy(buf + idx + i, save + i, i + 1 + off)
    #2 0x4ca0f6  (afl-fuzz+0x4ca0f6)  # rtn_fuzz
    #3 0x4c53ce  (afl-fuzz+0x4c53ce)  # input_to_state_stage
    #4 0x4ea041  (afl-fuzz+0x4ea041)
    #5 0x5069aa  (afl-fuzz+0x5069aa)
    #6 0x51d87d  (afl-fuzz+0x51d87d)

0x616000004d8d is located 0 bytes to the right of 525-byte region [0x616000004b80,0x616000004d8d)
allocated by thread T0 here:
    #0 0x494d3d  (afl-fuzz+0x494d3d)
    #1 0x4c7602  (afl-fuzz+0x4c7602)
    #2 0x4c595e  (afl-fuzz+0x4c595e)  # input_to_state_stage @ afl->queue_cur->cmplog_colorinput = ck_alloc_nozero(len)
    #3 0x4ea041  (afl-fuzz+0x4ea041)
    #4 0x5069aa  (afl-fuzz+0x5069aa)
    #5 0x51d87d  (afl-fuzz+0x51d87d)
```

The intent appears to be to reset the mutated section back to the original section, so the patch does this.
