### PR TITLE
Skip calculating top_rated_fuzz_p2 with FAST schedule

### DIFF
--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -737,7 +737,11 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
         u64 top_rated_fav_factor;
         u64 top_rated_fuzz_p2;
 
-        if (likely(afl->schedule >= FAST && afl->schedule <= RARE)) {
+        if (likely(afl->schedule >= FAST && afl->schedule < RARE)) {
+
+          top_rated_fuzz_p2 = 0;  // Skip the fuzz_p2 comparison
+
+        } else if (unlikely(afl->schedule == RARE)) {
 
           top_rated_fuzz_p2 =
               next_pow2(afl->n_fuzz[afl->top_rated[i]->n_fuzz_entry]);


### PR DESCRIPTION
After #1836 and https://github.com/AFLplusplus/AFLplusplus/commit/26f29fd485efaa08824c27501f82caeea525b5e3, function `update_bitmap_score` became more clear. But I still found redundant calculation of `top_rated_fuzz_p2` when `afl->schedule >= FAST && afl->schedule < RARE`, though it doesn't affect the final result. 
I remove it so the overhead to fetch memory and calculate useless values may be reduced.