### PR TITLE
Strip `-Wl,-no-undefined` during compilation

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1962,8 +1962,8 @@ param_st parse_linking_params(aflcc_state_t *aflcc, u8 *cur_argv, u8 scan,
     }
 
   } else if (!strcmp(cur_argv, "-Wl,-z,defs") ||
-
              !strcmp(cur_argv, "-Wl,--no-undefined") ||
+             !strcmp(cur_argv, "-Wl,-no-undefined") ||
              !strcmp(cur_argv, "--no-undefined") ||
              strstr(cur_argv, "afl-compiler-rt") ||
              strstr(cur_argv, "afl-llvm-rt")) {
@@ -3021,4 +3021,3 @@ int main(int argc, char **argv, char **envp) {
   return 0;
 
 }
-


### PR DESCRIPTION
Make the compiler wrapper stripping `-Wl,-no-undefined` in addition to `-Wl,--no-undefined`. Both flags are accepted by `clang` and used by building systems in the wild (e.g., samba will not build without this fix).

An example showcasing the issue:
```
❯ clang -Wl,-no-undefined
/usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../lib64/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
❯ clang -Wl,--no-undefined
/usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../lib64/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```