### PR TITLE
The code gettimeofday(&tv, &tz); uses the gettimeofday function to ge…

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -22,7 +22,7 @@
    how they affect the execution path.
 
  */
-
+#include <time.h>
 #include "afl-fuzz.h"
 #include "cmplog.h"
 #include "common.h"
@@ -543,9 +543,9 @@ int main(int argc, char **argv_orig, char **envp) {
             " based on afl by Michal Zalewski and a large online community\n");
 
   doc_path = access(DOC_PATH, F_OK) != 0 ? (u8 *)"docs" : (u8 *)DOC_PATH;
-
-  gettimeofday(&tv, &tz);
-  rand_set_seed(afl, tv.tv_sec ^ tv.tv_usec ^ getpid());
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  rand_set_seed(afl, ts.tv_sec ^ ts.tv_usec ^ getpid());
 
   afl->shmem_testcase_mode = 1;  // we always try to perform shmem fuzzing
 


### PR DESCRIPTION
This issue can be solved by using the clock_gettime function instead of gettimeofday to get the current time in your AFL++ code. clock_gettime provides a monotonic clock, which means that the time returned by this function always increases, even if the system time is adjusted. This ensures that the elapsed time is accurate even if the computer is suspended during a fuzzing session.

To implement this change, you can replace calls to gettimeofday with calls to clock_gettime, and update the relevant functions (e.g. get_cur_time and get_cur_time_ns) to use the new function.

However, it's important to consider the efficiency of the code, as some functions may need to execute as quickly as possible (for example, due to the use of the vDSO). You may need to make additional changes to ensure that the code remains efficient after this change.

In summary, replacing gettimeofday with clock_gettime should provide a simple fix for the issue of elapsed time being incorrect after a computer suspension. However, you should carefully consider the code efficiency and make any necessary changes to ensure that the code remains performant.