### PR TITLE
Fix bug where `-t 1000+` may result in enormous timeouts

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1931,7 +1931,7 @@ afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 
   if (exec_ms > timeout) {
 
-    /* If there was no response from forkserver after timeout seconds,
+    /* If there was no response from forkserver after timeout milliseconds,
     we kill the child. The forkserver should inform us afterwards */
 
     s32 tmp_pid = fsrv->child_pid;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2496,8 +2496,7 @@ int main(int argc, char **argv_orig, char **envp) {
           if ((afl->queue_buf[entry]->exec_us/1000) > max_ms)
             max_ms = afl->queue_buf[entry]->exec_us/1000;
       
-      if (max_ms > afl->fsrv.exec_tmout)
-        afl->fsrv.exec_tmout = max_ms;
+      afl->fsrv.exec_tmout = max_ms;
       afl->timeout_given = 1;
 
     }

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2493,8 +2493,8 @@ int main(int argc, char **argv_orig, char **envp) {
 
       for (entry = 0; entry < afl->queued_items; ++entry)
         if (!afl->queue_buf[entry]->disabled)
-          if (afl->queue_buf[entry]->exec_us > max_ms)
-            max_ms = afl->queue_buf[entry]->exec_us;
+          if ((afl->queue_buf[entry]->exec_us/1000) > max_ms)
+            max_ms = afl->queue_buf[entry]->exec_us/1000;
 
       afl->fsrv.exec_tmout = max_ms;
       afl->timeout_given = 1;

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2496,6 +2496,15 @@ int main(int argc, char **argv_orig, char **envp) {
           if ((afl->queue_buf[entry]->exec_us/1000) > max_ms)
             max_ms = afl->queue_buf[entry]->exec_us/1000;
       
+      // Add 20% as a safety margin, capped to exec_tmout given in -t option
+      max_ms *= 1.2;
+      if(max_ms > afl->fsrv.exec_tmout)
+        max_ms = afl->fsrv.exec_tmout;
+      
+      // Ensure that there is a sensible timeout even for very fast binaries
+      if(max_ms < 5)
+        max_ms = 5;
+
       afl->fsrv.exec_tmout = max_ms;
       afl->timeout_given = 1;
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2495,8 +2495,9 @@ int main(int argc, char **argv_orig, char **envp) {
         if (!afl->queue_buf[entry]->disabled)
           if ((afl->queue_buf[entry]->exec_us/1000) > max_ms)
             max_ms = afl->queue_buf[entry]->exec_us/1000;
-
-      afl->fsrv.exec_tmout = max_ms;
+      
+      if (max_ms > afl->fsrv.exec_tmout)
+        afl->fsrv.exec_tmout = max_ms;
       afl->timeout_given = 1;
 
     }


### PR DESCRIPTION
Using the afl-fuzz option `-t` with `+` results in timeouts that are 1000 times larger than intended, because of a missing conversion between microseconds and milliseconds