### PR TITLE
fixing -Wl,-rpath=<LLVM_LIBDIR>

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1150,16 +1150,12 @@ static void edit_params(u32 argc, char **argv, char **envp) {
     // in case LLVM is installed not via a package manager or "make install"
     // e.g. compiled download or compiled from github then its ./lib directory
     // might not be in the search path. Add it if so.
-    u8 *libdir = strdup(LLVM_LIBDIR);
+    const char *libdir = LLVM_LIBDIR;
     if (plusplus_mode && strlen(libdir) && strncmp(libdir, "/usr", 4) &&
         strncmp(libdir, "/lib", 4)) {
 
-      cc_params[cc_par_cnt++] = "-Wl,-rpath";
-      cc_params[cc_par_cnt++] = libdir;
-
-    } else {
-
-      free(libdir);
+      u8 *libdir_opt = strdup("-Wl,-rpath=" LLVM_LIBDIR);
+      cc_params[cc_par_cnt++] = libdir_opt;
 
     }
 


### PR DESCRIPTION
In the scenario where we're using **LLVM** installed on a custom toolchain, `afl-cc` sets the option `-Wl,-rpath <LLVM_LIBDIR>`:
```c
cc_params[cc_par_cnt++] = "-Wl,-rpath";
cc_params[cc_par_cnt++] = <LLVM_LIBDIR>;
```

This is not working and I guess the problem is that the option to the linker should be passed using one of the two ways:
- `-Wl,-rpath=<LLVM_LIBDIR>`
- `-Wl,-rpath,<LLVM_LIBDIR>`

Both ways worked fine on my toolchain.