### PR TITLE
[wontfix] make error @SIMPLE_FILES

### DIFF
--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -703,7 +703,7 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 #else
 
       snprintf(fn, PATH_MAX, "%s/crashes/id_%06llu_%02u", afl->out_dir,
-               afl->saved_crashes, afl->last_kill_signal);
+               afl->saved_crashes, afl->fsrv.last_kill_signal);
 
 #endif                                                    /* ^!SIMPLE_FILES */
 


### PR DESCRIPTION
Hi there!
I tried to compile with SIMPLE_FILES, but got  an error message.
Please have a look through it.
Sincerely.

```
src/afl-fuzz-bitmap.c: In function ‘save_if_interesting’:
src/afl-fuzz-bitmap.c:706:39: error: ‘afl_state_t’ {aka ‘struct afl_state’} has no member named ‘last_kill_signal’
  706 |                afl->saved_crashes, afl->last_kill_signal);
      |                                       ^~
make: *** [GNUmakefile:437: afl-fuzz] Error 1
```