### PR TITLE
Fix argv-fuzz.

### DIFF
--- a/utils/argv_fuzzing/argv-fuzz-inl.h
+++ b/utils/argv_fuzzing/argv-fuzz-inl.h
@@ -34,6 +34,7 @@
 #ifndef _HAVE_ARGV_FUZZ_INL
 #define _HAVE_ARGV_FUZZ_INL
 
+#include <string.h>
 #include <unistd.h>
 
 #define AFL_INIT_ARGV()          \
@@ -63,18 +64,19 @@ static char **afl_init_argv(int *argc) {
   char *ptr = in_buf;
   int   rc = 0;
 
-  if (read(0, in_buf, MAX_CMDLINE_LEN - 2) < 0) {}
+  ssize_t num = 0;
+  if ((num = read(0, in_buf, MAX_CMDLINE_LEN - 2)) < 0) {}
+  if (in_buf[num - 1] == '\n') {
+      in_buf[num - 1] = 0;
+  }
 
-  while (*ptr && rc < MAX_CMDLINE_PAR) {
-
-    ret[rc] = ptr;
+  char delim = ' ';
+  char *curarg = strtok(ptr, &delim);
+  while (curarg && rc < MAX_CMDLINE_PAR) {
+    ret[rc] = curarg;
     if (ret[rc][0] == 0x02 && !ret[rc][1]) ret[rc]++;
     rc++;
-
-    while (*ptr)
-      ptr++;
-    ptr++;
-
+    curarg = strtok(NULL, &delim);
   }
 
   *argc = rc;
@@ -87,4 +89,3 @@ static char **afl_init_argv(int *argc) {
 #undef MAX_CMDLINE_PAR
 
 #endif                                              /* !_HAVE_ARGV_FUZZ_INL */
-


### PR DESCRIPTION
Hi! I tried to use `argv-fuzz-inl.h` to build target to fuzz argv, I executed binary and faced the problem that all the input from `stdin` is placed to `argv[0]`. And if I use `AFL_INIT_SET0`, the `argv[0]` is rewritten by passed program name, so nothing from `stdin` data stays in the `argv`.

I fix this problem with using `strtok` from `string.h` for command line arguments parsing.

Please, tell me, if I just didn't understand how to use this, I'll close the PR. Moreover, I didn't understand, why do we need to check `0x02` values.