### PR TITLE
instrumentation fixes for wasm

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1035,7 +1035,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   cc_params[cc_par_cnt++] =
       "-D__AFL_LOOP(_A)="
-      "({ static volatile char *_B __attribute__((used)); "
+      "({ static volatile char *_B __attribute__((used,unused)); "
       " _B = (char*)\"" PERSIST_SIG
       "\"; "
 #ifdef __APPLE__
@@ -1049,7 +1049,7 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   cc_params[cc_par_cnt++] =
       "-D__AFL_INIT()="
-      "do { static volatile char *_A __attribute__((used)); "
+      "do { static volatile char *_A __attribute__((used,unused)); "
       " _A = (char*)\"" DEFER_SIG
       "\"; "
 #ifdef __APPLE__


### PR DESCRIPTION
Something was missed across merges such that `afl-clang-fast` broke wasm. Use the passthrough flag instead so we really don't touch wasm.

Also fix `-Wunused-but-set-variable`. Attribute `used` is so `_B` isn't optimized out. `unused` is to avoid the warning.