### PR TITLE
Always use shared memory in persistent mode, when possible

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,9 +5,12 @@
 
 
 ### Version ++4.04a (dev)
-  - fix gramatron and grammar_mutatur build scripts
+  - fix gramatron and grammar_mutator build scripts
   - afl-cc:
     - make gcc_mode (afl-gcc-fast) work with gcc down to version 3.6
+  - llvm-mode:
+    - AFL runtime will always pass inputs via shared memory, when possible,
+      ignoring the command line.
 
 
 ### Version ++4.03c (release)

--- a/dynamic_list.txt
+++ b/dynamic_list.txt
@@ -27,7 +27,6 @@
   "__afl_selective_coverage";
   "__afl_selective_coverage_start_off";
   "__afl_selective_coverage_temp";
-  "__afl_sharedmem_fuzzing";
   "__afl_trace";
   "__cmplog_ins_hook1";
   "__cmplog_ins_hook16";

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1097,7 +1097,6 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   cc_params[cc_par_cnt++] =
       "-D__AFL_FUZZ_INIT()="
-      "int __afl_sharedmem_fuzzing = 1;"
       "extern unsigned int *__afl_fuzz_len;"
       "extern unsigned char *__afl_fuzz_ptr;"
       "unsigned char __afl_fuzz_alt[1048576];"

--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -57,7 +57,6 @@ $AFL_HOME/afl-fuzz -i IN -o OUT ./a.out
   #include "hash.h"
 #endif
 
-int                   __afl_sharedmem_fuzzing = 1;
 extern unsigned int  *__afl_fuzz_len;
 extern unsigned char *__afl_fuzz_ptr;
 
@@ -68,7 +67,7 @@ __attribute__((weak)) int LLVMFuzzerInitialize(int *argc, char ***argv);
 int                       LLVMFuzzerRunDriver(int *argc, char ***argv,
                                               int (*callback)(const uint8_t *data, size_t size));
 
-// Default nop ASan hooks for manual posisoning when not linking the ASan
+// Default nop ASan hooks for manual poisoning when not linking the ASan
 // runtime
 // https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning
 __attribute__((weak)) void __asan_poison_memory_region(
@@ -312,7 +311,6 @@ int LLVMFuzzerRunDriver(int *argcp, char ***argvp,
 
   if (argc == 2 && !strcmp(argv[1], "-")) {
 
-    __afl_sharedmem_fuzzing = 0;
     __afl_manual_init();
     return ExecuteFilesOnyByOne(argc, argv, callback);
 
@@ -325,8 +323,6 @@ int LLVMFuzzerRunDriver(int *argcp, char ***argvp,
     printf("WARNING: using the deprecated call style `%s %d`\n", argv[0], N);
 
   } else if (argc > 1) {
-
-    __afl_sharedmem_fuzzing = 0;
 
     if (argc == 2) { __afl_manual_init(); }
 


### PR DESCRIPTION
With this PR, the input will always be delivered via shared memory, if it's available.