### PR TITLE
Possible missing initialisation in custom mutator

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -1894,6 +1894,7 @@ custom_mutator_stage:
   LIST_FOREACH(&afl->custom_mutator_list, struct custom_mutator, {
 
     if (el->afl_custom_fuzz) {
+      havoc_queued = afl->queued_items;
 
       afl->current_custom_fuzz = el;
       afl->stage_name = el->name_short;


### PR DESCRIPTION
Hi :wave: 

**Describe the bug**

There could be a missing initialisation in the Custom Mutator stage. From what I understand, [this check](https://github.com/AFLplusplus/AFLplusplus/blob/85c5b5218c6a7b2289f309fbd1625a5d0a602a00/src/afl-fuzz-one.c#L1975) is meant to verify if the custom mutator's mutations have been added to the corpus. If so, the cycles for the custom mutator are increased. However, when the stage starts, or when each custom mutator is called, the `havoc_queued` variable is not initialised with `afl->queued_items`. 

**Expected behavior**

If the initialisation is missing, the custom mutator's cycles could be wrongly extended.  

**Additional context**

After reading the code, it seems like the Custom Mutator's code follows Havoc stage's code, which does initialise  `havoc_queued` with `afl->queued_items` [while initialising the stage ](https://github.com/AFLplusplus/AFLplusplus/blob/85c5b5218c6a7b2289f309fbd1625a5d0a602a00/src/afl-fuzz-one.c#L2061) for the current test case. 

------------

I've noticed this while trying to understand better how the Custom Mutator API's is called. I'm sorry if this is not actually a bug! 

Best,
Manuel.