### PR TITLE
Fix delayed pcmap writing for code coverage with pc-table

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -1617,7 +1617,7 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
       }
 
-      if (pc_filter) {
+      if (pc_filter && !mod_info->next) {
 
         char PcDescr[1024];
         // This function is a part of the sanitizer run-time.
@@ -1644,7 +1644,7 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
       }
 
-      if (__afl_filter_pcs && strstr(mod_info->name, __afl_filter_pcs_module)) {
+      if (__afl_filter_pcs && !mod_info->next && strstr(mod_info->name, __afl_filter_pcs_module)) {
 
         u32 result_index;
         if (locate_in_pcs(PC, &result_index)) {
@@ -1669,7 +1669,11 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
     }
 
-    mod_info->mapped = 1;
+    if (__afl_pcmap_ptr) {
+
+      mod_info->mapped = 1;
+
+    }
 
     if (__afl_debug) {
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -1644,7 +1644,8 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
       }
 
-      if (__afl_filter_pcs && !mod_info->next && strstr(mod_info->name, __afl_filter_pcs_module)) {
+      if (__afl_filter_pcs && !mod_info->next &&
+          strstr(mod_info->name, __afl_filter_pcs_module)) {
 
         u32 result_index;
         if (locate_in_pcs(PC, &result_index)) {
@@ -1669,11 +1670,7 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
     }
 
-    if (__afl_pcmap_ptr) {
-
-      mod_info->mapped = 1;
-
-    }
+    if (__afl_pcmap_ptr) { mod_info->mapped = 1; }
 
     if (__afl_debug) {
 


### PR DESCRIPTION
When using pc-table and a pcmap (e.g. from nyx preload code) to measure code coverage, modules can be loaded (and __sanitizer_cov_pcs_init runs) before the __afl_pcmap_ptr is actually available. For this purpose, the mechanism was previously delaying this mapping step until the pcmap was available. This logic broke with the refactoring for dynamic coverage filtering and this patch restores the old behavior. With the patch, the pc filtering parts of the code will only run on the last loaded module while we still iterate over all available modules every time the callback is made. We mark modules as mapped only if we had the pcmap already when iterating.