### PR TITLE
Fix bug: compilation cannot pass when DEBUG macro is enabled

### DIFF
--- a/include/afl-mutations.h
+++ b/include/afl-mutations.h
@@ -2456,7 +2456,7 @@ inline u32 afl_mutate(afl_state_t *afl, u8 *buf, u32 len, u32 steps,
         }
 
         char buf[20];
-        snprintf(buf, sizeof(buf), "%ld", val);
+        snprintf(buf, sizeof(buf), "%lld", val);
         u32 old_len = off2 - off;
         u32 new_len = strlen(buf);
 

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -2995,7 +2995,7 @@ havoc_stage:
           // fprintf(stderr, "val: %u-%u = %ld\n", off, off2, val);
 
           char buf[20];
-          snprintf(buf, sizeof(buf), "%ld", val);
+          snprintf(buf, sizeof(buf), "%lld", val);
 
           // fprintf(stderr, "BEFORE: %s\n", out_buf);
 


### PR DESCRIPTION
<img width="1004" alt="image" src="https://github.com/AFLplusplus/AFLplusplus/assets/59284400/cca5d950-ac89-40f3-b0a8-2ff7486f9cab">
