### PR TITLE
afl-showmap: Start a only a single fork server

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1421,6 +1421,14 @@ int main(int argc, char **argv_orig, char **envp) {
     // If @@ are in the target args, replace them and also set use_stdin=false.
     detect_file_args(argv + optind, stdin_file, &fsrv->use_stdin);
 
+    fsrv->dev_null_fd = open("/dev/null", O_RDWR);
+    if (fsrv->dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
+
+    fsrv->out_file = stdin_file;
+    fsrv->out_fd =
+        open(stdin_file, O_RDWR | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+    if (fsrv->out_fd < 0) { PFATAL("Unable to create '%s'", stdin_file); }
+
   } else {
 
     // If @@ are in the target args, replace them and also set use_stdin=false.
@@ -1588,6 +1596,14 @@ int main(int argc, char **argv_orig, char **envp) {
 
     fsrv->map_size = map_size;
 
+  } else {
+
+    afl_fsrv_start(fsrv, use_argv, &stop_soon,
+                   (get_afl_env("AFL_DEBUG_CHILD") ||
+                    get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
+                       ? 1
+                       : 0);
+
   }
 
   if (in_dir || in_filelist) {
@@ -1616,9 +1632,6 @@ int main(int argc, char **argv_orig, char **envp) {
     u8  *dn = NULL;
 
     if (getenv("AFL_DEBUG_GDB")) wait_for_gdb = true;
-
-    fsrv->dev_null_fd = open("/dev/null", O_RDWR);
-    if (fsrv->dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
     if (in_filelist) {
 
@@ -1666,10 +1679,6 @@ int main(int argc, char **argv_orig, char **envp) {
     }
 
     atexit(at_exit_handler);
-    fsrv->out_file = stdin_file;
-    fsrv->out_fd =
-        open(stdin_file, O_RDWR | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
-    if (fsrv->out_fd < 0) { PFATAL("Unable to create '%s'", out_file); }
 
     if (get_afl_env("AFL_DEBUG")) {
 
@@ -1684,12 +1693,6 @@ int main(int argc, char **argv_orig, char **envp) {
       SAYF("\n");
 
     }
-
-    afl_fsrv_start(fsrv, use_argv, &stop_soon,
-                   (get_afl_env("AFL_DEBUG_CHILD") ||
-                    get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                       ? 1
-                       : 0);
 
     map_size = fsrv->map_size;
 


### PR DESCRIPTION
A forkserver is started by afl_fsrv_get_mapsize() when dynamically finding the map size.  When an input directory option is specified a second fork server was also started.  This commit re-arranges the inits for several forkserver struct members so that we can re-use the server started by the get_mapsize() call when not in coresight/qemu/unicorn modes and just start the server otherwise.

The duplicate forkservers lead to two copies of the program-under-test running simultaneously.  In my case, I have an application  that tries to reserve a specific port before the deferred init (__AFL_INIT()).  The second attempt to reserve the port will fail.  It is too troublesome to try to remove the port access or otherwise make it fault tolerant, and it didn't seem like afl-showmap really needed two fork servers anyway.