### PR TITLE
feat: show bound cpu

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -146,6 +146,10 @@ void bind_to_free_cpu(afl_state_t *afl) {
 
       }
 
+    } else {
+
+      OKF("CPU binding request using -b %d successful.", afl->cpu_to_bind);
+
     }
 
     return;


### PR DESCRIPTION
When using variables setting the CPU binding, it's not always trivial to display that value, and this seems like the right place to debug this flag.