### PR TITLE
Fix kill signals configuring.

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1305,10 +1305,6 @@ int main(int argc, char **argv_orig, char **envp) {
                                  : 0);
     be_quiet = save_be_quiet;
 
-    configure_afl_kill_signals(
-        fsrv, NULL, NULL,
-        (fsrv->qemu_mode || unicorn_mode) ? SIGKILL : SIGTERM);
-
     if (new_map_size) {
 
       // only reinitialize when it makes sense
@@ -1332,6 +1328,10 @@ int main(int argc, char **argv_orig, char **envp) {
     fsrv->map_size = map_size;
 
   }
+
+  configure_afl_kill_signals(
+      fsrv, NULL, NULL,
+      (fsrv->qemu_mode || unicorn_mode) ? SIGKILL : SIGTERM);
 
   if (in_dir) {
 


### PR DESCRIPTION
Hi! I've found the bug related with configuring afl kill signals for QEMU and unicorn modes in `afl-showmap.c`.
The `configure_afl_kill_signals` function is called only under condition `!fsrv->cs_mode && !fsrv->qemu_mode && !unicorn_mode`, and as a result no signals for QEMU and unicorn modes are set, and `afl-showmap` (and `afl-cmin`) hangs. Fixed the error by moving configuring out of this scope.