### PR TITLE
require value in env variables

### DIFF
--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -1249,3 +1249,4 @@ s32 create_file(u8 *fn) {
   return fd;
 
 }
+

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -715,17 +715,23 @@ char *get_afl_env(char *env) {
 
   char *val;
 
-  if ((val = getenv(env)) != NULL) {
+  if ((val = getenv(env))) {
 
-    if (!be_quiet) {
+    if (*val) {
+      
+      if (!be_quiet) {
 
-      OKF("Loaded environment variable %s with value %s", env, val);
+        OKF("Loaded environment variable %s with value %s", env, val);
+
+      }
+
+      return val;
 
     }
 
   }
 
-  return val;
+  return NULL;
 
 }
 
@@ -1243,4 +1249,3 @@ s32 create_file(u8 *fn) {
   return fd;
 
 }
-

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -721,7 +721,7 @@ char *get_afl_env(char *env) {
       
       if (!be_quiet) {
 
-        OKF("Loaded environment variable %s with value %s", env, val);
+        OKF("Enabled environment variable %s with value %s", env, val);
 
       }
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -113,7 +113,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
   u8  lockfile[PATH_MAX] = "";
   s32 i;
 
-  if (afl->afl_env.afl_no_affinity && !afl->afl_env.afl_try_affinity) {
+  if (afl->afl_env.afl_no_affinity = 1 && afl->afl_env.afl_try_affinity != 1) {
 
     if (afl->cpu_to_bind != -1) {
 
@@ -130,7 +130,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
 
     if (!bind_cpu(afl, afl->cpu_to_bind)) {
 
-      if (afl->afl_env.afl_try_affinity) {
+      if (afl->afl_env.afl_try_affinity = 1) {
 
         WARNF(
             "Could not bind to requested CPU %d! Make sure you passed a valid "
@@ -2957,4 +2957,3 @@ void save_cmdline(afl_state_t *afl, u32 argc, char **argv) {
   *buf = 0;
 
 }
-

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -113,7 +113,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
   u8  lockfile[PATH_MAX] = "";
   s32 i;
 
-  if (afl->afl_env.afl_no_affinity = 1 && afl->afl_env.afl_try_affinity != 1) {
+  if (afl->afl_env.afl_no_affinity && !afl->afl_env.afl_try_affinity) {
 
     if (afl->cpu_to_bind != -1) {
 
@@ -130,7 +130,7 @@ void bind_to_free_cpu(afl_state_t *afl) {
 
     if (!bind_cpu(afl, afl->cpu_to_bind)) {
 
-      if (afl->afl_env.afl_try_affinity = 1) {
+      if (afl->afl_env.afl_try_affinity) {
 
         WARNF(
             "Could not bind to requested CPU %d! Make sure you passed a valid "
@@ -2957,3 +2957,4 @@ void save_cmdline(afl_state_t *afl, u32 argc, char **argv) {
   *buf = 0;
 
 }
+


### PR DESCRIPTION
This is a partial proposal for a change. Let me know what you think, and I'll add the changes listed below.

I came across this when trying to disable affinity in the container image, in which during the build `AFL_TRY_AFFINITY` is set to `1`. Setting that value to `0` or anything else doesn't do anything, as the code just checks if the variable exists (even when empty it'll return true).

The only way to unset it is using `unset AFL_TRY_AFFINITY` before `afl-fuzz`. A small thing to do, but not obvious, especially as the verbosity when starting is unclear, as it mentions the value but that value with booleans doesn't mean anything.  `[+] Loaded environment variable AFL_TRY_AFFINITY with value 0` still enables that function.

### TODO

- [ ] Have every boolean `afl->afl_env.*` check to be set to `1` else they should be false