### PR TITLE
afl-cc: Avoid casts of string literals to char*, in definition of __AFL_INIT() etc.

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1171,8 +1171,8 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   cc_params[cc_par_cnt++] =
       "-D__AFL_LOOP(_A)="
-      "({ static volatile char *_B __attribute__((used,unused)); "
-      " _B = (char*)\"" PERSIST_SIG
+      "({ static volatile const char *_B __attribute__((used,unused)); "
+      " _B = (const char*)\"" PERSIST_SIG
       "\"; "
       "extern int __afl_connected;"
 #ifdef __APPLE__
@@ -1187,8 +1187,8 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   cc_params[cc_par_cnt++] =
       "-D__AFL_INIT()="
-      "do { static volatile char *_A __attribute__((used,unused)); "
-      " _A = (char*)\"" DEFER_SIG
+      "do { static volatile const char *_A __attribute__((used,unused)); "
+      " _A = (const char*)\"" DEFER_SIG
       "\"; "
 #ifdef __APPLE__
       "__attribute__((visibility(\"default\"))) "


### PR DESCRIPTION
With the right -W options, compilers may complain about the cast of string literals (for PERSIST_SIG and DEFER_SIG) to (char*), and they're right to do so, because string literals are constant. Since some projects enable -Werror, this can lead to a broken build with afl-cc.

Let's simply cast to (const char *), which preserves the constness of the string literal.