### PR TITLE
Stop hardcoding the path /usr/local/lib/afl in afl-ld-lto.c and respect the configured PREFIX

### DIFF
--- a/src/afl-ld-lto.c
+++ b/src/afl-ld-lto.c
@@ -278,7 +278,7 @@ int main(int argc, char **argv) {
   if (getenv("AFL_LD_PASSTHROUGH") != NULL) passthrough = 1;
   if (getenv("AFL_REAL_LD") != NULL) real_ld = getenv("AFL_REAL_LD");
 
-  if (!afl_path || !*afl_path) afl_path = "/usr/local/lib/afl";
+  if (!afl_path || !*afl_path) afl_path = AFL_PATH;
 
   setenv("AFL_LD_CALLER", "1", 1);
 


### PR DESCRIPTION
This is very unrealistic scenarios, but in the strange case where someone would use the environment variable `ALF_PATH=` (ie empty string) really rely on the configure time AFL_PATH rather than an hardcoded `/usr/local/lib/afl` path.