### PR TITLE
Allow to skip README.txt creation in crashes/

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -619,6 +619,10 @@ The QEMU wrapper used to instrument binary-only code supports several settings:
     emulation" variables (e.g., `QEMU_STACK_SIZE`), but there should be no
     reason to touch them.
 
+  - Normally a `README.txt` is written to the `crashes/` directory when a first
+    crash is found. Setting `AFL_NO_CRASH_README` will prevent this. Useful when
+    counting crashes based on a file count in that directory.
+
 ## 7) Settings for afl-frida-trace
 
 The FRIDA wrapper used to instrument binary-only code supports many of the same

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1267,3 +1267,4 @@ void queue_testcase_store_mem(afl_state_t *afl, struct queue_entry *q, u8 *mem);
 #endif
 
 #endif
+

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -386,7 +386,7 @@ typedef struct afl_env_vars {
       afl_bench_until_crash, afl_debug_child, afl_autoresume, afl_cal_fast,
       afl_cycle_schedules, afl_expand_havoc, afl_statsd, afl_cmplog_only_new,
       afl_exit_on_seed_issues, afl_try_affinity, afl_ignore_problems,
-      afl_keep_timeouts, afl_pizza_mode;
+      afl_keep_timeouts, afl_pizza_mode, afl_no_crash_readme;
 
   u8 *afl_tmpdir, *afl_custom_mutator_library, *afl_python_module, *afl_path,
       *afl_hang_tmout, *afl_forksrv_init_tmout, *afl_preload,
@@ -1267,4 +1267,3 @@ void queue_testcase_store_mem(afl_state_t *afl, struct queue_entry *q, u8 *mem);
 #endif
 
 #endif
-

--- a/include/envs.h
+++ b/include/envs.h
@@ -159,6 +159,7 @@ static char *afl_environment_variables[] = {
     "AFL_NO_COLOUR",
 #endif
     "AFL_NO_CPU_RED",
+    "AFL_NO_CRASH_README",
     "AFL_NO_FORKSRV",
     "AFL_NO_UI",
     "AFL_NO_PYTHON",
@@ -234,4 +235,3 @@ static char *afl_environment_variables[] = {
 extern char *afl_environment_variables[];
 
 #endif
-

--- a/include/envs.h
+++ b/include/envs.h
@@ -235,3 +235,4 @@ static char *afl_environment_variables[] = {
 extern char *afl_environment_variables[];
 
 #endif
+

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -720,7 +720,7 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
       }
 
-      if (unlikely(!afl->saved_crashes)) { write_crash_readme(afl); }
+      if (unlikely(!afl->saved_crashes) && (afl->afl_env.afl_no_crash_readme != 1)) { write_crash_readme(afl); }
 
 #ifndef SIMPLE_FILES
 
@@ -821,4 +821,3 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
   return keeping;
 
 }
-

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -720,7 +720,12 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
       }
 
-      if (unlikely(!afl->saved_crashes) && (afl->afl_env.afl_no_crash_readme != 1)) { write_crash_readme(afl); }
+      if (unlikely(!afl->saved_crashes) &&
+          (afl->afl_env.afl_no_crash_readme != 1)) {
+
+        write_crash_readme(afl);
+
+      }
 
 #ifndef SIMPLE_FILES
 
@@ -821,3 +826,4 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
   return keeping;
 
 }
+

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -510,6 +510,14 @@ void read_afl_environment(afl_state_t *afl, char **envp) {
 
             afl->afl_env.afl_pizza_mode =
                 atoi((u8 *)get_afl_env(afl_environment_variables[i]));
+
+          } else if (!strncmp(env, "AFL_NO_CRASH_README",
+
+                              afl_environment_variable_len)) {
+
+            afl->afl_env.afl_no_crash_readme =
+                atoi((u8 *)get_afl_env(afl_environment_variables[i]));
+
             if (afl->afl_env.afl_pizza_mode == 0) {
 
               afl->afl_env.afl_pizza_mode = 1;
@@ -665,4 +673,3 @@ void afl_states_request_skip(void) {
   LIST_FOREACH(&afl_states, afl_state_t, { el->skip_requested = 1; });
 
 }
-

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -673,3 +673,4 @@ void afl_states_request_skip(void) {
   LIST_FOREACH(&afl_states, afl_state_t, { el->skip_requested = 1; });
 
 }
+


### PR DESCRIPTION
When automating processing of crash results, the README.txt is always an oddity to skip (for example, a similar file doesn't appear in any other directory which has significant meaning, such as `hangs` or `queue`).

This env variable allows the user to skip the creation of that file if so desired.
