### PR TITLE
Change map size dummy value.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -57,7 +57,7 @@ typedef uint128_t         u128;
 #define FS_OPT_SHDMEM_FUZZ 0x01000000
 #define FS_OPT_NEWCMPLOG 0x02000000
 #define FS_OPT_OLD_AFLPP_WORKAROUND 0x0f000000
-// FS_OPT_MAX_MAPSIZE is 8388608 = 0x800000 = 2^23 = 1 << 22
+// FS_OPT_MAX_MAPSIZE is 8388608 = 0x800000 = 2^23 = 1 << 23
 #define FS_OPT_MAX_MAPSIZE ((0x00fffffeU >> 1) + 1)
 #define FS_OPT_GET_MAPSIZE(x) (((x & 0x00fffffe) >> 1) + 1)
 #define FS_OPT_SET_MAPSIZE(x) \

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1240,7 +1240,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
     u32 save_be_quiet = be_quiet;
     be_quiet = !debug;
-    fsrv->map_size = 4194304;  // dummy temporary value
+    fsrv->map_size = FS_OPT_MAX_MAPSIZE;  // dummy temporary value
     u32 new_map_size =
         afl_fsrv_get_mapsize(fsrv, use_argv, &stop_soon,
                              (get_afl_env("AFL_DEBUG_CHILD") ||

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1240,7 +1240,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
     u32 save_be_quiet = be_quiet;
     be_quiet = !debug;
-    fsrv->map_size = FS_OPT_MAX_MAPSIZE;  // dummy temporary value
+    if (map_size > 4194304) {
+        fsrv->map_size = map_size;
+    }
+    else {
+        fsrv->map_size = 4194304; // dummy temporary value
+    }
     u32 new_map_size =
         afl_fsrv_get_mapsize(fsrv, use_argv, &stop_soon,
                              (get_afl_env("AFL_DEBUG_CHILD") ||


### PR DESCRIPTION
Hi! We've been using afl-showmap and faced the following problem, while fuzzing very large target. Map size of target we've been fuzzing was 6927891 and we set corresponding env variable AFL_MAP_SIZE=6927891. 

But in https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-showmap.c#L1243 fsrv->map_size is temporarilly set to hardcoded dummy value 4194304. After that afl_fsrv_get_mapsize is called, where  afl_fsrv_start is called. Theт, in afl_fsrv_start in https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-forkserver.c#L897 we get tmp_map_size, which is 6927891 as well, and tmp_map_size is limited from above with FS_OPT_MAX_MAPSIZE (2^23 == 1 << 23 == 8388608). But fsrv->map_size equals to 1 << 22 and less than tmp_map_size, so we got following error message:

    [-] PROGRAM ABORT : Target's coverage map size of 6927936 is larger than the one this afl++ is set with (4194304). Either set AFL_MAP_SIZE=6927936 and restart  afl-fuzz, or change MAP_SIZE_POW2 in config.h and recompile afl-fuzz
         Location : afl_fsrv_start(), src/afl-forkserver.c:912

To fix this error, we suggest to set dummy value according to FS_OPT_MAX_MAPSIZE. Also, we've fixed the incorrect comment in `include/types.h`.

Also, we have a question, why in `afl-common.c` map size is limited above with 2^29? https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-common.c#L1205

Maybe it makes sense to limit there also with 2^23, because forkserver anyway will limit it stronger by itself.