### PR TITLE
Replay record loop fix

### DIFF
--- a/include/afl-record-compat.h
+++ b/include/afl-record-compat.h
@@ -24,7 +24,7 @@ unsigned char fuzz_buf[FUZZ_BUF_SIZE];
 
 int __afl_persistent_loop(unsigned int max_cnt) {
 
-  static unsigned int       cycle_cnt = 1;
+  static unsigned int       cycle_cnt = 2;
   static unsigned short int inited = 0;
   char                      tcase[PATH_MAX];
 
@@ -32,7 +32,7 @@ int __afl_persistent_loop(unsigned int max_cnt) {
 
     if (!inited) {
 
-      cycle_cnt = replay_record_cnt;
+      cycle_cnt = replay_record_cnt+1;
       inited = 1;
 
     }

--- a/include/afl-record-compat.h
+++ b/include/afl-record-compat.h
@@ -24,15 +24,15 @@ unsigned char fuzz_buf[FUZZ_BUF_SIZE];
 
 int __afl_persistent_loop(unsigned int max_cnt) {
 
-  static unsigned int       cycle_cnt = 2;
+  static unsigned int       cycle_cnt = 1;
   static unsigned short int inited = 0;
   char                      tcase[PATH_MAX];
 
-  if (is_replay_record) {
+  if (is_replay_record && cycle_cnt) {
 
     if (!inited) {
 
-      cycle_cnt = replay_record_cnt+1;
+      cycle_cnt = replay_record_cnt;
       inited = 1;
 
     }
@@ -59,7 +59,7 @@ int __afl_persistent_loop(unsigned int max_cnt) {
 
   }
 
-  return --cycle_cnt;
+  return cycle_cnt--;
 
 }
 


### PR DESCRIPTION
Needed to fix record compat loop to replay correct number of inputs (and always at least one input) since the cycle cnt will get immediately decremented before first iteration.

Note also that the recent addition of the file extension in saving input in fsrv_run_target in afl-forkserver.c:
```c
               afl->file_extension ? "." : "",
               afl->file_extension ? (const char *)afl->file_extension : "");
```
Breaks compilation, since afl state is not passed to fsrv, passing afl state to fsrv_run_target is a change that will touch several components and will require creating a state variable in the tools, so I did not proceed with fixing this for now.
(But can proceed with the required changes if you want :)).

D.