### PR TITLE
Make fuzzer_stats update atomic

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -250,11 +250,13 @@ void write_stats_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
 #endif
 
   u64   cur_time = get_cur_time();
-  u8    fn[PATH_MAX];
+  u8    fn_tmp[PATH_MAX];
+  u8    fn_final[PATH_MAX];
   FILE *f;
 
-  snprintf(fn, PATH_MAX, "%s/fuzzer_stats", afl->out_dir);
-  f = create_ffile(fn);
+  snprintf(fn_tmp, PATH_MAX, "%s/.fuzzer_stats_tmp", afl->out_dir);
+  snprintf(fn_final, PATH_MAX, "%s/fuzzer_stats", afl->out_dir);
+  f = create_ffile(fn_tmp);
 
   /* Keep last values in case we're called from another context
      where exec/sec stats and such are not readily available. */
@@ -412,6 +414,7 @@ void write_stats_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
   }
 
   fclose(f);
+  rename(fn_tmp, fn_final);
 
 }
 


### PR DESCRIPTION
This writes fuzzer_stats to a temp file and then atomically renames the temp file into fuzzer_stats so that any read on fuzzer_stats will always return a consistent view of the AFL state (otherwise there is a very low change of AFL's write and $tool's read lead to a race condition and yield inconsistent results).