### PR TITLE
Add an env to afl-clang-fast to disable setting rpath if LLVM path isn't recognized

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -135,6 +135,12 @@ subset of the settings discussed in section 1, with the exception of:
   - `TMPDIR` and `AFL_KEEP_ASSEMBLY`, since no temporary assembly files are
     created.
 
+  - LLVM modes compiling C++ will normally set rpath in the binary if LLVM is
+    not in a usual location (/usr or /lib). Setting `AFL_LLVM_NO_RPATH=1`
+    disables this behaviour in case it isn't desired. For example, the compiling
+    toolchain might be in a custom location, but the target machine has LLVM
+    runtime libs in the search path.
+
 Then there are a few specific features that are only available in
 instrumentation mode:
 

--- a/include/envs.h
+++ b/include/envs.h
@@ -162,6 +162,7 @@ static char *afl_environment_variables[] = {
     "AFL_LLVM_MAP_DYNAMIC",
     "AFL_LLVM_NGRAM_SIZE",
     "AFL_NGRAM_SIZE",
+    "AFL_LLVM_NO_RPATH",
     "AFL_LLVM_NOT_ZERO",
     "AFL_LLVM_INSTRUMENT_FILE",
     "AFL_LLVM_THREADSAFE_INST",

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1144,19 +1144,22 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   if (!have_pic) { cc_params[cc_par_cnt++] = "-fPIC"; }
 
-  // in case LLVM is installed not via a package manager or "make install"
-  // e.g. compiled download or compiled from github then its ./lib directory
-  // might not be in the search path. Add it if so.
-  u8 *libdir = strdup(LLVM_LIBDIR);
-  if (plusplus_mode && strlen(libdir) && strncmp(libdir, "/usr", 4) &&
-      strncmp(libdir, "/lib", 4)) {
+  if (!getenv("AFL_LLVM_NO_RPATH")) {
+    // in case LLVM is installed not via a package manager or "make install"
+    // e.g. compiled download or compiled from github then its ./lib directory
+    // might not be in the search path. Add it if so.
+    u8 *libdir = strdup(LLVM_LIBDIR);
+    if (plusplus_mode && strlen(libdir) && strncmp(libdir, "/usr", 4) &&
+        strncmp(libdir, "/lib", 4)) {
 
-    cc_params[cc_par_cnt++] = "-Wl,-rpath";
-    cc_params[cc_par_cnt++] = libdir;
+      cc_params[cc_par_cnt++] = "-Wl,-rpath";
+      cc_params[cc_par_cnt++] = libdir;
 
-  } else {
+    } else {
 
-    free(libdir);
+      free(libdir);
+
+    }
 
   }
 
@@ -2289,7 +2292,9 @@ int main(int argc, char **argv, char **envp) {
             "  AFL_LLVM_CTX: use full context sensitive coverage (for "
             "CLASSIC)\n"
             "  AFL_LLVM_NGRAM_SIZE: use ngram prev_loc count coverage (for "
-            "CLASSIC)\n");
+            "CLASSIC)\n"
+            "  AFL_LLVM_NO_RPATH: disable rpath setting for custom LLVM "
+            "locations\n");
 
 #ifdef AFL_CLANG_FLTO
       if (have_lto)


### PR DESCRIPTION
rpath is not desired, eg. in firefox where we use a custom clang and create a distributable build.