### PR TITLE
Use sync_id instead of use_banner while building statsd metric messages

### DIFF
--- a/src/afl-fuzz-statsd.c
+++ b/src/afl-fuzz-statsd.c
@@ -223,7 +223,7 @@ int statsd_format_metric(afl_state_t *afl, char *buff, size_t bufflen) {
   char tags[MAX_TAG_LEN * 2] = {0};
   if (afl->statsd_tags_format) {
 
-    snprintf(tags, MAX_TAG_LEN * 2, afl->statsd_tags_format, afl->use_banner,
+    snprintf(tags, MAX_TAG_LEN * 2, afl->statsd_tags_format, afl->sync_id,
              VERSION);
 
   }


### PR DESCRIPTION
This PR fixes https://github.com/AFLplusplus/AFLplusplus/issues/1881

Note, with this fix `-T` option will not have an influence on the banner that is used in statsd messages.