### PR TITLE
custom_mutator: add fuzz_run

### DIFF
--- a/docs/custom_mutators.md
+++ b/docs/custom_mutators.md
@@ -58,7 +58,8 @@ int afl_custom_post_trim(void *data, unsigned char success);
 size_t afl_custom_havoc_mutation(void *data, unsigned char *buf, size_t buf_size, unsigned char **out_buf, size_t max_size);
 unsigned char afl_custom_havoc_mutation_probability(void *data);
 unsigned char afl_custom_queue_get(void *data, const unsigned char *filename);
-void (*afl_custom_fuzz_send)(void *data, const u8 *buf, size_t buf_size);
+void afl_custom_fuzz_send(void *data, const u8 *buf, size_t buf_size);
+u8 afl_custom_fuzz_run(void *data, unsigned int timeout, int shm_id, unsigned int map_size);
 u8 afl_custom_queue_new_entry(void *data, const unsigned char *filename_new_queue, const unsigned int *filename_orig_queue);
 const char* afl_custom_introspection(my_mutator_t *data);
 void afl_custom_deinit(void *data);
@@ -104,6 +105,9 @@ def queue_get(filename):
     return True
 
 def fuzz_send(buf):
+    pass
+
+def fuzz_run(timeout, shm_id, map_size):
     pass
 
 def queue_new_entry(filename_new_queue, filename_orig_queue):
@@ -199,6 +203,16 @@ def deinit():  # optional for Python
     e.g. via IPC. This replaces some usage of utils/afl_proxy but requires
     that you start the target with afl-fuzz.
     Example: [custom_mutators/examples/custom_send.c](../custom_mutators/examples/custom_send.c)
+
+
+- `fuzz_run` (optional):
+
+    This method can be used if you want to run target yourself, i.e. totally disable forkserver.
+    This is useful when running a daemon, only start and connect once on init, then send command on each run,
+    result in a similar situation with persistent mode.
+    You need to set `__AFL_SHM_ID` and `AFL_MAP_SIZE` environ variables in an execve.
+    Each time called, AFL++ will clear the trace_bits for you, so you don't need to bother with this.
+    Note: only one `fuzz_run` is allowed, even with many custom mutators.
 
 - `queue_new_entry` (optional):
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -346,6 +346,7 @@ enum {
   /* 14 */ PY_FUNC_FUZZ_SEND,
   /* 15 */ PY_FUNC_SPLICE_OPTOUT,
   /* 16 */ PY_FUNC_POST_RUN,
+  /* 17 */ PY_FUNC_FUZZ_RUN,
   PY_FUNC_COUNT
 
 };
@@ -1022,6 +1023,27 @@ struct custom_mutator {
   void (*afl_custom_fuzz_send)(void *data, const u8 *buf, size_t buf_size);
 
   /**
+   * Run program myself. Don't use either forkserver or execve of AFL.
+   * Use together with afl_custom_fuzz_send to get full control of data and run.
+   * @param data pointer returned in afl_custom_init by this custom mutator
+   * @param timeout timeout passed in afl-fuzz argument, in ms
+   * @param shm_id shared memory id, can be set in environ variable for child
+   * @param map_size shared memory map size, can be set in environ variable for
+   * child
+   * @return Program status like afl_fsrv_run_target returns.
+   * typedef enum fsrv_run_result {
+
+   *   FSRV_RUN_OK = 0,
+   *   FSRV_RUN_TMOUT,
+   *   FSRV_RUN_CRASH,
+   *   FSRV_RUN_ERROR,
+   *   FSRV_RUN_NOINST,
+   *   FSRV_RUN_NOBITS,
+   * } fsrv_run_result_t;
+   */
+  u8 (*afl_custom_fuzz_run)(void *data, u32 timeout, s32 shm_id, u32 map_size);
+
+  /**
    * This method can be used if you want to run some code or scripts each time
    * AFL++ executes the target with afl-fuzz.
    *
@@ -1044,6 +1066,7 @@ struct custom_mutator {
    */
   u8 (*afl_custom_queue_new_entry)(void *data, const u8 *filename_new_queue,
                                    const u8 *filename_orig_queue);
+
   /**
    * Deinitialize the custom mutator.
    *
@@ -1086,6 +1109,7 @@ void                   finalize_py_module(void *);
 
 u32         fuzz_count_py(void *, const u8 *, size_t);
 void        fuzz_send_py(void *, const u8 *, size_t);
+u8          fuzz_run_py(void *, u32, s32, u32);
 void        post_run_py(void *);
 size_t      post_process_py(void *, u8 *, size_t, u8 **);
 s32         init_trim_py(void *, u8 *, size_t);

--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -187,6 +187,12 @@ typedef struct afl_forkserver {
 
   u8 persistent_mode;
 
+  /* A duplicate since struct custom_mutator and struct sharedmem_t is
+   * unavaliable in forkserver.h */
+  void *custom_mutator_data;
+  u8 (*custom_fuzz_run)(void *, u32, s32, u32);
+  s32 shm_id;
+
 #ifdef __linux__
   nyx_plugin_handler_t *nyx_handlers;
   char                 *out_dir_path;    /* path to the output directory     */

--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -397,6 +397,18 @@ struct custom_mutator *load_custom_mutator(afl_state_t *afl, const char *fn) {
 
   }
 
+  /* "afl_custom_fuzz_run", optional */
+  mutator->afl_custom_fuzz_run = dlsym(dh, "afl_custom_fuzz_run");
+  if (!mutator->afl_custom_fuzz_run) {
+
+    ACTF("optional symbol 'afl_custom_fuzz_run' not found.");
+
+  } else {
+
+    OKF("Found 'afl_custom_fuzz_run'.");
+
+  }
+
   /* "afl_custom_post_run", optional */
   mutator->afl_custom_post_run = dlsym(dh, "afl_custom_post_run");
   if (!mutator->afl_custom_post_run) {

--- a/src/afl-fuzz-python.c
+++ b/src/afl-fuzz-python.c
@@ -249,6 +249,8 @@ static py_mutator_t *init_py_module(afl_state_t *afl, u8 *module_name) {
         PyObject_GetAttrString(py_module, "queue_get");
     py_functions[PY_FUNC_FUZZ_SEND] =
         PyObject_GetAttrString(py_module, "fuzz_send");
+    py_functions[PY_FUNC_FUZZ_RUN] =
+        PyObject_GetAttrString(py_module, "fuzz_run");
     py_functions[PY_FUNC_POST_RUN] =
         PyObject_GetAttrString(py_module, "post_run");
     py_functions[PY_FUNC_SPLICE_OPTOUT] =
@@ -467,6 +469,12 @@ struct custom_mutator *load_custom_mutator_py(afl_state_t *afl,
   if (py_functions[PY_FUNC_FUZZ_SEND]) {
 
     mutator->afl_custom_fuzz_send = fuzz_send_py;
+
+  }
+
+  if (py_functions[PY_FUNC_FUZZ_RUN]) {
+
+    mutator->afl_custom_fuzz_run = fuzz_run_py;
 
   }
 
@@ -930,6 +938,61 @@ void fuzz_send_py(void *py_mutator, const u8 *buf, size_t buf_size) {
   Py_DECREF(py_args);
 
   if (py_value != NULL) { Py_DECREF(py_value); }
+
+}
+
+u8 fuzz_run_py(void *py_mutator, u32 timeout, s32 shm_id, u32 map_size) {
+
+  PyObject *py_args, *py_value;
+
+  py_args = PyTuple_New(3);
+
+  py_value = PyLong_FromSize_t(timeout);
+  if (!py_value) {
+
+    Py_DECREF(py_args);
+    FATAL("Failed to convert arguments");
+
+  }
+
+  PyTuple_SetItem(py_args, 0, py_value);
+
+  py_value = PyLong_FromLong(shm_id);
+  if (!py_value) {
+
+    Py_DECREF(py_args);
+    FATAL("Failed to convert arguments");
+
+  }
+
+  PyTuple_SetItem(py_args, 1, py_value);
+
+  py_value = PyLong_FromSize_t(map_size);
+  if (!py_value) {
+
+    Py_DECREF(py_args);
+    FATAL("Failed to convert arguments");
+
+  }
+
+  PyTuple_SetItem(py_args, 2, py_value);
+
+  py_value = PyObject_CallObject(
+      ((py_mutator_t *)py_mutator)->py_functions[PY_FUNC_FUZZ_RUN], py_args);
+  Py_DECREF(py_args);
+
+  if (py_value != NULL) {
+
+    long result = PyLong_AsLong(py_value);
+    Py_DECREF(py_value);
+    return (u8)result;
+
+  } else {
+
+    PyErr_Print();
+    FATAL("Call failed");
+
+  }
 
 }
 


### PR DESCRIPTION
This method can be used if you want to run target yourself, i.e. totally disable forkserver.
This is useful when running a daemon, only start and connect once on init, then send command on each run, result in a similar situation with persistent mode.
You need to set `__AFL_SHM_ID` and `AFL_MAP_SIZE` environ variables in an execve.
Each time called, AFL++ will clear the trace_bits for you, so you don't need to bother with this.
Note: only one `fuzz_run` is allowed, even with many custom mutators.

Both C and Python mutator have been tested locally.
The current implementation is a little dirty since it saved some duplicated variables in `afl_forkserver`.
Any review is highly appreciated!