### PR TITLE
Push both stable and dev

### DIFF
--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -2,7 +2,9 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: [ stable ]
+    branches:
+    - stable
+    - dev
 #    paths:
 #    - Dockerfile
 
@@ -21,10 +23,18 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Publish aflpp to Registry
+    - name: Publish aflpp ${{ github.ref }} to Registry
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: aflplusplus/aflplusplus:${{ github.ref }}
+    - name: Publish aflpp dev as latest to Registry
       uses: docker/build-push-action@v2
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
         tags: aflplusplus/aflplusplus:latest
+      if: "${{ github.ref }}" == "dev"

--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -5,8 +5,6 @@ on:
     branches:
     - stable
     - dev
-#    paths:
-#    - Dockerfile
 
 jobs:
   push_to_registry:
@@ -30,11 +28,12 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: aflplusplus/aflplusplus:${{ github.ref }}
+      if: "${{ github.ref }}" == "dev"
     - name: Publish aflpp dev as latest to Registry
       uses: docker/build-push-action@v2
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: aflplusplus/aflplusplus:latest
-      if: "${{ github.ref }}" == "dev"
+        tags: aflplusplus/aflplusplus:${{ github.ref }},aflplusplus/aflplusplus:latest
+      if: "${{ github.ref }}" == "stable"

--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -29,7 +29,7 @@ jobs:
         push: true
         tags: aflplusplus/aflplusplus:${{ github.ref }}
       if: "${{ github.ref }}" == "dev"
-    - name: Publish aflpp dev as latest to Registry
+    - name: Publish aflpp ${{ github.ref }} and latest to Registry
       uses: docker/build-push-action@v2
       with:
         context: .


### PR DESCRIPTION
Preferring Docker to try out AFL++, I'd like to also be able to run the dev branch easily.

It also makes more sense to have `dev` as the `latest`, and have a `stable` tag for those wanting, well... stable.
I'd understand if you'd disagree, and I would be fine with that too.

Furthermore, having no experience with github actions, please verify if these jobs are set correctly :sweat_smile: 