### PR TITLE
Fix exit_on_time.

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -1410,12 +1410,13 @@ void show_stats_pizza(afl_state_t *afl) {
 
   /* AFL_EXIT_ON_TIME. */
 
-  if (unlikely(afl->last_find_time && !afl->non_instrumented_mode &&
-               afl->afl_env.afl_exit_on_time &&
-               (cur_ms - afl->last_find_time) > afl->exit_on_time)) {
+  /* If no coverage was found yet, check whether run time is greater than exit_on_time. */
 
+  if (unlikely(!afl->non_instrumented_mode && afl->afl_env.afl_exit_on_time &&
+	       (afl->last_find_time && (cur_ms - afl->last_find_time) > afl->exit_on_time ||
+		!afl->last_find_time &&
+		(afl->prev_run_time + cur_ms - afl->start_time) > afl->exit_on_time))) {
     afl->stop_soon = 2;
-
   }
 
   if (unlikely(afl->total_crashes && afl->afl_env.afl_bench_until_crash)) {


### PR DESCRIPTION
Hi! We've found the bug, that if no coverage was found during all the fuzzing process, exit_on_time is ignored and fuzzing can become endless. We fixed it with checking whether `run_time`, which is equal to `prev_run_time + cur_ms - start_time`, can be greater than `exit_on_time`. 