### PR TITLE
Increase fuzz_level for mopt_common_fuzzing

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -5683,6 +5683,7 @@ pacemaker_fuzzing:
 
   }                                                                /* block */
 
+  ++afl->queue_cur->fuzz_level;
   return ret_val;
 
 }

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -1007,10 +1007,16 @@ u32 calculate_score(afl_state_t *afl, struct queue_entry *q) {
       break;
 
     case LIN:
+      // Don't modify perf_score for unfuzzed seeds
+      if (!q->fuzz_level) break;
+
       factor = q->fuzz_level / (afl->n_fuzz[q->n_fuzz_entry] + 1);
       break;
 
     case QUAD:
+      // Don't modify perf_score for unfuzzed seeds
+      if (!q->fuzz_level) break;
+
       factor =
           q->fuzz_level * q->fuzz_level / (afl->n_fuzz[q->n_fuzz_entry] + 1);
       break;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1297,6 +1297,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+  if (afl->is_main_node == 1 && afl->schedule != FAST && afl->schedule != EXPLORE) {
+
+    FATAL("-M is compatible only with fast and explore -p power schedules");
+
+  }
+
   if (optind == argc || !afl->in_dir || !afl->out_dir || show_help) {
 
     usage(argv[0], show_help);


### PR DESCRIPTION
Trying to fix #1633 

One of the possible fix is to prevent factorizing perf_score for unfuzzed seeds like it is done for other power schedules. These changes fixes hanging in a fuzzing loop without any mutations performed.

Also I discovered that fuzz_level of testcases doesn't increased when MOpt mode is enabled (-L 0 options, `mopt_common_fuzzing` function). This change itself also fixes the original issue (even without changing factorization strategy for lin and quad),

As I understand, the bugfixes in 03e6d33a4044115c44afeb6c1ae735c0310018af and 6596284cc41484ec5062ca53109ec5bd7899e56f not needed anymore and could be reverted