### PR TITLE
Pass correct Nyx ID when creating a Nyx runner

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -679,8 +679,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     }
 
-    fsrv->nyx_runner =
-        fsrv->nyx_handlers->nyx_new(nyx_config, fsrv->nyx_bind_cpu_id);
+    fsrv->nyx_runner = fsrv->nyx_handlers->nyx_new(nyx_config, fsrv->nyx_id);
 
     ck_free(workdir_path);
     ck_free(outdir_path_absolute);


### PR DESCRIPTION
Each Nyx instance requires a numeric id when being created. Nyx internally assumes that id 0 is the parent id and all non-zero ids are child instances that will run what the parent runs. For this purpose, `fsrv->nyx_id` is actually populated with the id used with `-M/-S`. Mistakenly the code currently uses `nyx_bind_cpu_id` though which works by coincidence if you only ever run a single AFL++ instance with `-M` on a device and the CPU with id 0 is not busy already. Running two AFL++ instances with `-M` in parallel will cause a Nyx assertion to fail and reveals the failure.