### PR TITLE
Fix GCC plugin crash when using deny/allow list

### DIFF
--- a/instrumentation/afl-gcc-pass.so.cc
+++ b/instrumentation/afl-gcc-pass.so.cc
@@ -714,9 +714,11 @@ struct afl_pass : gimple_opt_pass {
 
   }
 
+  /* Returns the source file name attached to the function declaration F. If
+     there is no source location information, returns an empty string.  */
   std::string getSourceName(function *F) {
 
-    return DECL_SOURCE_FILE(F->decl);
+    return DECL_SOURCE_FILE(F->decl) ? DECL_SOURCE_FILE(F->decl) : "";
 
   }
 


### PR DESCRIPTION
The provided function declaration F may not have valid location
information. Return an empty string in this case as the two callers are
already using this convention to filter out functions from being
instrumented when deny/allow list are used.