### PR TITLE
Add support for UTF-8 line rendering

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,8 +45,8 @@ ifdef NO_SPLICING
   override CFLAGS_OPT += -DNO_SPLICING
 endif
 
-ifdef UTF
-  override CFLAGS_OPT += -DFANCY_BOXES_UTF
+ifdef NO_UTF
+  override CFLAGS_OPT += -DFANCY_BOXES_NO_UTF
 endif
 
 ifdef ASAN_BUILD
@@ -395,7 +395,7 @@ help:
 	@echo INTROSPECTION - compile afl-fuzz with mutation introspection
 	@echo NO_PYTHON - disable python support
 	@echo NO_SPLICING - disables splicing mutation in afl-fuzz, not recommended for normal fuzzing
-	@echo UTF - use UTF-8 for line rendering in status screen
+	@echo NO_UTF - do not use UTF-8 for line rendering in status screen (fallback to G1 box drawing, of vanilla AFL)
 	@echo NO_NYX - disable building nyx mode dependencies
 	@echo "NO_CORESIGHT - disable building coresight (arm64 only)"
 	@echo NO_UNICORN_ARM64 - disable building unicorn on arm64

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,6 +45,10 @@ ifdef NO_SPLICING
   override CFLAGS_OPT += -DNO_SPLICING
 endif
 
+ifdef UTF
+  override CFLAGS_OPT += -DFANCY_BOXES_UTF
+endif
+
 ifdef ASAN_BUILD
   $(info Compiling ASAN version of binaries)
   override CFLAGS += $(ASAN_CFLAGS)
@@ -391,6 +395,7 @@ help:
 	@echo INTROSPECTION - compile afl-fuzz with mutation introspection
 	@echo NO_PYTHON - disable python support
 	@echo NO_SPLICING - disables splicing mutation in afl-fuzz, not recommended for normal fuzzing
+	@echo UTF - use UTF-8 for line rendering in status screen
 	@echo NO_NYX - disable building nyx mode dependencies
 	@echo "NO_CORESIGHT - disable building coresight (arm64 only)"
 	@echo NO_UNICORN_ARM64 - disable building unicorn on arm64

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,7 +87,7 @@ These build options exist:
 * INTROSPECTION - compile afl-fuzz with mutation introspection
 * NO_PYTHON - disable python support
 * NO_SPLICING - disables splicing mutation in afl-fuzz, not recommended for normal fuzzing
-* UTF - use UTF-8 for line rendering in status screen
+* NO_UTF - do not use UTF-8 for line rendering in status screen (fallback to G1 box drawing, of vanilla AFL)
 * NO_NYX - disable building nyx mode dependencies
 * NO_CORESIGHT - disable building coresight (arm64 only)
 * NO_UNICORN_ARM64 - disable building unicorn on arm64

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,6 +87,7 @@ These build options exist:
 * INTROSPECTION - compile afl-fuzz with mutation introspection
 * NO_PYTHON - disable python support
 * NO_SPLICING - disables splicing mutation in afl-fuzz, not recommended for normal fuzzing
+* UTF - use UTF-8 for line rendering in status screen
 * NO_NYX - disable building nyx mode dependencies
 * NO_CORESIGHT - disable building coresight (arm64 only)
 * NO_UNICORN_ARM64 - disable building unicorn on arm64

--- a/include/config.h
+++ b/include/config.h
@@ -120,9 +120,9 @@
 
 // #define _WANT_ORIGINAL_AFL_ALLOC
 
-/* Comment out to disable fancy ANSI boxes and use poor man's 7-bit UI: */
+/* Comment out to disable fancy boxes and use poor man's 7-bit UI: */
 
-#ifndef ANDROID_DISABLE_FANCY  // Fancy boxes are ugly from adb
+#ifndef DISABLE_FANCY
   #define FANCY_BOXES
 #endif
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -116,42 +116,63 @@
  * Box drawing sequences *
  *************************/
 
-#ifdef FANCY_BOXES
-
-  #define SET_G1 "\x1b)0"                      /* Set G1 for box drawing    */
-  #define RESET_G1 "\x1b)B"                    /* Reset G1 to ASCII         */
-  #define bSTART "\x0e"                        /* Enter G1 drawing mode     */
-  #define bSTOP "\x0f"                         /* Leave G1 drawing mode     */
-  #define bH "q"                               /* Horizontal line           */
-  #define bV "x"                               /* Vertical line             */
-  #define bLT "l"                              /* Left top corner           */
-  #define bRT "k"                              /* Right top corner          */
-  #define bLB "m"                              /* Left bottom corner        */
-  #define bRB "j"                              /* Right bottom corner       */
-  #define bX "n"                               /* Cross                     */
-  #define bVR "t"                              /* Vertical, branch right    */
-  #define bVL "u"                              /* Vertical, branch left     */
-  #define bHT "v"                              /* Horizontal, branch top    */
-  #define bHB "w"                              /* Horizontal, branch bottom */
-
-#else
+#ifdef FANCY_BOXES_UTF
 
   #define SET_G1 ""
   #define RESET_G1 ""
   #define bSTART ""
   #define bSTOP ""
-  #define bH "-"
-  #define bV "|"
-  #define bLT "+"
-  #define bRT "+"
-  #define bLB "+"
-  #define bRB "+"
-  #define bX "+"
-  #define bVR "+"
-  #define bVL "+"
-  #define bHT "+"
-  #define bHB "+"
+  #define bH "\u2500"                          /* Horizontal line           */
+  #define bV "\u2502"                          /* Vertical line             */
+  #define bLT "\u250c"                         /* Left top corner           */
+  #define bRT "\u2510"                         /* Right top corner          */
+  #define bLB "\u2514"                         /* Left bottom corner        */
+  #define bRB "\u2518"                         /* Right bottom corner       */
+  #define bX "\u253c"                          /* Cross                     */
+  #define bVR "\u251c"                         /* Vertical, branch right    */
+  #define bVL "\u2524"                         /* Vertical, branch left     */
+  #define bHT "\u2534"                         /* Horizontal, branch top    */
+  #define bHB "\u252c"                         /* Horizontal, branch bottom */
 
+#else
+
+  #ifdef FANCY_BOXES
+
+    #define SET_G1 "\x1b)0"                    /* Set G1 for box drawing    */
+    #define RESET_G1 "\x1b)B"                  /* Reset G1 to ASCII         */
+    #define bSTART "\x0e"                      /* Enter G1 drawing mode     */
+    #define bSTOP "\x0f"                       /* Leave G1 drawing mode     */
+    #define bH "q"                             /* Horizontal line           */
+    #define bV "x"                             /* Vertical line             */
+    #define bLT "l"                            /* Left top corner           */
+    #define bRT "k"                            /* Right top corner          */
+    #define bLB "m"                            /* Left bottom corner        */
+    #define bRB "j"                            /* Right bottom corner       */
+    #define bX "n"                             /* Cross                     */
+    #define bVR "t"                            /* Vertical, branch right    */
+    #define bVL "u"                            /* Vertical, branch left     */
+    #define bHT "v"                            /* Horizontal, branch top    */
+    #define bHB "w"                            /* Horizontal, branch bottom */
+
+  #else
+
+    #define SET_G1 ""
+    #define RESET_G1 ""
+    #define bSTART ""
+    #define bSTOP ""
+    #define bH "-"
+    #define bV "|"
+    #define bLT "+"
+    #define bRT "+"
+    #define bLB "+"
+    #define bRB "+"
+    #define bX "+"
+    #define bVR "+"
+    #define bVL "+"
+    #define bHT "+"
+    #define bHB "+"
+
+  #endif
 #endif                                                      /* ^FANCY_BOXES */
 
 /***********************

--- a/include/debug.h
+++ b/include/debug.h
@@ -116,43 +116,43 @@
  * Box drawing sequences *
  *************************/
 
-#ifdef FANCY_BOXES_UTF
+#ifdef FANCY_BOXES_NO_UTF
 
-  #define SET_G1 ""
-  #define RESET_G1 ""
-  #define bSTART ""
-  #define bSTOP ""
-  #define bH "\u2500"                          /* Horizontal line           */
-  #define bV "\u2502"                          /* Vertical line             */
-  #define bLT "\u250c"                         /* Left top corner           */
-  #define bRT "\u2510"                         /* Right top corner          */
-  #define bLB "\u2514"                         /* Left bottom corner        */
-  #define bRB "\u2518"                         /* Right bottom corner       */
-  #define bX "\u253c"                          /* Cross                     */
-  #define bVR "\u251c"                         /* Vertical, branch right    */
-  #define bVL "\u2524"                         /* Vertical, branch left     */
-  #define bHT "\u2534"                         /* Horizontal, branch top    */
-  #define bHB "\u252c"                         /* Horizontal, branch bottom */
+  #define SET_G1 "\x1b)0"                      /* Set G1 for box drawing    */
+  #define RESET_G1 "\x1b)B"                    /* Reset G1 to ASCII         */
+  #define bSTART "\x0e"                        /* Enter G1 drawing mode     */
+  #define bSTOP "\x0f"                         /* Leave G1 drawing mode     */
+  #define bH "q"                               /* Horizontal line           */
+  #define bV "x"                               /* Vertical line             */
+  #define bLT "l"                              /* Left top corner           */
+  #define bRT "k"                              /* Right top corner          */
+  #define bLB "m"                              /* Left bottom corner        */
+  #define bRB "j"                              /* Right bottom corner       */
+  #define bX "n"                               /* Cross                     */
+  #define bVR "t"                              /* Vertical, branch right    */
+  #define bVL "u"                              /* Vertical, branch left     */
+  #define bHT "v"                              /* Horizontal, branch top    */
+  #define bHB "w"                              /* Horizontal, branch bottom */
 
 #else
 
   #ifdef FANCY_BOXES
 
-    #define SET_G1 "\x1b)0"                    /* Set G1 for box drawing    */
-    #define RESET_G1 "\x1b)B"                  /* Reset G1 to ASCII         */
-    #define bSTART "\x0e"                      /* Enter G1 drawing mode     */
-    #define bSTOP "\x0f"                       /* Leave G1 drawing mode     */
-    #define bH "q"                             /* Horizontal line           */
-    #define bV "x"                             /* Vertical line             */
-    #define bLT "l"                            /* Left top corner           */
-    #define bRT "k"                            /* Right top corner          */
-    #define bLB "m"                            /* Left bottom corner        */
-    #define bRB "j"                            /* Right bottom corner       */
-    #define bX "n"                             /* Cross                     */
-    #define bVR "t"                            /* Vertical, branch right    */
-    #define bVL "u"                            /* Vertical, branch left     */
-    #define bHT "v"                            /* Horizontal, branch top    */
-    #define bHB "w"                            /* Horizontal, branch bottom */
+    #define SET_G1 ""
+    #define RESET_G1 ""
+    #define bSTART ""
+    #define bSTOP ""
+    #define bH "\u2500"                        /* Horizontal line           */
+    #define bV "\u2502"                        /* Vertical line             */
+    #define bLT "\u250c"                       /* Left top corner           */
+    #define bRT "\u2510"                       /* Right top corner          */
+    #define bLB "\u2514"                       /* Left bottom corner        */
+    #define bRB "\u2518"                       /* Right bottom corner       */
+    #define bX "\u253c"                        /* Cross                     */
+    #define bVR "\u251c"                       /* Vertical, branch right    */
+    #define bVL "\u2524"                       /* Vertical, branch left     */
+    #define bHT "\u2534"                       /* Horizontal, branch top    */
+    #define bHB "\u252c"                       /* Horizontal, branch bottom */
 
   #else
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -381,6 +381,12 @@ static void usage(u8 *argv0, int more_help) {
   SAYF("Compiled with NO_SPLICING.\n");
 #endif
 
+#ifdef NO_UTF
+  SAYF("Compiled without UTF-8 support for line rendering in status screen.\n");
+#else
+  SAYF("Compiled with UTF-8 support for line rendering in status screen.\n");
+#endif
+
 #ifdef PROFILING
   SAYF("Compiled with PROFILING.\n");
 #endif

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -381,10 +381,8 @@ static void usage(u8 *argv0, int more_help) {
   SAYF("Compiled with NO_SPLICING.\n");
 #endif
 
-#ifdef NO_UTF
+#ifdef FANCY_BOXES_NO_UTF
   SAYF("Compiled without UTF-8 support for line rendering in status screen.\n");
-#else
-  SAYF("Compiled with UTF-8 support for line rendering in status screen.\n");
 #endif
 
 #ifdef PROFILING

--- a/utils/qbdi_mode/build.sh
+++ b/utils/qbdi_mode/build.sh
@@ -52,6 +52,6 @@ ${compiler_prefix}${CC} -shared -o libdemo.so demo-so.c -w -g
 echo "[+] Building afl-fuzz for Android"
 # build afl-fuzz
 cd ../..
-${compiler_prefix}${CC} -DANDROID_DISABLE_FANCY=1 -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -I include/ -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DDOC_PATH=\"/usr/local/share/doc/afl\" -Wno-unused-function src/afl-fuzz*.c src/afl-common.c src/afl-sharedmem.c src/afl-forkserver.c src/afl-performance.c -o utils/qbdi_mode/afl-fuzz -ldl -lm -w
+${compiler_prefix}${CC} -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -I include/ -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DDOC_PATH=\"/usr/local/share/doc/afl\" -Wno-unused-function src/afl-fuzz*.c src/afl-common.c src/afl-sharedmem.c src/afl-forkserver.c src/afl-performance.c -o utils/qbdi_mode/afl-fuzz -ldl -lm -w
 
 echo "[+] All done. Enjoy!"


### PR DESCRIPTION
Frustrated by the lack of support for the classic fancy boxes rendering in WSL terminals, I decided to add support for UTF-8 rendering.

default `make` compilation still yields:  
![image](https://github.com/AFLplusplus/AFLplusplus/assets/49478940/431e9668-a193-4d01-94c6-2b037143d145)

Optional `make UTF=1` compilation now yields:  
![image](https://github.com/AFLplusplus/AFLplusplus/assets/49478940/03a81529-4a3c-4736-b9af-0a497a9709fb)
