### PR TITLE
Fix possible doc inconsistency for custom mutator's queue_get function.

### DIFF
--- a/docs/custom_mutators.md
+++ b/docs/custom_mutators.md
@@ -125,8 +125,9 @@ def deinit():  # optional for Python
 
 - `queue_get` (optional):
 
-    This method determines whether the custom fuzzer should fuzz the current
-    queue entry or not
+    This method determines whether AFL++ should fuzz the current
+    queue entry or not: all defined custom mutators as well as
+    all AFL++'s mutators.
 
 - `fuzz_count` (optional):
 


### PR DESCRIPTION
Hi :wave: 

**Describe the bug**

After reading the code, I noticed there could be an inconsistency between `queue_get`'s documentation and its actual implementation.

The current documentation states that it controls whether the custom fuzzer should fuzz the current entry. This does not seem wrong but possibly incomplete regarding the [actual code](https://github.com/AFLplusplus/AFLplusplus/blob/f7d19390fbcdf774276662d0785c5abc663d5475/src/afl-fuzz-one.c#L356). At the moment, the implementation controls whether the current queue entry should be fuzzed including AFL++'s mutators. 

Best,
Manuel.