### PR TITLE
build: fix compiler version in build output

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -291,8 +291,6 @@ ifeq "$(shell command -v svn >/dev/null && svn proplist . 2>/dev/null && echo 1 
   IN_REPO=1
 endif
 
-CCVER=$(shell cc -v 2>&1|tail -n 1)
-
 ifeq "$(shell echo 'int main() { return 0;}' | $(CC) $(CFLAGS) -fsanitize=address -x c - -o .test2 2>/dev/null && echo 1 || echo 0 ; rm -f .test2 )" "1"
 	ASAN_CFLAGS=-fsanitize=address -fstack-protector-all -fno-omit-frame-pointer -DASAN_BUILD
 	ASAN_LDFLAGS=-fsanitize=address -fstack-protector-all -fno-omit-frame-pointer
@@ -439,7 +437,7 @@ endif
 
 .PHONY: ready
 ready:
-	@echo "[+] Everything seems to be working, ready to compile. ($(CCVER))"
+	@echo "[+] Everything seems to be working, ready to compile. ($(shell $(CC) --version 2>&1|head -n 1))"
 
 afl-as: src/afl-as.c include/afl-as.h $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) src/$@.c -o $@ $(LDFLAGS)


### PR DESCRIPTION
Currently, if I build like with Clang, I'll get:
```bash
make LLVM_CONFIG=llvm-config-15 CC=clang-15 CXX=clang++-15
<snip>
[+] Everything seems to be working, ready to compile. (gcc version 12.1.0 (Ubuntu 12.1.0-2ubuntu1~22.04) )
clang-15 -O2 -D_FORTIFY_SOURCE=1 ....
```

Which is somewhat confusing. Fix this, and in a way that still outputs the correct version info for Clang and GCC.
Use `--version`, and pick the first line, as that is where they are consistent in output.
`clang -v` gives the version first, whereas `gcc -v` gives the version on the last line.

We switch to using $(CC), otherwise we also get incorrect output, and drop `CCVER` altogether, given this is it's only use.