### PR TITLE
remove extra limits.h in afl-ld-lto for BSD

### DIFF
--- a/src/afl-ld-lto.c
+++ b/src/afl-ld-lto.c
@@ -46,11 +46,6 @@
 
 #include <dirent.h>
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
-    defined(__DragonFly__)
-  #include <limits.h>
-#endif
-
 #ifdef __APPLE__
   #include <sys/syslimits.h>
 #endif


### PR DESCRIPTION
Don't include limits.h twice on BSD systems.
#1800