### PR TITLE
Support building LTO on Gentoo

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -214,6 +214,17 @@ ifeq "$(LLVM_LTO)" "1"
     ifeq "$(AFL_REAL_LD)" ""
       ifneq "$(shell readlink $(LLVM_BINDIR)/ld.lld 2>&1)" ""
         AFL_REAL_LD = $(LLVM_BINDIR)/ld.lld
+      else ifneq "$(shell command -v ld.lld 2>/dev/null)" ""
+        AFL_REAL_LD = $(shell command -v ld.lld)
+        TMP_LDLDD_VERSION = $(shell $(AFL_REAL_LD) --version | awk '{ print $$2 }')
+        ifeq "$(LLVMVER)" "$(TMP_LDLDD_VERSION)"
+          $(warning ld.lld found in a weird location ($(AFL_REAL_LD)), but its the same version as LLVM so we will allow it)
+        else
+          $(warning ld.lld found in a weird location ($(AFL_REAL_LD)) and its of a different version than LLMV ($(TMP_LDLDD_VERSION) vs. $(LLVMVER)) - cannot enable LTO mode)
+          AFL_REAL_LD=
+          LLVM_LTO = 0
+        endif
+        undefine TMP_LDLDD_VERSION
       else
         $(warning ld.lld not found, cannot enable LTO mode)
         LLVM_LTO = 0
@@ -229,7 +240,7 @@ AFL_CLANG_FUSELD=
 ifeq "$(LLVM_LTO)" "1"
   ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=`command -v ld` -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
     AFL_CLANG_FUSELD=1
-    ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=ld.lld --ld-path=$(LLVM_BINDIR)/ld.lld -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
+    ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=ld.lld --ld-path=$(AFL_REAL_LD) -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
       AFL_CLANG_LDPATH=1
     endif
   else


### PR DESCRIPTION
Running `make all` on Gentoo with LLVM, ld.ldd and LLVMgold installed through the package manager doesn't result in an LTO version. The makefile expects `ld.ldd` to be inside `$LLVM_BINDIR` which isn't the case for me. 

I don't know if my solution is appropriate but it does make everything work on my system so hence this PR. I'm happy to make further changes if needed.

Before this patch:
```
make[1]: Entering directory '/home/quinox/.cache/tmp/AFLplusplus'
[+] llvm_mode detected llvm 10+, enabling neverZero implementation and c++14
[+] llvm_mode detected llvm 11+, enabling afl-lto LTO implementation
GNUmakefile.llvm:218: ld.lld not found, cannot enable LTO mode
[+] shmat seems to be working.
...
Build Summary:
[+] afl-fuzz and supporting tools successfully built
[+] LLVM basic mode successfully built
[+] LLVM mode successfully built
[-] LLVM LTO mode could not be build, it is optional, if you want it, please install LLVM 11-14. More information at instrumentation/README.lto.md on how to build it
[+] gcc_mode successfully built
```

After this patch:
```
make[1]: Entering directory '/home/quinox/.cache/tmp/AFLplusplus'
[+] llvm_mode detected llvm 10+, enabling neverZero implementation and c++14
[+] llvm_mode detected llvm 11+, enabling afl-lto LTO implementation
GNUmakefile.llvm:219: ld.ldd found in a weird location (/usr/bin/ld.lld), you better know what you're doing
[+] shmat seems to be working.
...
Build Summary:
[+] afl-fuzz and supporting tools successfully built
[+] LLVM basic mode successfully built
[+] LLVM mode successfully built
[+] LLVM LTO mode successfully built
[+] gcc_mode successfully built
```




---

Information from my package manger:

ld.lld:
```
quinox@gofu ~> emerge --search '^lld$'

[ Results for search key : ^lld$ ]
Searching...

*  sys-devel/lld
      Latest version available: 14.0.6
      Latest version installed: 14.0.6
      Size of files: 103.143 KiB
      Homepage:      https://llvm.org/
      Description:   The LLVM linker (link editor)
      License:       Apache-2.0-with-LLVM-exceptions UoI-NCSA

[ Applications found : 1 ]

quinox@gofu ~> equery files lld | grep 'ld\.lld'
/usr/bin/ld.lld

quinox@gofu ~> /usr/bin/ld.lld --version
LLD 14.0.6 (compatible with GNU linkers)
```

LLVM:
```
quinox@gofu ~> emerge --search '^llvm$'

[ Results for search key : ^llvm$ ]
Searching...

*  sys-devel/llvm
      Latest version available: 14.0.6-r2
      Latest version installed: 14.0.6-r2
      Size of files: 103.372 KiB
      Homepage:      https://llvm.org/
      Description:   Low Level Virtual Machine
      License:       Apache-2.0-with-LLVM-exceptions UoI-NCSA BSD public-domain rc

[ Applications found : 1 ]

quinox@gofu ~> equery files llvm | grep llvm-config
/usr/lib/llvm/14/bin/llvm-config
/usr/lib/llvm/14/bin/x86_64-pc-linux-gnu-llvm-config
/usr/lib/llvm/14/include/llvm/Config/llvm-config.h
/usr/lib/llvm/14/include/x86_64-pc-linux-gnu/llvm/Config/llvm-config.h
/usr/lib/llvm/14/share/man/man1/llvm-config.1.bz2

quinox@gofu ~> /usr/lib/llvm/14/bin/llvm-config --bindir
/usr/lib/llvm/14/bin

quinox@gofu ~> ls -al /usr/lib/llvm/14/bin/ld.lld
ls: cannot access '/usr/lib/llvm/14/bin/ld.lld': No such file or directory
```