### PR TITLE
Python mutators: Gracious error handling for illegal return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ utils/persistent_mode/persistent_demo_new
 utils/persistent_mode/test-instr
 !coresight_mode
 !coresight_mode/coresight-trace
+vuln_prog

--- a/custom_mutators/examples/example.py
+++ b/custom_mutators/examples/example.py
@@ -60,7 +60,7 @@ def fuzz(buf, add_buf, max_size):
 
     ret[:3] = random.choice(COMMANDS)
 
-    return ''
+    return ret
 
 
 # Uncomment and implement the following methods if you want to use a custom

--- a/custom_mutators/examples/example.py
+++ b/custom_mutators/examples/example.py
@@ -60,7 +60,7 @@ def fuzz(buf, add_buf, max_size):
 
     ret[:3] = random.choice(COMMANDS)
 
-    return ret
+    return ''
 
 
 # Uncomment and implement the following methods if you want to use a custom

--- a/src/afl-fuzz-python.c
+++ b/src/afl-fuzz-python.c
@@ -29,24 +29,33 @@
 #ifdef USE_PYTHON
 
 // Tries to cast a python bytearray or bytes to a char ptr
-static inline bool py_bytes(PyObject *py_value, /* out */ char **bytes, /* out */ size_t *size) {
-  if (!py_value) {
-    return false;
-  }
+static inline bool py_bytes(PyObject *py_value, /* out */ char **bytes,
+                            /* out */ size_t *size) {
+
+  if (!py_value) { return false; }
 
   *bytes = PyByteArray_AsString(py_value);
   if (*bytes) {
+
     // we got a bytearray
     *size = PyByteArray_Size(py_value);
+
   } else {
+
     *bytes = PyBytes_AsString(py_value);
     if (!*bytes) {
+
       // No valid type returned.
       return false;
+
     }
+
     *size = PyBytes_Size(py_value);
+
   }
+
   return true;
+
 }
 
 static void *unsupported(afl_state_t *afl, unsigned int seed) {
@@ -116,7 +125,9 @@ static size_t fuzz_py(void *py_mutator, u8 *buf, size_t buf_size, u8 **out_buf,
 
     char *bytes;
     if (!py_bytes(py_value, &bytes, &mutated_size)) {
+
       FATAL("Python mutator fuzz() should return a bytearray or bytes");
+
     }
 
     if (mutated_size) {
@@ -665,14 +676,19 @@ size_t trim_py(void *py_mutator, u8 **out_buf) {
 
     char *bytes;
     if (!py_bytes(py_value, &bytes, &trimmed_size)) {
+
       FATAL("Python mutator fuzz() should return a bytearray");
+
     }
 
     if (trimmed_size) {
+
       *out_buf = afl_realloc(BUF_PARAMS(trim), trimmed_size);
       if (unlikely(!*out_buf)) { PFATAL("alloc"); }
       memcpy(*out_buf, bytes, trimmed_size);
+
     }
+
     Py_DECREF(py_value);
 
   } else {
@@ -729,7 +745,9 @@ size_t havoc_mutation_py(void *py_mutator, u8 *buf, size_t buf_size,
 
     char *bytes;
     if (!py_bytes(py_value, &bytes, &mutated_size)) {
+
       FATAL("Python mutator fuzz() should return a bytearray");
+
     }
 
     if (mutated_size <= buf_size) {
@@ -799,11 +817,16 @@ const char *introspection_py(void *py_mutator) {
 
   } else {
 
-    char *ret;
+    char * ret;
     size_t len;
     if (!py_bytes(py_value, &ret, &len)) {
-      FATAL("Python mutator introspection call returned illegal type (expected bytes or bytearray)");
+
+      FATAL(
+          "Python mutator introspection call returned illegal type (expected "
+          "bytes or bytearray)");
+
     }
+
     return ret;
 
   }


### PR DESCRIPTION
This fixed bug 2 in #1458 - when instead of a `bytearray`, the returned null pointer would be subsequently dereferenced.
Insetad, `afl-fuzz` will now crash with a meaningful error. 
Additonally, this PR allows `bytes`, on top of `bytearray`. utf8-strings, as used in  #1458 are still not supported (with good reason)