### PR TITLE
docs: Document linker scripts change required in some projects

### DIFF
--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -333,6 +333,24 @@ is a non-standard way to set this, otherwise set up the build normally and edit
 the generated build environment afterwards manually to point it to the right
 compiler (and/or `RANLIB` and `AR`).
 
+#### Linker scripts
+
+If the project uses linker scripts to hide the symbols exported by the
+binary, then you may see errors such as:
+
+```
+undefined symbol: __afl_area_ptr
+```
+
+The solution is to modify the linker script to add:
+
+```
+{
+  global:
+    __afl_*;
+}
+```
+
 ### f) Better instrumentation
 
 If you just fuzz a target program as-is, you are wasting a great opportunity for


### PR DESCRIPTION
AFL instrumentation modifies the binary to export extra symbols which
must be visible if the main binary dlopen()s an instrumented DLL.
This change was required by nbdkit since it uses a linker script to
limit the symbols exported from the main binary:

https://gitlab.com/nbdkit/nbdkit/-/commit/355cacb812126f5e37a2468f6939821b15017373

Signed-off-by: Richard W.M. Jones <rjones@redhat.com>