### PR TITLE
fixes github actions

### DIFF
--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - stable
       - dev
+    tags:
+      - '*'
 
 jobs:
   push_to_registry:
@@ -37,3 +39,11 @@ jobs:
           push: true
           tags: aflplusplus/aflplusplus:${{ github.ref_name }},aflplusplus/aflplusplus:latest
         if: ${{ github.ref_name == 'stable' }}
+      - name: Publish tagged release to docker.io registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: aflplusplus/aflplusplus:${{ github.ref_name }}
+        if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build_aflplusplus_docker.yaml
+++ b/.github/workflows/build_aflplusplus_docker.yaml
@@ -3,37 +3,37 @@ name: Publish Docker Images
 on:
   push:
     branches:
-    - stable
-    - dev
+      - stable
+      - dev
 
 jobs:
   push_to_registry:
     name: Push Docker images to Dockerhub
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to Dockerhub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Publish aflpp ${{ github.ref }} to Registry
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: aflplusplus/aflplusplus:${{ github.ref }}
-      if: "${{ github.ref }}" == "dev"
-    - name: Publish aflpp ${{ github.ref }} and latest to Registry
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: aflplusplus/aflplusplus:${{ github.ref }},aflplusplus/aflplusplus:latest
-      if: "${{ github.ref }}" == "stable"
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Publish dev as dev to docker.io registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: aflplusplus/aflplusplus:${{ github.ref_name }}
+        if: ${{ github.ref_name == 'dev' }}
+      - name: Publish stable as stable and latest to docker.io registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: aflplusplus/aflplusplus:${{ github.ref_name }},aflplusplus/aflplusplus:latest
+        if: ${{ github.ref_name == 'stable' }}

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Here is some information to get you started:
 ## Building and installing AFL++
 
 To have AFL++ easily available with everything compiled, pull the image directly
-from the Docker Hub (available for x86_64 and arm64):
+from the Docker Hub (available for both x86_64 and arm64):
 
 ```shell
-docker pull aflplusplus/aflplusplus
-docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus
+docker pull aflplusplus/aflplusplus:stable
+docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus:stable
 ```
 
-This image is automatically generated when a push to the stable repo happens
+This image is automatically published when a push to the stable branch happens
 (see [branches](#branches)). If you use the command above, you will find your
 target source code in `/src` in the container.
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ To have AFL++ easily available with everything compiled, pull the image directly
 from the Docker Hub (available for both x86_64 and arm64):
 
 ```shell
-docker pull aflplusplus/aflplusplus:stable
-docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus:stable
+docker pull docker.io/aflplusplus/aflplusplus:stable
+docker run -ti -v /location/of/your/target:/src docker.io/aflplusplus/aflplusplus:stable
 ```
 
 This image is automatically published when a push to the stable branch happens

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,8 +8,8 @@ hence afl-clang-lto is available) or just pull directly from the Docker Hub
 (for x86_64 and arm64):
 
 ```shell
-docker pull aflplusplus/aflplusplus
-docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus
+docker pull aflplusplus/aflplusplus:stable
+docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus:stable
 ```
 
 This image is automatically generated when a push to the stable repo happens.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,8 +8,8 @@ hence afl-clang-lto is available) or just pull directly from the Docker Hub
 (for x86_64 and arm64):
 
 ```shell
-docker pull aflplusplus/aflplusplus:stable
-docker run -ti -v /location/of/your/target:/src aflplusplus/aflplusplus:stable
+docker pull docker.io/aflplusplus/aflplusplus:stable
+docker run -ti -v /location/of/your/target:/src docker.io/aflplusplus/aflplusplus:stable
 ```
 
 This image is automatically generated when a push to the stable repo happens.

--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -47,7 +47,7 @@ tasks, fuzzing may put a strain on your hardware and on the OS. In particular:
   example, the following line will run a Docker container with all this preset:
 
   ```shell
-  # docker run -ti --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk aflplusplus/aflplusplus:stable
+  # docker run -ti --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk docker.io/aflplusplus/aflplusplus:stable
   ```
 
 ## 1. Instrumenting the target

--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -47,7 +47,7 @@ tasks, fuzzing may put a strain on your hardware and on the OS. In particular:
   example, the following line will run a Docker container with all this preset:
 
   ```shell
-  # docker run -ti --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk aflplusplus/aflplusplus
+  # docker run -ti --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk aflplusplus/aflplusplus:stable
   ```
 
 ## 1. Instrumenting the target


### PR DESCRIPTION
This fixes the problem introduced by #1442 . Also updated the workflow versions.

I've also made the `:stable` tag explicit everywhere. That should make it more clear for every user what they're pulling. Also follows the recommendation that you should always use a tagged image. `:latest` still points to stable, so nothing changes for existing users.

So to keep with that idea, I've also added a push for tagged releases, so things like `aflplusplus/aflplusplus:4.00d` will work in the future.

Finally, as now everyone is hosting a registry, and some container daemons decided to not enforce `docker.io` as the default anymore, I've made them all fully qualified, i.e.: `docker.io/aflplusplus/aflplusplus:stable`.

WDYT ?