### PR TITLE
bugfix: free a chunk with a size of 0, it will cause 1 byte oob.

### DIFF
--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -101,6 +101,10 @@ class UnicornSimpleHeap(object):
         #    - Allocate at least 1 4k page of memory to make Unicorn happy
         #    - Add guard pages at the start and end of the region
         total_chunk_size = UNICORN_PAGE_SIZE + ALIGN_PAGE_UP(size) + UNICORN_PAGE_SIZE
+
+        if size == 0:
+            retrun 0
+        
         # Gross but efficient way to find space for the chunk:
         chunk = None
         for addr in range(self.HEAP_MIN_ADDR, self.HEAP_MAX_ADDR, UNICORN_PAGE_SIZE):

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -103,7 +103,7 @@ class UnicornSimpleHeap(object):
         total_chunk_size = UNICORN_PAGE_SIZE + ALIGN_PAGE_UP(size) + UNICORN_PAGE_SIZE
 
         if size == 0:
-            retrun 0
+            return 0
         
         # Gross but efficient way to find space for the chunk:
         chunk = None


### PR DESCRIPTION
Malloc does not check the size. Generally, malloc(0) should return 0 but there will return two pages. Free will use is_buffer_in_chunk to check whether the address is in the chunk. At that time, the chunk.data_addr == total_size . Free pass address and "1" to is_buffer_in_chunk. So cause 1 byte out-of-bound.