### PR TITLE
Update workflows to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1

--- a/.github/workflows/rust_custom_mutator.yml
+++ b/.github/workflows/rust_custom_mutator.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: custom_mutators/rust
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust Toolchain


### PR DESCRIPTION
22.04 is the most recent LTS release and the official docker container
is running on it. It probably makes sense to run the unit tests on that
as well.