### PR TITLE
fix bug

### DIFF
--- a/utils/afl_network_proxy/afl-network-server.c
+++ b/utils/afl_network_proxy/afl-network-server.c
@@ -173,6 +173,7 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
     }
 
     out_file = alloc_printf("%s/.afl-input-temp-%u", use_dir, getpid());
+	fsrv->out_file = out_file;
 
   }
 


### PR DESCRIPTION
when using network proxy fuzzing，out_file will close after one fuzz. Howerver fsrv->out_file is zero, out_file wiil not be reopen, write testcase will fail.