### PR TITLE
Use proper AFL_NYX_AUX_SIZE for nyx_aux_string

### DIFF
--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -197,6 +197,7 @@ typedef struct afl_forkserver {
   u32                   nyx_id;          /* nyx runner id (0 -> master)      */
   u32                   nyx_bind_cpu_id; /* nyx runner cpu id                */
   char                 *nyx_aux_string;
+  u32                   nyx_aux_string_len;
   bool                  nyx_use_tmp_workdir;
   char                 *nyx_tmp_workdir_path;
   s32                   nyx_log_fd;

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -615,14 +615,20 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     if (getenv("AFL_NYX_AUX_SIZE") != NULL) {
 
+      fsrv->nyx_aux_string_len = atoi(getenv("AFL_NYX_AUX_SIZE"));
+
       if (fsrv->nyx_handlers->nyx_config_set_aux_buffer_size(
-              nyx_config, atoi(getenv("AFL_NYX_AUX_SIZE"))) != 1) {
+              nyx_config, fsrv->nyx_aux_string_len) != 1) {
 
         NYX_PRE_FATAL(fsrv,
                       "Invalid AFL_NYX_AUX_SIZE value set (must be a multiple "
                       "of 4096) ...");
 
       }
+
+    } else {
+
+      fsrv->nyx_aux_string_len = 0x1000;
 
     }
 
@@ -697,8 +703,8 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
     fsrv->nyx_handlers->nyx_option_set_timeout(fsrv->nyx_runner, 2, 0);
     fsrv->nyx_handlers->nyx_option_apply(fsrv->nyx_runner);
 
-    fsrv->nyx_aux_string = malloc(0x1000);
-    memset(fsrv->nyx_aux_string, 0, 0x1000);
+    fsrv->nyx_aux_string = malloc(fsrv->nyx_aux_string_len);
+    memset(fsrv->nyx_aux_string, 0, fsrv->nyx_aux_string_len);
 
     /* dry run */
     fsrv->nyx_handlers->nyx_set_afl_input(fsrv->nyx_runner, "INIT", 4);

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -866,7 +866,7 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
     if (unlikely(fd < 0)) { PFATAL("Unable to create '%s'", fn_log); }
 
     u32 nyx_aux_string_len = afl->fsrv.nyx_handlers->nyx_get_aux_string(
-        afl->fsrv.nyx_runner, afl->fsrv.nyx_aux_string, 0x1000);
+        afl->fsrv.nyx_runner, afl->fsrv.nyx_aux_string, afl->fsrv.nyx_aux_string_len);
 
     ck_write(fd, afl->fsrv.nyx_aux_string, nyx_aux_string_len, fn_log);
     close(fd);


### PR DESCRIPTION
Currently, AFL_NYX_AUX_SIZE doesn't work because AFL++ uses the hardcoded 0x1000 size for `nyx_aux_string` rather than the actually set size. This causes ASan traces to still be truncated to 4K, no matter what AFL_NYX_AUX_SIZE is set to.

The attached fix was validated to work in our setup and produces the proper traces now.