### PR TITLE
Remove redundant comparison of `fav_factor` in `update_bitmap_score`

### DIFF
--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -746,30 +746,9 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
 
         }
 
-        if (fuzz_p2 > top_rated_fuzz_p2) {
+        if (fuzz_p2 > top_rated_fuzz_p2) continue;
 
-          continue;
-
-        } else if (fuzz_p2 == top_rated_fuzz_p2) {
-
-          if (fav_factor > top_rated_fav_factor) { continue; }
-
-        }
-
-        if (unlikely(afl->schedule >= RARE) || unlikely(afl->fixed_seed)) {
-
-          if (fav_factor > afl->top_rated[i]->len << 2) { continue; }
-
-        } else {
-
-          if (fav_factor >
-              afl->top_rated[i]->exec_us * afl->top_rated[i]->len) {
-
-            continue;
-
-          }
-
-        }
+        if (fav_factor > top_rated_fav_factor) continue;
 
         /* Looks like we're going to win. Decrease ref count for the
            previous winner, discard its afl->fsrv.trace_bits[] if necessary. */


### PR DESCRIPTION
When reviewing `update_bitmap_score`, I get confused about the logic of comparing `fav_factor` and `top_rated_fav_factor` then skip the loop. `top_rated_fav_factor` was actually calculated twice, but only one calculation and comparison is needed. The replacement shown below should not change the semantic of this code.

```diff
-        if (unlikely(afl->schedule >= RARE) || unlikely(afl->fixed_seed)) {
-
-          if (fav_factor > afl->top_rated[i]->len << 2) { continue; }
-
-        } else {
-
-          if (fav_factor >
-              afl->top_rated[i]->exec_us * afl->top_rated[i]->len) {
-
-            continue;
-
-          }
-
-        }
+        if (fav_factor > top_rated_fav_factor) continue;
```

Since now `fav_factor` > `top_rated_fav_factor` in the loop will always cause skip of current iteration, `else if (fuzz_p2 == top_rated_fuzz_p2)` is also redundant.

```diff
         if (fuzz_p2 > top_rated_fuzz_p2) {
 
           continue;
 
-        } else if (fuzz_p2 == top_rated_fuzz_p2) {
-
-          if (fav_factor > top_rated_fav_factor) { continue; }
-
         }
 
         if (fav_factor > top_rated_fav_factor) continue;
```

Finally we get two simple condition that skip current iteration.

```cpp
        if (fuzz_p2 > top_rated_fuzz_p2) continue;

        if (fav_factor > top_rated_fav_factor) continue;
```