### PR TITLE
Arm64

### DIFF
--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -145,7 +145,7 @@ ifndef OS
  $(error "Operating system unsupported")
 endif
 
-GUM_DEVKIT_VERSION=16.0.1
+GUM_DEVKIT_VERSION=16.0.6
 GUM_DEVKIT_FILENAME=frida-gumjs-devkit-$(GUM_DEVKIT_VERSION)-$(OS)-$(ARCH).tar.xz
 GUM_DEVKIT_URL="https://github.com/frida/frida/releases/download/$(GUM_DEVKIT_VERSION)/$(GUM_DEVKIT_FILENAME)"
 

--- a/frida_mode/src/instrument/instrument_arm64.c
+++ b/frida_mode/src/instrument/instrument_arm64.c
@@ -196,7 +196,7 @@ static void instrument_coverage_switch(GumStalkerObserver *self,
   insn = instrument_disassemble(from_insn);
   deterministic = instrument_is_deterministic(insn);
   cs_free(insn, 1);
-  if (deterministic) { return; }
+  if (!deterministic) { return; }
 
   /*
    * Since each block is prefixed with a restoration prologue, we need to be


### PR DESCRIPTION
* Bump the version of FRIDA to the latest 16.0.6
* Fix an error with inverted logic for branch suppression on ARM64 (only edges resulting from non-deterministic branches should be emitted, the inverse was the case formerly).