### PR TITLE
Broken LTO mode and response file support due to #1912

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2059,7 +2059,6 @@ void add_lto_passes(aflcc_state_t *aflcc) {
 #endif
 
   insert_param(aflcc, "-Wl,--allow-multiple-definition");
-  insert_param(aflcc, aflcc->lto_flag);
 
 }
 
@@ -2295,10 +2294,6 @@ param_st parse_misc_params(aflcc_state_t *aflcc, u8 *cur_argv, u8 scan) {
 
     SCAN_KEEP(aflcc->have_pic, 1);
 
-  } else if (cur_argv[0] != '-') {
-
-    SCAN_KEEP(aflcc->non_dash, 1);
-
   } else if (!strcmp(cur_argv, "-m32") ||
 
              !strcmp(cur_argv, "armv7a-linux-androideabi")) {
@@ -2373,6 +2368,14 @@ param_st parse_misc_params(aflcc_state_t *aflcc, u8 *cur_argv, u8 scan) {
       final_ = PARAM_DROP;
 
     }
+
+  } else if (cur_argv[0] != '-') {
+
+    /* It's a weak, loose pattern, with very different purpose
+     than others. We handle it at last, cautiously and robustly. */
+
+    if (scan && cur_argv[0] != '@')  // response file support
+      aflcc->non_dash = 1;
 
   }
 
@@ -2912,10 +2915,16 @@ static void edit_params(aflcc_state_t *aflcc, u32 argc, char **argv,
     //     use. insert_param(aflcc, "-flegacy-pass-manager");
     // #endif
 
-    if (aflcc->lto_mode && !aflcc->have_c) {
+    if (aflcc->lto_mode) {
 
-      add_lto_linker(aflcc);
-      add_lto_passes(aflcc);
+      insert_param(aflcc, aflcc->lto_flag);
+
+      if (!aflcc->have_c) {
+
+        add_lto_linker(aflcc);
+        add_lto_passes(aflcc);
+
+      }
 
     } else {
 


### PR DESCRIPTION
I still keep on doing some regression tests for #1912 manually by myself. So far I've found two bugs.

## Broken LTO mode

`SanitizerCoverageLTO.so` was taken over by `SanitizerCoveragePCGUARD.so`, which should never happen.

For example:
```text
$ /home/AFLplusplus/afl-clang-lto++ -fsanitize=fuzzer,address -O0 -gdwarf-4 -DUSE_LLVM_LIBFUZZER_STYLE -c -o /home/microBug/build/mbug.o /home/microBug/microBug.cpp

afl-cc++4.10a by Michal Zalewski, Laszlo Szekeres, Marc Heuse - mode: LLVM-LTO-PCGUARD
[+] Found '-fsanitize=fuzzer', replacing with libAFLDriver.a
SanitizerCoveragePCGUARD++4.10a
Note: Found constructor function _GLOBAL__sub_I_microBug.cpp with prio 65535, we will not instrument this, putting it into a block list.
[+] Instrumented 51 locations with no collisions (non-hardened mode) of which are 0 handled and 0 unhandled selects.

$ /home/AFLplusplus/afl-clang-lto -fsanitize=fuzzer,address -O0 -gdwarf-4 -c -o /home/microBug/build/calls.o /home/microBug/calls.c

afl-cc++4.10a by Michal Zalewski, Laszlo Szekeres, Marc Heuse - mode: LLVM-LTO-PCGUARD
[+] Found '-fsanitize=fuzzer', replacing with libAFLDriver.a
SanitizerCoveragePCGUARD++4.10a
[+] Instrumented 11 locations with no collisions (non-hardened mode) of which are 0 handled and 0 unhandled selects.

$ /home/AFLplusplus/afl-clang-lto++ -fsanitize=fuzzer,address -O0 -gdwarf-4 /home/microBug/build/calls.o /home/microBug/build/mbug.o -o /home/microBug/build/bug-san1-dyn1-dbg1-64

afl-cc++4.10a by Michal Zalewski, Laszlo Szekeres, Marc Heuse - mode: LLVM-LTO-PCGUARD
[+] Found '-fsanitize=fuzzer', replacing with libAFLDriver.a
afl-llvm-lto++4.10a by Marc "vanHauser" Heuse <mh@mh-sec.de>
[!] WARNING: No instrumentation targets found.
```

As you can see, afl-cc did not drive clang in LTO mode throughout. I made further investigation on this mess.

First of all, let's see what happened:
1. `afl-cc` got mode "LLVM-LTO-PCGUARD" because `aflcc->compiler_mode` is `LTO` and then `aflcc->instrument_mode` set to `INSTRUMENT_PCGUARD` https://github.com/AFLplusplus/AFLplusplus/blob/ee7d69b8175f31f2efb2b3bf15f2bbb29f61aa14/src/afl-cc.c#L1167-L1182
2. `aflcc->have_c` is true when compiling `calls.o` and `mbug.o`, so it goes to `add_optimized_pcguard`, with no LTO methods involved. When linking there is no `-c` so `SanitizerCoverageLTO.so` kicks in, but instrumentation has already done against each object previously, by `SanitizerCoveragePCGUARD.so`. https://github.com/AFLplusplus/AFLplusplus/blob/ee7d69b8175f31f2efb2b3bf15f2bbb29f61aa14/src/afl-cc.c#L2915-L2936


For the first point, earliest commit introduces the code pieces around `// force CFG` can be traced back to 3 years ago, in commit 7a86149: https://github.com/AFLplusplus/AFLplusplus/blob/7a861498c27997cd7be01a5650d54cff3b87a02e/src/afl-cc.c#L1671-L1684   That's reasonable, because for LTO instrumentation both `afl-llvm-lto-instrumentation.so` and `SanitizerCoverageLTO.so` are available at that time, and the later was recommended. So far the previous pass had gone, while the old code can also work well.


For the second point, earliest commit introduces `have_c` is commit 654f389, and that's the key! It was locally defined in `edit_params` and initialized as 0, first set at https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L712 which means the 5 references before all definitely have false logical values, making `if (lto_mode && !have_c)` actually equivalent to `if (lto_mode)`:
https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L465
https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L485
https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L505
https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L528
https://github.com/AFLplusplus/AFLplusplus/blob/654f389e73c9fd5b7e141b33ea28ab0fdda3178f/src/afl-cc.c#L564

4 of them were removed in commit fa2b040, and the last one was handed down to this very day——evaluated before setting linker options and loading LTO pass `SanitizerCoverageLTO.so`. However #1912 ensures consistency with actual situation for `have_c` before each use, just right breaks the trick in this aged code piece.🤣

In summary, I think this should be `if (lto_mode)`, unless there is a counter-example can be provided to prove [*warnings during compilation*](https://github.com/AFLplusplus/AFLplusplus/commit/654f389e73c9fd5b7e141b33ea28ab0fdda3178f) exists because of `-c` in LTO mode (at least not met during my test).


## Broken response file support

Because `aflcc->non_dash` detection shadows all "@..." options. The detection is now placed at very end of `parse_misc_params`, and keeps `final_` unchanged to prevent other misses in next parsing steps.