### PR TITLE
fix Rust speedtest example dependency

### DIFF
--- a/unicorn_mode/samples/speedtest/rust/Cargo.toml
+++ b/unicorn_mode/samples/speedtest/rust/Cargo.toml
@@ -11,5 +11,5 @@ panic = "abort"
 
 [dependencies]
 unicornafl = { path = "../../../unicornafl/bindings/rust/", version="1.0.0" }
-capstone="0.10.0"
+capstone="0.11.0"
 libc="0.2.66"


### PR DESCRIPTION
Hi, the Rust capstone dependency was updated on the unicornafl side but not on the AFL++-rust-speedtest side preventing it from compiling.