### PR TITLE
fix getOperand out of range

### DIFF
--- a/instrumentation/afl-llvm-common.cc
+++ b/instrumentation/afl-llvm-common.cc
@@ -289,6 +289,9 @@ void scanForDangerousFunctions(llvm::Module *M) {
 
     StringRef ifunc_name = IF.getName();
     Constant *r = IF.getResolver();
+    if(r->getNumOperands() == 0){
+      continue ;
+    }
     StringRef r_name = cast<Function>(r->getOperand(0))->getName();
     if (!be_quiet)
       fprintf(stderr,


### PR DESCRIPTION
This commit fixes a sloppy function call that should normally check the number of insn's Operand before calling insn's getOperand method. The fix is that if it is 0 it should continue the loop. I solved problem https://github.com/AFLplusplus/AFLplusplus/issues/1688#issue-1648543691 using this modification