### PR TITLE
Should memset EFF_ALEN(len) of eff_map

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -842,7 +842,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
   eff_map = afl_realloc(AFL_BUF_PARAM(eff), EFF_ALEN(len));
   if (unlikely(!eff_map)) { PFATAL("alloc"); }
-  memset(eff_map, 0, sizeof(len));
+  memset(eff_map, 0, EFF_ALEN(len));
   eff_map[0] = 1;
 
   if (EFF_APOS(len - 1) != 0) {
@@ -3571,7 +3571,7 @@ static u8 mopt_common_fuzzing(afl_state_t *afl, MOpt_globals_t MOpt_globals) {
 
   eff_map = afl_realloc(AFL_BUF_PARAM(eff), EFF_ALEN(len));
   if (unlikely(!eff_map)) { PFATAL("alloc"); }
-  memset(eff_map, 0, sizeof(len));
+  memset(eff_map, 0, EFF_ALEN(len));
   eff_map[0] = 1;
 
   if (EFF_APOS(len - 1) != 0) {


### PR DESCRIPTION
9065d4ba86ecdafeade50e5235ee1e99f4179692 seems not incorrect on the lenght of the `eff_map`, I fix it here.

Regarding #1721, I carefully checked all usages of `afl_realloc` and the `eff_map` seems the only place that forgets to do the initialization so the original fix is no longer needed once this PR is accepted.