### PR TITLE
Fix llvm 17 pcguard compile error

### DIFF
--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -18,11 +18,6 @@
     #include "llvm/ADT/Triple.h"
   #endif
 #endif
-#if LLVM_VERSION_MAJOR < 17
-  #include "llvm/Analysis/EHPersonalities.h"
-#else
-  #include "llvm/IR/EHPersonalities.h"
-#endif
 #include "llvm/Analysis/PostDominators.h"
 #if LLVM_VERSION_MAJOR < 15
   #include "llvm/IR/CFG.h"
@@ -33,10 +28,10 @@
   #include "llvm/IR/DebugInfo.h"
 #endif
 #include "llvm/IR/Dominators.h"
-#if LLVM_VERSION_MAJOR < 17
-  #include "llvm/Analysis/EHPersonalities.h"
-#else
+#if LLVM_VERSION_MAJOR >= 17
   #include "llvm/IR/EHPersonalities.h"
+#else
+  #include "llvm/Analysis/EHPersonalities.h"
 #endif
 #include "llvm/IR/Function.h"
 #if LLVM_VERSION_MAJOR >= 16

--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -20,6 +20,8 @@
 #endif
 #if LLVM_VERSION_MAJOR < 17
   #include "llvm/Analysis/EHPersonalities.h"
+#else
+  #include "llvm/IR/EHPersonalities.h"
 #endif
 #include "llvm/Analysis/PostDominators.h"
 #if LLVM_VERSION_MAJOR < 15
@@ -31,8 +33,10 @@
   #include "llvm/IR/DebugInfo.h"
 #endif
 #include "llvm/IR/Dominators.h"
-#if LLVM_VERSION_MAJOR >= 17
+#if LLVM_VERSION_MAJOR < 17
   #include "llvm/Analysis/EHPersonalities.h"
+#else
+  #include "llvm/IR/EHPersonalities.h"
 #endif
 #include "llvm/IR/Function.h"
 #if LLVM_VERSION_MAJOR >= 16


### PR DESCRIPTION
For building with llvm 17,
f567a89dae29afb2e421d649f0e750e77913f08c was good, and then suddenly broke in 9324f3f6289c62451e2add1f7553a7eda0d7d642.