### PR TITLE
Issue #2007: add filename extension to /crashes files

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -2003,7 +2003,7 @@ afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
     if (unlikely(fsrv->persistent_record)) {
 
       retval = FSRV_RUN_TMOUT;
-      persistent_out_fmt = "%s/hangs/RECORD:%06u,cnt:%06u";
+      persistent_out_fmt = "%s/hangs/RECORD:%06u,cnt:%06u%s%s";
       goto store_persistent_record;
 
     }
@@ -2039,7 +2039,7 @@ afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
     if (unlikely(fsrv->persistent_record)) {
 
       retval = FSRV_RUN_CRASH;
-      persistent_out_fmt = "%s/crashes/RECORD:%06u,cnt:%06u";
+      persistent_out_fmt = "%s/crashes/RECORD:%06u,cnt:%06u%s%s";
       goto store_persistent_record;
 
     }
@@ -2066,7 +2066,9 @@ store_persistent_record: {
     if (likely(len && data)) {
 
       snprintf(fn, sizeof(fn), persistent_out_fmt, fsrv->persistent_record_dir,
-               fsrv->persistent_record_cnt, writecnt++);
+               fsrv->persistent_record_cnt, writecnt++,
+               afl->file_extension ? "." : "",
+               afl->file_extension ? (const char*)afl->file_extension : "");
       int fd = open(fn, O_CREAT | O_TRUNC | O_WRONLY, 0644);
       if (fd >= 0) {
 

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -528,14 +528,18 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 #ifndef SIMPLE_FILES
 
     queue_fn =
-        alloc_printf("%s/queue/id:%06u,%s", afl->out_dir, afl->queued_items,
+        alloc_printf("%s/queue/id:%06u,%s%s%s", afl->out_dir, afl->queued_items,
                      describe_op(afl, new_bits + is_timeout,
-                                 NAME_MAX - strlen("id:000000,")));
+                                 NAME_MAX - strlen("id:000000,")),
+                     afl->file_extension ? "." : "",
+                     afl->file_extension ? (const char*)afl->file_extension : "");
 
 #else
 
     queue_fn =
-        alloc_printf("%s/queue/id_%06u", afl->out_dir, afl->queued_items);
+        alloc_printf("%s/queue/id_%06u", afl->out_dir, afl->queued_items,
+                     afl->file_extension ? "." : "",
+                     afl->file_extension ? (const char*)afl->file_extension : "");
 
 #endif                                                    /* ^!SIMPLE_FILES */
     fd = open(queue_fn, O_WRONLY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
@@ -739,14 +743,18 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
 #ifndef SIMPLE_FILES
 
-      snprintf(fn, PATH_MAX, "%s/hangs/id:%06llu,%s", afl->out_dir,
+      snprintf(fn, PATH_MAX, "%s/hangs/id:%06llu,%s%s%s", afl->out_dir,
                afl->saved_hangs,
-               describe_op(afl, 0, NAME_MAX - strlen("id:000000,")));
+               describe_op(afl, 0, NAME_MAX - strlen("id:000000,")),
+               afl->file_extension ? "." : "",
+               afl->file_extension ? (const char*)afl->file_extension : "");
 
 #else
 
-      snprintf(fn, PATH_MAX, "%s/hangs/id_%06llu", afl->out_dir,
-               afl->saved_hangs);
+      snprintf(fn, PATH_MAX, "%s/hangs/id_%06llu%s%s", afl->out_dir,
+               afl->saved_hangs,
+               afl->file_extension ? "." : "",
+               afl->file_extension ? (const char*)afl->file_extension : "");
 
 #endif                                                    /* ^!SIMPLE_FILES */
 
@@ -792,14 +800,18 @@ save_if_interesting(afl_state_t *afl, void *mem, u32 len, u8 fault) {
 
 #ifndef SIMPLE_FILES
 
-      snprintf(fn, PATH_MAX, "%s/crashes/id:%06llu,sig:%02u,%s", afl->out_dir,
+      snprintf(fn, PATH_MAX, "%s/crashes/id:%06llu,sig:%02u,%s%s%s", afl->out_dir,
                afl->saved_crashes, afl->fsrv.last_kill_signal,
-               describe_op(afl, 0, NAME_MAX - strlen("id:000000,sig:00,")));
+               describe_op(afl, 0, NAME_MAX - strlen("id:000000,sig:00,")),
+               afl->file_extension ? "." : "",
+               afl->file_extension ? (const char*)afl->file_extension : "");
 
 #else
 
-      snprintf(fn, PATH_MAX, "%s/crashes/id_%06llu_%02u", afl->out_dir,
-               afl->saved_crashes, afl->fsrv.last_kill_signal);
+      snprintf(fn, PATH_MAX, "%s/crashes/id_%06llu_%02u%s%s", afl->out_dir,
+               afl->saved_crashes, afl->fsrv.last_kill_signal,
+               afl->file_extension ? "." : "",
+               afl->file_extension ? (const char*)afl->file_extension : "");
 
 #endif                                                    /* ^!SIMPLE_FILES */
 

--- a/src/afl-fuzz-extras.c
+++ b/src/afl-fuzz-extras.c
@@ -743,7 +743,10 @@ void save_auto(afl_state_t *afl) {
   for (i = 0; i < MIN((u32)USE_AUTO_EXTRAS, afl->a_extras_cnt); ++i) {
 
     u8 *fn =
-        alloc_printf("%s/queue/.state/auto_extras/auto_%06u", afl->out_dir, i);
+        alloc_printf("%s/queue/.state/auto_extras/auto_%06u%s%s", afl->out_dir, i,
+                     afl->file_extension ? "." : "",
+                     afl->file_extension ? (const char*)afl->file_extension : "");
+
     s32 fd;
 
     fd = open(fn, O_WRONLY | O_CREAT | O_TRUNC, DEFAULT_PERMISSION);

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -1157,18 +1157,22 @@ void perform_dry_run(afl_state_t *afl) {
 
 #ifndef SIMPLE_FILES
 
-          snprintf(crash_fn, PATH_MAX, "%s/crashes/id:%06llu,sig:%02u,%s%s",
+          snprintf(crash_fn, PATH_MAX, "%s/crashes/id:%06llu,sig:%02u,%s%s%s%s",
                    afl->out_dir, afl->saved_crashes, afl->fsrv.last_kill_signal,
                    describe_op(afl, 0,
                                NAME_MAX - strlen("id:000000,sig:00,") -
                                    strlen(use_name)),
-                   use_name);
+                   use_name,
+                   afl->file_extension ? "." : "",
+                   afl->file_extension ? (const char*)afl->file_extension : "");
 
 #else
 
-          snprintf(crash_fn, PATH_MAX, "%s/crashes/id_%06llu_%02u",
+          snprintf(crash_fn, PATH_MAX, "%s/crashes/id_%06llu_%02u%s%s",
                    afl->out_dir, afl->saved_crashes,
-                   afl->fsrv.last_kill_signal);
+                   afl->fsrv.last_kill_signal,
+                   afl->file_extension ? "." : "",
+                   afl->file_extension ? (const char*)afl->file_extension : "");
 
 #endif
 
@@ -1439,7 +1443,9 @@ void pivot_inputs(afl_state_t *afl) {
       u32 src_id;
 
       afl->resuming_fuzz = 1;
-      nfn = alloc_printf("%s/queue/%s", afl->out_dir, rsl);
+      nfn = alloc_printf("%s/queue/%s%s%s", afl->out_dir, rsl,
+                         afl->file_extension ? "." : "",
+                         afl->file_extension ? (const char*)afl->file_extension : "");
 
       /* Since we're at it, let's also get the parent and figure out the
          appropriate depth for this entry. */
@@ -1479,12 +1485,16 @@ void pivot_inputs(afl_state_t *afl) {
 
       }
 
-      nfn = alloc_printf("%s/queue/id:%06u,time:0,execs:%llu,orig:%s",
-                         afl->out_dir, id, afl->fsrv.total_execs, use_name);
+      nfn = alloc_printf("%s/queue/id:%06u,time:0,execs:%llu,orig:%s%s%s",
+                         afl->out_dir, id, afl->fsrv.total_execs, use_name,
+                         afl->file_extension ? "." : "",
+                         afl->file_extension ? (const char*)afl->file_extension : "");
 
 #else
 
-      nfn = alloc_printf("%s/queue/id_%06u", afl->out_dir, id);
+      nfn = alloc_printf("%s/queue/id_%06u%s%s", afl->out_dir, id,
+                         afl->file_extension ? "." : "",
+                         afl->file_extension ? (const char*)afl->file_extension : "");
 
 #endif                                                    /* ^!SIMPLE_FILES */
 


### PR DESCRIPTION
This is very helpful for code that inpects a file name extension when determining what code to run.

It's also useful for applications that constrain the user to choose files by extension.