### PR TITLE
Fixes to afl-cc and documentation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,6 +66,10 @@ ifdef MSAN_BUILD
   override LDFLAGS += -fsanitize=memory
 endif
 
+ifdef CODE_COVERAGE
+  override CFLAGS += -D__AFL_CODE_COVERAGE=1
+endif
+
 ifeq "$(findstring android, $(shell $(CC) --version 2>/dev/null))" ""
 ifeq "$(shell echo 'int main() {return 0; }' | $(CC) $(CFLAGS) -Werror -x c - -flto=full -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
 	CFLAGS_FLTO ?= -flto=full

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -1521,7 +1521,7 @@ void add_defs_persistent_mode(aflcc_state_t *aflcc) {
       "({ static volatile const char *_B __attribute__((used,unused)); "
       " _B = (const char*)\"" PERSIST_SIG
       "\"; "
-      "extern int __afl_connected;"
+      "extern __attribute__((visibility(\"default\"))) int __afl_connected;"
 #ifdef __APPLE__
       "__attribute__((visibility(\"default\"))) "
       "int _L(unsigned int) __asm__(\"___afl_persistent_loop\"); "

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2311,6 +2311,11 @@ void add_runtime(aflcc_state_t *aflcc) {
 
     }
 
+  #if __AFL_CODE_COVERAGE
+    // Required for dladdr used in afl-compiler-rt.o
+    insert_param(aflcc, "-ldl");
+  #endif
+
   #if !defined(__APPLE__) && !defined(__sun)
     if (!aflcc->shared_linking && !aflcc->partial_linking)
       insert_object(aflcc, "dynamic_list.txt", "-Wl,--dynamic-list=%s", 0);

--- a/utils/dynamic_covfilter/README.md
+++ b/utils/dynamic_covfilter/README.md
@@ -7,7 +7,12 @@ where doing this dynamically without requiring a new build can be beneficial.
 Especially when dealing with larger builds, it is much more convenient to
 select the target code locations at runtime instead of doing so at build time.
 
-There are two ways of doing this in AFL++:
+There are two ways of doing this in AFL++. Both approaches require a build of
+AFL++ with `CODE_COVERAGE=1`, so make sure to build AFL++ first by invoking
+
+`CODE_COVERAGE=1 make`
+
+Once you have built AFL++, you can choose out of two approaches:
 
 ## Simple Selection with `AFL_PC_FILTER`
 


### PR DESCRIPTION
* Fixes an error with `-ldl` linker flag missing when using `CODE_COVERAGE=1`
* Fixes an error with hidden symbol `__afl_connected` when using `_AFL_LOOP` in code with hidden visibility
* Update documentation of dynamic_covfilter