### PR TITLE
Load autodictionary when using new forkserver

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1152,12 +1152,11 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         }
 
-        while (dict_size != 0) {
+        while (offset < dict_size) {
 
-          rlen = read(fsrv->fsrv_st_fd, dict + offset, dict_size);
+          rlen = read(fsrv->fsrv_st_fd, dict + offset, dict_size - offset);
           if (rlen > 0) {
 
-            dict_size -= rlen;
             offset += rlen;
 
           } else {
@@ -1165,7 +1164,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
             FATAL(
                 "Reading autodictionary fail at position %u with %u bytes "
                 "left.",
-                offset, dict_size);
+                offset, dict_size - offset);
 
           }
 


### PR DESCRIPTION
Fixes a bug where the new fork server would decrement dict_size until zero then try to use it as the upper bound for the number of bytes to pass to add_extra_func, causing it to never store any of the tokens.