### PR TITLE
issue #2001: fix passing rpath to linker on macOS

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2379,7 +2379,11 @@ void add_runtime(aflcc_state_t *aflcc) {
     if (aflcc->plusplus_mode && strlen(libdir) && strncmp(libdir, "/usr", 4) &&
         strncmp(libdir, "/lib", 4)) {
 
+#ifdef __APPLE__
+      u8 *libdir_opt = strdup("-Wl,-rpath," LLVM_LIBDIR);
+#else
       u8 *libdir_opt = strdup("-Wl,-rpath=" LLVM_LIBDIR);
+#endif
       insert_param(aflcc, libdir_opt);
 
     }


### PR DESCRIPTION
Seems on macOS, `ld` does not want an `=` when specifying `-rpath`.