### PR TITLE
Fixing typo: & (background) to && (and)

### DIFF
--- a/test/test-llvm.sh
+++ b/test/test-llvm.sh
@@ -265,7 +265,7 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
       echo 00000000000000000000000000000000 > in/in
       AFL_BENCH_UNTIL_CRASH=1 ../afl-fuzz -m none -V15 -i in -o out -c./test-cmplog -- ./test-c >>errors 2>&1
     } >>errors 2>&1
-    test -n "$( ls out/default/crashes/id:000000* out/default/hangs/id:000000* 2>/dev/null )" & {
+    test -n "$( ls out/default/crashes/id:000000* out/default/hangs/id:000000* 2>/dev/null )" && {
       $ECHO "$GREEN[+] afl-fuzz is working correctly with llvm_mode cmplog"
     } || {
       echo CUT------------------------------------------------------------------CUT


### PR DESCRIPTION
Presently the actual outcome of the test is being ignored by using & (running the test in background) instead of && (conditioning response on outcome of test). This is clearly a typo