### PR TITLE
Add option for random cmplog colorization

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -656,7 +656,7 @@ typedef struct afl_state {
   u32 cmplog_max_filesize;
   u32 cmplog_lvl;
   u32 colorize_success;
-  u8  cmplog_enable_arith, cmplog_enable_transform;
+  u8  cmplog_enable_arith, cmplog_enable_transform, cmplog_random_colorization;
 
   struct afl_pass_stat *pass_stats;
   struct cmp_map       *orig_cmp_map;

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -167,6 +167,13 @@ static u8 get_exec_checksum(afl_state_t *afl, u8 *buf, u32 len, u64 *cksum) {
 
 }
 
+/* replace everything with different values */
+static void random_replace(afl_state_t *afl, u8 *buf, u32 len){
+  for(u32 i=0; i < len; i++){
+    buf[i] = rand_below(afl, 256);
+  }
+}
+
 /* replace everything with different values but stay in the same type */
 static void type_replace(afl_state_t *afl, u8 *buf, u32 len) {
 
@@ -293,7 +300,11 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len,
 
   memcpy(backup, buf, len);
   memcpy(changed, buf, len);
-  type_replace(afl, changed, len);
+  if (afl->cmplog_random_colorization) {
+    random_replace(afl, changed, len);
+  } else {
+    type_replace(afl, changed, len);
+  }
 
   while ((rng = pop_biggest_range(&ranges)) != NULL &&
          afl->stage_cur < afl->stage_max) {

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -168,10 +168,14 @@ static u8 get_exec_checksum(afl_state_t *afl, u8 *buf, u32 len, u64 *cksum) {
 }
 
 /* replace everything with different values */
-static void random_replace(afl_state_t *afl, u8 *buf, u32 len){
-  for(u32 i=0; i < len; i++){
+static void random_replace(afl_state_t *afl, u8 *buf, u32 len) {
+
+  for (u32 i = 0; i < len; i++) {
+
     buf[i] = rand_below(afl, 256);
+
   }
+
 }
 
 /* replace everything with different values but stay in the same type */
@@ -301,9 +305,13 @@ static u8 colorization(afl_state_t *afl, u8 *buf, u32 len,
   memcpy(backup, buf, len);
   memcpy(changed, buf, len);
   if (afl->cmplog_random_colorization) {
+
     random_replace(afl, changed, len);
+
   } else {
+
     type_replace(afl, changed, len);
+
   }
 
   while ((rng = pop_biggest_range(&ranges)) != NULL &&

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -172,7 +172,15 @@ static void random_replace(afl_state_t *afl, u8 *buf, u32 len) {
 
   for (u32 i = 0; i < len; i++) {
 
-    buf[i] = rand_below(afl, 256);
+    u8 c;
+
+    do {
+
+      c = rand_below(afl, 256);
+
+    } while (c == buf[i]);
+
+    buf[i] = c;
 
   }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -171,10 +171,11 @@ static void usage(u8 *argv0, int more_help) {
       "                  if using QEMU/FRIDA or the fuzzing target is "
       "compiled\n"
       "                  for CmpLog then just use -c 0.\n"
-      "  -l cmplog_opts - CmpLog configuration values (e.g. \"2AT\"):\n"
+      "  -l cmplog_opts - CmpLog configuration values (e.g. \"2ATR\"):\n"
       "                  1=small files, 2=larger files (default), 3=all "
       "files,\n"
-      "                  A=arithmetic solving, T=transformational solving.\n\n"
+      "                  A=arithmetic solving, T=transformational solving,\n"
+      "                  R=random colorization bytes.\n\n"
       "Fuzzing behavior settings:\n"
       "  -Z            - sequential queue selection instead of weighted "
       "random\n"
@@ -1112,6 +1113,10 @@ int main(int argc, char **argv_orig, char **envp) {
             case 't':
             case 'T':
               afl->cmplog_enable_transform = 1;
+              break;
+            case 'r':
+            case 'R':
+              afl->cmplog_random_colorization = 1;
               break;
             default:
               FATAL("Unknown option value '%c' in -l %s", *c, optarg);


### PR DESCRIPTION
Added option to do random colorization for cmplog, rather than type based. Addresses issue #1546 