### PR TITLE
Add AFL_SYNC_TIME variable for synchronization time tuning

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -517,6 +517,10 @@ checks or alter some of the more exotic semantics of the tool:
     (empty/non present) will add no tags to the metrics. For more information,
     see [rpc_statsd.md](rpc_statsd.md).
 
+  - `AFL_SYNC_TIME` allows you to specify a different minimal time (in minutes)
+    between fuzzing instances synchronization. Default sync time is 30 minutes,
+    note that time is halfed for -M main nodes.
+
   - Setting `AFL_TARGET_ENV` causes AFL++ to set extra environment variables for
     the target binary. Example: `AFL_TARGET_ENV="VAR1=1 VAR2='a b c'" afl-fuzz
     ... `. This exists mostly for things like `LD_LIBRARY_PATH` but it would

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -577,7 +577,8 @@ typedef struct afl_state {
       last_find_time,                   /* Time for most recent path (ms)   */
       last_crash_time,                  /* Time for most recent crash (ms)  */
       last_hang_time,                   /* Time for most recent hang (ms)   */
-      exit_on_time;                     /* Delay to exit if no new paths    */
+      exit_on_time,                     /* Delay to exit if no new paths    */
+      sync_time;                        /* Sync time (ms)                   */
 
   u32 slowest_exec_ms,                  /* Slowest testcase non hang in ms  */
       subseq_tmouts;                    /* Number of timeouts in a row      */

--- a/include/envs.h
+++ b/include/envs.h
@@ -206,6 +206,7 @@ static char *afl_environment_variables[] = {
     "AFL_STATSD_HOST",
     "AFL_STATSD_PORT",
     "AFL_STATSD_TAGS_FLAVOR",
+    "AFL_SYNC_TIME",
     "AFL_TESTCACHE_SIZE",
     "AFL_TESTCACHE_ENTRIES",
     "AFL_TMIN_EXACT",

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -524,12 +524,12 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
                               afl_environment_variable_len)) {
 
-            int stime = atoi((u8 *)get_afl_env(afl_environment_variables[i]));
-            if (stime > 0) {
-              afl->sync_time = stime * 60 * 1000;
+            int time = atoi((u8 *)get_afl_env(afl_environment_variables[i]));
+            if (time > 0) {
+                afl->sync_time = time * (60 * 1000LL);
             } else {
-                WARNF("incorrect value for AFL_SYNC_TIME environment variable, "
-                      "used default value %d instead.", afl->sync_time / 60 / 1000);
+              WARNF("incorrect value for AFL_SYNC_TIME environment variable, "
+                    "used default value %lld instead.", afl->sync_time / 60 / 1000);
             }
           }
 

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -101,6 +101,7 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->stats_update_freq = 1;
   afl->stats_avg_exec = 0;
   afl->skip_deterministic = 1;
+  afl->sync_time = SYNC_TIME;
   afl->cmplog_lvl = 2;
   afl->min_length = 1;
   afl->max_length = MAX_FILE;
@@ -519,6 +520,17 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
             }
 
+          } else if (!strncmp(env, "AFL_SYNC_TIME",
+
+                              afl_environment_variable_len)) {
+
+            int stime = atoi((u8 *)get_afl_env(afl_environment_variables[i]));
+            if (stime > 0) {
+              afl->sync_time = stime * 60 * 1000;
+            } else {
+                WARNF("incorrect value for AFL_SYNC_TIME environment variable, "
+                      "used default value %d instead.", afl->sync_time / 60 / 1000);
+            }
           }
 
         } else {

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -295,6 +295,7 @@ static void usage(u8 *argv0, int more_help) {
       "AFL_STATSD_TAGS_FLAVOR: set statsd tags format (default: disable tags)\n"
       "                        Supported formats are: 'dogstatsd', 'librato',\n"
       "                        'signalfx' and 'influxdb'\n"
+      "AFL_SYNC_TIME: sync time between fuzzing instances (in minutes)\n"
       "AFL_TESTCACHE_SIZE: use a cache for testcases, improves performance (in MB)\n"
       "AFL_TMPDIR: directory to use for input file generation (ramdisk recommended)\n"
       "AFL_EARLY_FORKSERVER: force an early forkserver in an afl-clang-fast/\n"
@@ -2511,7 +2512,7 @@ int main(int argc, char **argv_orig, char **envp) {
         if (unlikely(afl->is_main_node)) {
 
           if (unlikely(get_cur_time() >
-                       (SYNC_TIME >> 1) + afl->last_sync_time)) {
+                       (afl->sync_time >> 1) + afl->last_sync_time)) {
 
             if (!(sync_interval_cnt++ % (SYNC_INTERVAL / 3))) {
 
@@ -2523,7 +2524,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
         } else {
 
-          if (unlikely(get_cur_time() > SYNC_TIME + afl->last_sync_time)) {
+          if (unlikely(get_cur_time() > afl->sync_time + afl->last_sync_time)) {
 
             if (!(sync_interval_cnt++ % SYNC_INTERVAL)) { sync_fuzzers(afl); }
 


### PR DESCRIPTION
Hi!

I'm trying to combine AFL++ with symbolic engine for the sake of hybrid fuzzing. One of the metrics I track is imported path - number of generated inputs by symbolic engine that have proven to be useful for fuzzer. I found out that time of synchronization between fuzzing instances is set in `include/config.h` to 30 minutes by default. The value can be tuned only by re-compiling AFL++, so I decided it would be cool to make this parameter tweakable via environment variable.