### PR TITLE
C++ compilation should use CPPFLAGS

### DIFF
--- a/GNUmakefile.gcc_plugin
+++ b/GNUmakefile.gcc_plugin
@@ -38,7 +38,7 @@ override CFLAGS += $(CFLAGS_SAFE)
 
 CXXFLAGS    ?= -O3 -g -funroll-loops
 # -D_FORTIFY_SOURCE=1
-CXXEFLAGS   := $(CXXFLAGS) -Wall -std=c++11
+CXXEFLAGS   := $(CXXFLAGS) $(CPPFLAGS) -Wall -std=c++11
 
 CC          ?= gcc
 CXX         ?= g++

--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -300,7 +300,7 @@ endif
 ifneq "$(LLVM_CONFIG)" ""
   CLANG_CFL += -I$(shell dirname $(LLVM_CONFIG))/../include
 endif
-CLANG_CPPFL  = `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fPIC $(CXXFLAGS) -Wno-deprecated-declarations
+CLANG_CPPFL  = `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fPIC $(CXXFLAGS) $(CPPFLAGS) -Wno-deprecated-declarations
 CLANG_LFL    = `$(LLVM_CONFIG) --ldflags` $(LDFLAGS)
 
 # wasm fuzzing: disable thread-local storage and unset LLVM debug flag


### PR DESCRIPTION
`CPPFLAGS` should be used for C++ compilation too (ref: [implicit GNU Make rule](https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html#index-C_002b_002b_002c-rule-to-compile)).

This makes it easier to use `--sysroot` when required, which needs to be used with all flag variations: `CFLAGS`, `CFLAGS_SAFE`, and `CXXFLAGS`.