### PR TITLE
afl->cmplog_binary memory leak problem

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -388,6 +388,8 @@ static inline const char *colorfilter(const char *x) {
                                                                               \
     } while (1);                                                              \
                                                                               \
+                                                                              \
+                                                                              \
   } while (0)
 
 #define ck_read(fd, buf, len, fn)                              \

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -592,6 +592,7 @@ void afl_state_deinit(afl_state_t *afl) {
   if (afl->sync_id) { ck_free(afl->out_dir); }
   if (afl->pass_stats) { ck_free(afl->pass_stats); }
   if (afl->orig_cmp_map) { ck_free(afl->orig_cmp_map); }
+  if (afl->cmplog_binary) { ck_free(afl->cmplog_binary); }
 
   afl_free(afl->queue_buf);
   afl_free(afl->out_buf);

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -107,7 +107,7 @@ void afl_shm_deinit(sharedmem_t *shm) {
     if (shm->cmp_map != NULL) {
 
       munmap(shm->cmp_map, shm->map_size);
-      shm->map = NULL;
+      shm->cmp_map = NULL;
 
     }
 


### PR DESCRIPTION
afl->cmplog_binary memory should be free when afl deinit to avoid memory leak.