### PR TITLE
redqueen: time limit for colorization

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -85,6 +85,9 @@
 /* Maximum allowed fails per CMP value. Default: 96 */
 #define CMPLOG_FAIL_MAX 96
 
+/* Maximum time (sec) for colorization of a single input */
+#define CMPLOG_COLORIZATION_TIME_MAX 180
+
 /* -------------------------------------*/
 /* Now non-cmplog configuration options */
 /* -------------------------------------*/


### PR DESCRIPTION
For nondeterministic inputs, or inputs where a large portion of the input bytes break the path (e.g., bytes protected by a checksum), colorization will split the range once for every byte in the input

This is bad: for a 10k input that runs in 100ms, colorization will take upwards of 15 minutes. For larger/slower inputs, it can easily take hours.

This places an upper-bound on the runtime of colorization.

I have no idea what a reasonable timeout for colorization is (I completely made up "3 minutes"). It might be nice to benchmark this (e.g. fuzzbench).