### PR TITLE
Fix warning prio-ctor-dtor

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -67,8 +67,8 @@
   #endif
 #endif
 
-#define CTOR_PRIO 3
-#define EARLY_FS_PRIO 5
+#define CTOR_PRIO 103
+#define EARLY_FS_PRIO 105
 
 #include <sys/mman.h>
 #include <fcntl.h>
@@ -1387,7 +1387,7 @@ __attribute__((constructor(CTOR_PRIO))) void __afl_auto_early(void) {
 
 /* preset __afl_area_ptr #2 */
 
-__attribute__((constructor(1))) void __afl_auto_second(void) {
+__attribute__((constructor(102))) void __afl_auto_second(void) {
 
   if (__afl_already_initialized_second) return;
   __afl_already_initialized_second = 1;
@@ -1431,7 +1431,7 @@ __attribute__((constructor(1))) void __afl_auto_second(void) {
 /* preset __afl_area_ptr #1 - at constructor level 0 global variables have
    not been set */
 
-__attribute__((constructor(0))) void __afl_auto_first(void) {
+__attribute__((constructor(101))) void __afl_auto_first(void) {
 
   if (__afl_already_initialized_first) return;
   __afl_already_initialized_first = 1;

--- a/instrumentation/afl-llvm-rt-lto.o.c
+++ b/instrumentation/afl-llvm-rt-lto.o.c
@@ -18,7 +18,7 @@ unsigned char __afl_lto_mode = 0;
 
 /* Proper initialization routine. */
 
-__attribute__((constructor(0))) void __afl_auto_init_globals(void) {
+__attribute__((constructor(101))) void __afl_auto_init_globals(void) {
 
   if (getenv("AFL_DEBUG")) fprintf(stderr, "[__afl_auto_init_globals]\n");
   __afl_lto_mode = 1;

--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -108,7 +108,7 @@ static FILE *output_file;
 
 // Experimental feature to use afl_driver without AFL's deferred mode.
 // Needs to run before __afl_auto_init.
-__attribute__((constructor(0))) static void __decide_deferred_forkserver(void) {
+__attribute__((constructor(101))) static void __decide_deferred_forkserver(void) {
 
   if (getenv("AFL_DRIVER_DONT_DEFER")) {
 


### PR DESCRIPTION
There are four warnings when building distrib, like warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]. This patch changes priorities which are between 101 and 65535 to resolve this issue.

```
/home/fanta/source/AFLplusplus/frida_mode/../instrumentation/afl-compiler-rt.o.c:1370:1: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
1370 | __attribute__((constructor(EARLY_FS_PRIO))) void __early_forkserver(void) {
| ^~~~~~~~~~~~~
/home/fanta/source/AFLplusplus/frida_mode/../instrumentation/afl-compiler-rt.o.c:1378:1: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
1378 | __attribute__((constructor(CTOR_PRIO))) void __afl_auto_early(void) {
| ^~~~~~~~~~~~~
/home/fanta/source/AFLplusplus/frida_mode/../instrumentation/afl-compiler-rt.o.c:1390:1: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
1390 | __attribute__((constructor(1))) void __afl_auto_second(void) {
| ^~~~~~~~~~~~~
/home/fanta/source/AFLplusplus/frida_mode/../instrumentation/afl-compiler-rt.o.c:1434:1: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
1434 | __attribute__((constructor(0))) void __afl_auto_first(void) {
| ^~~~~~~~~~~~~
```

Reference: https://maskray.me/blog/2021-11-07-init-ctors-init-array