### PR TITLE
Fix wrong option name of AFL_LLVM_INSTRUMENT

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -154,7 +154,7 @@ Available options:
   - CTX - context sensitive instrumentation
   - GCC - outdated gcc instrumentation
   - LTO - LTO instrumentation
-  - NATIVE - clang's original pcguard based instrumentation
+  - LLVMNATIVE - clang's original pcguard based instrumentation
   - NGRAM-x - deeper previous location coverage (from NGRAM-2 up to NGRAM-16)
   - PCGUARD - our own pcguard based instrumentation (default)
 


### PR DESCRIPTION
According to:

https://github.com/AFLplusplus/AFLplusplus/blob/c4b1566ba35c697cda7822bd0cf30e2e3eeee0c7/src/afl-cc.c#L1840

the docs here seem outdated.