### PR TITLE
fix installation packages commands for debian 10

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,4 @@
-# Building and installing AFL++
+
 
 ## Linux on x86
 
@@ -16,11 +16,8 @@ This image is automatically generated when a push to the stable repo happens.
 You will find your target source code in `/src` in the container.
 
 If you want to build AFL++ yourself, you have many options. The easiest choice
-is to build and install everything.
+is to build and install everything:
 
-First install the required packages:
-
-On Debian 10: 
 ```shell
 sudo apt-get update
 sudo apt-get install -y build-essential python3-dev automake cmake git flex bison libglib2.0-dev libpixman-1-dev python3-setuptools
@@ -28,21 +25,6 @@ sudo apt-get install -y build-essential python3-dev automake cmake git flex biso
 sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang
 sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
 sudo apt-get install -y ninja-build # for QEMU mode
-```
-
-On other systems: 
-
-```shell
-sudo apt-get update
-sudo apt-get install -y build-essential python3-dev automake cmake git flex bison libglib2.0-dev libpixman-1-dev python3-setuptools
-# try to install llvm 11 and install the distro default if that fails
-sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang
-sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-dev
-sudo apt-get install -y ninja-build # for QEMU mode
-```
-
-Then install AFLplusplus:
-```shell
 git clone https://github.com/AFLplusplus/AFLplusplus
 cd AFLplusplus
 make distrib

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,7 +30,7 @@ sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //
 sudo apt-get install -y ninja-build # for QEMU mode
 ```
 
-On other distributions and versions of Debian: 
+On other systems: 
 
 ```shell
 sudo apt-get update

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,4 @@
-
+# Building and installing AFL++
 
 ## Linux on x86
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,7 +16,21 @@ This image is automatically generated when a push to the stable repo happens.
 You will find your target source code in `/src` in the container.
 
 If you want to build AFL++ yourself, you have many options. The easiest choice
-is to build and install everything:
+is to build and install everything.
+
+First install the required packages:
+
+On Debian 10: 
+```shell
+sudo apt-get update
+sudo apt-get install -y build-essential python3-dev automake cmake git flex bison libglib2.0-dev libpixman-1-dev python3-setuptools
+# try to install llvm 11 and install the distro default if that fails
+sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang
+sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+sudo apt-get install -y ninja-build # for QEMU mode
+```
+
+On other distributions and versions of Debian: 
 
 ```shell
 sudo apt-get update
@@ -25,6 +39,10 @@ sudo apt-get install -y build-essential python3-dev automake cmake git flex biso
 sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang
 sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-dev
 sudo apt-get install -y ninja-build # for QEMU mode
+```
+
+Then install AFLplusplus
+```shell
 git clone https://github.com/AFLplusplus/AFLplusplus
 cd AFLplusplus
 make distrib

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -41,7 +41,7 @@ sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//
 sudo apt-get install -y ninja-build # for QEMU mode
 ```
 
-Then install AFLplusplus
+Then install AFLplusplus:
 ```shell
 git clone https://github.com/AFLplusplus/AFLplusplus
 cd AFLplusplus


### PR DESCRIPTION
Hi !
I tried to install afl++ on a fresh install of debian 10 and the command listed in INSTALL.md to install gcc failed. I think it might be due to a change in the way gcc report its version number. So I just added a small section for Debian 10 to INSTALL.md so the instructions work. 
I know the documentation cannot reflect all the small differences accross all distributions so feel free to close the pull request if you think this fix is easy enough for users to figure out by themselves and not needing an edit to the installation instructions.
Thanks for reading and for maintaining afl++ !