### PR TITLE
Removing -Wl,rpath <LLVM_LIBDIR> when using GCC 

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1144,7 +1144,8 @@ static void edit_params(u32 argc, char **argv, char **envp) {
 
   if (!have_pic) { cc_params[cc_par_cnt++] = "-fPIC"; }
 
-  if (!getenv("AFL_LLVM_NO_RPATH")) {
+  if (compiler_mode != GCC_PLUGIN && compiler_mode != GCC &&
+      !getenv("AFL_LLVM_NO_RPATH")) {
 
     // in case LLVM is installed not via a package manager or "make install"
     // e.g. compiled download or compiled from github then its ./lib directory


### PR DESCRIPTION
In the scenario where the compiling toolchain is in a custom location, then `afl-cc` sets the option `-Wl,-rpath <LLVM_LIBDIR>` , I guess this is fine as long as we're not using **GCC**.

With this pull request I'm making sure that this option is not added when using **GCC**.