### PR TITLE
add check for n_fuzz update

### DIFF
--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -575,7 +575,7 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
     }
 
     /* For AFLFast schedules we update the new queue entry */
-    if (cksum) {
+    if (likely(cksum)) {
 
       afl->queue_top->n_fuzz_entry = cksum % N_FUZZ_SIZE;
       afl->n_fuzz[afl->queue_top->n_fuzz_entry] = 1;

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -575,8 +575,12 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
     }
 
     /* For AFLFast schedules we update the new queue entry */
-    afl->queue_top->n_fuzz_entry = cksum % N_FUZZ_SIZE;
-    afl->n_fuzz[afl->queue_top->n_fuzz_entry] = 1;
+    if (cksum) {
+
+      afl->queue_top->n_fuzz_entry = cksum % N_FUZZ_SIZE;
+      afl->n_fuzz[afl->queue_top->n_fuzz_entry] = 1;
+
+    }
 
     /* Try to calibrate inline; this also calls update_bitmap_score() when
        successful. */


### PR DESCRIPTION
Check for AFLFast before update `afl->n_fuzz`, or fuzzer will crash when `afl->schedule >= FAST && afl->schedule <= RARE` is not true (e.g. `afl-fuzz -p exploit`) because `afl->n_fuzz` is not initialized:
https://github.com/AFLplusplus/AFLplusplus/blob/24503fba5fd2580559223ec3c6ee408dfa15e080/src/afl-fuzz.c#L1555-L1559