### PR TITLE
Fix exit on time

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -669,9 +669,15 @@ void show_stats_normal(afl_state_t *afl) {
 
   /* AFL_EXIT_ON_TIME. */
 
-  if (unlikely(afl->last_find_time && !afl->non_instrumented_mode &&
-               afl->afl_env.afl_exit_on_time &&
-               (cur_ms - afl->last_find_time) > afl->exit_on_time)) {
+  /* If no coverage was found yet, check whether run time is greater than
+   * exit_on_time. */
+
+  if (unlikely(
+          !afl->non_instrumented_mode && afl->afl_env.afl_exit_on_time &&
+          ((afl->last_find_time &&
+            (cur_ms - afl->last_find_time) > afl->exit_on_time) ||
+           (!afl->last_find_time && (afl->prev_run_time + cur_ms -
+                                     afl->start_time) > afl->exit_on_time)))) {
 
     afl->stop_soon = 2;
 

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -676,8 +676,8 @@ void show_stats_normal(afl_state_t *afl) {
           !afl->non_instrumented_mode && afl->afl_env.afl_exit_on_time &&
           ((afl->last_find_time &&
             (cur_ms - afl->last_find_time) > afl->exit_on_time) ||
-           (!afl->last_find_time && (afl->prev_run_time + cur_ms -
-                                     afl->start_time) > afl->exit_on_time)))) {
+           (!afl->last_find_time && (cur_ms - afl->start_time) 
+	                             > afl->exit_on_time)))) {
 
     afl->stop_soon = 2;
 
@@ -1480,8 +1480,8 @@ void show_stats_pizza(afl_state_t *afl) {
           !afl->non_instrumented_mode && afl->afl_env.afl_exit_on_time &&
           ((afl->last_find_time &&
             (cur_ms - afl->last_find_time) > afl->exit_on_time) ||
-           (!afl->last_find_time && (afl->prev_run_time + cur_ms -
-                                     afl->start_time) > afl->exit_on_time)))) {
+           (!afl->last_find_time && (cur_ms - afl->start_time)
+	                             > afl->exit_on_time)))) {
 
     afl->stop_soon = 2;
 


### PR DESCRIPTION
Hi! I've realized that my fix for exit on time #1555 was only for the pizza mode and, moreover, incorrect. Here I fix exit on time again and in both modes, and now that works.

By the way, @domenukk didn't notice as well that fix #1555 was only for the pizza mode. @vanhauser-thc, does AFL++ still need supporting pizza mode with the exact copy of normal mode code? It can be really misleading. 