### PR TITLE
Cmplog should search for unprefixed target in PATH, not PWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Thank you! (For people sending pull requests - please add yourself to this list
     Thomas Rooijakkers                    David Carlier
     Ruben ten Hove                        Joey Jiao
     fuzzah                                @intrigus-lgtm
+    Yaakov Saxon
   ```
 
 </details>

--- a/frida_mode/test/cmplog/GNUmakefile
+++ b/frida_mode/test/cmplog/GNUmakefile
@@ -2,8 +2,9 @@ PWD:=$(shell pwd)/
 ROOT:=$(PWD)../../../
 BUILD_DIR:=$(PWD)build/
 
+TEST_CMPLOG_BASENAME=compcovtest
 TEST_CMPLOG_SRC=$(PWD)cmplog.c
-TEST_CMPLOG_OBJ=$(BUILD_DIR)compcovtest
+TEST_CMPLOG_OBJ=$(BUILD_DIR)$(TEST_CMPLOG_BASENAME)
 
 TEST_BIN:=$(PWD)../../build/test
 
@@ -13,7 +14,7 @@ CMP_LOG_INPUT:=$(TEST_DATA_DIR)in
 QEMU_OUT:=$(BUILD_DIR)qemu-out
 FRIDA_OUT:=$(BUILD_DIR)frida-out
 
-.PHONY: all 32 clean qemu frida frida-nocmplog format
+.PHONY: all 32 clean qemu frida frida-nocmplog frida-unprefixedpath format
 
 all: $(TEST_CMPLOG_OBJ)
 	make -C $(ROOT)frida_mode/
@@ -63,6 +64,18 @@ frida-nocmplog: $(TEST_CMPLOG_OBJ) $(CMP_LOG_INPUT)
 		-Z \
 		-- \
 			$(TEST_CMPLOG_OBJ) @@
+
+
+frida-unprefixedpath: $(TEST_CMPLOG_OBJ) $(CMP_LOG_INPUT)
+	PATH=$(BUILD_DIR) $(ROOT)afl-fuzz \
+		-O \
+		-i $(TEST_DATA_DIR) \
+		-o $(FRIDA_OUT) \
+		-c 0 \
+		-l 3AT \
+		-Z \
+		-- \
+			$(TEST_CMPLOG_BASENAME) @@
 
 debug: $(TEST_CMPLOG_OBJ) $(CMP_LOG_INPUT)
 	gdb \

--- a/frida_mode/test/cmplog/Makefile
+++ b/frida_mode/test/cmplog/Makefile
@@ -19,6 +19,9 @@ frida:
 frida-nocmplog:
 	@gmake frida-nocmplog
 
+frida-unprefixedpath:
+	@gmake frida-unprefixedpath
+
 format:
 	@gmake format
 

--- a/src/afl-fuzz-cmplog.c
+++ b/src/afl-fuzz-cmplog.c
@@ -41,7 +41,7 @@ void cmplog_exec_child(afl_forkserver_t *fsrv, char **argv) {
 
   }
 
-  execv(argv[0], argv);
+  execv(fsrv->target_path, argv);
 
 }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2081,6 +2081,7 @@ int main(int argc, char **argv_orig, char **envp) {
     afl->cmplog_fsrv.qemu_mode = afl->fsrv.qemu_mode;
     afl->cmplog_fsrv.frida_mode = afl->fsrv.frida_mode;
     afl->cmplog_fsrv.cmplog_binary = afl->cmplog_binary;
+    afl->cmplog_fsrv.target_path = afl->fsrv.target_path;
     afl->cmplog_fsrv.init_child_func = cmplog_exec_child;
 
     if ((map_size <= DEFAULT_SHMEM_SIZE ||


### PR DESCRIPTION
This fixes a bug in cmplog, where, if afl-fuzz is called with an unprefixed-path target (eg `-- targetapp` instead of `-- /path/to/targetapp`), while afl-fuzz itself will correctly look for `target` in `PATH`, cmplog instead looks for it in `PWD`.

If the target does not happen to be in PWD, then it will fail with the confusing error message: 
```
[-] PROGRAM ABORT : Unable to execute target application ('targetapp')
         Location : afl_fsrv_start(), src/afl-forkserver.c:1077
```

This bug is present in standard instrumented mode and Frida mode, but not QEMU mode.

Inasmuch as it violates the general principle and expectation that unprefixed executables should be executed by PATH rather than PWD, this bug being fixed also constitutes a security vulnerability, which could theoretically be exploited by placing a malicious executable of the same name into the user's working directory.