### PR TITLE
Add -l option for adjustable block deletion performance in tmin

### DIFF
--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -82,7 +82,7 @@ static u8 crash_mode,                  /* Crash-centric mode?               */
     remove_shm = 1,                    /* remove shmem on exit?             */
     debug;                             /* debug mode                        */
 
-static u32 del_len_limit;              /* Minimum block deletion length     */
+static u32 del_len_limit = 1;          /* Minimum block deletion length     */
 
 static volatile u8 stop_soon;          /* Ctrl-C pressed?                   */
 
@@ -423,7 +423,6 @@ next_pass:
 
   del_len = next_pow2(in_len / TRIM_START_STEPS);
   stage_o_len = in_len;
-  if (!del_len_limit) { del_len_limit = 1; }
 
   ACTF(cBRI "Stage #1: " cRST "Removing blocks of data...");
 
@@ -1070,7 +1069,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
         del_len_limit = atoi(optarg);
 
-        if (del_len_limit < 1 || del_len_limit >= TMIN_MAX_FILE) {
+        if (del_len_limit < 1 || del_len_limit > TMIN_MAX_FILE) {
 
           FATAL("Value of -l out of range between 1 and TMIN_MAX_FILE");
 

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -82,6 +82,8 @@ static u8 crash_mode,                  /* Crash-centric mode?               */
     remove_shm = 1,                    /* remove shmem on exit?             */
     debug;                             /* debug mode                        */
 
+static u32 del_len_limit;              /* Minimum block deletion length     */
+
 static volatile u8 stop_soon;          /* Ctrl-C pressed?                   */
 
 static afl_forkserver_t *fsrv;
@@ -421,6 +423,7 @@ next_pass:
 
   del_len = next_pow2(in_len / TRIM_START_STEPS);
   stage_o_len = in_len;
+  if (!del_len_limit) { del_len_limit = 1; }
 
   ACTF(cBRI "Stage #1: " cRST "Removing blocks of data...");
 
@@ -480,7 +483,7 @@ next_del_blksize:
 
   }
 
-  if (del_len > 1 && in_len >= 1) {
+  if (del_len > del_len_limit && in_len >= 1) {
 
     del_len /= 2;
     goto next_del_blksize;
@@ -796,8 +799,9 @@ static void usage(u8 *argv0) {
       "Minimization settings:\n"
 
       "  -e            - solve for edge coverage only, ignore hit counts\n"
-      "  -x            - treat non-zero exit codes as crashes\n\n"
-      "  -H            - minimize a hang (hang mode)\n"
+      "  -l bytes      - set minimum block deletion length to speed up minimization\n"
+      "  -x            - treat non-zero exit codes as crashes\n"
+      "  -H            - minimize a hang (hang mode)\n\n"
 
       "For additional tips, please consult %s/README.md.\n\n"
 
@@ -829,8 +833,9 @@ static void usage(u8 *argv0) {
 
 int main(int argc, char **argv_orig, char **envp) {
 
-  s32    opt;
-  u8     mem_limit_given = 0, timeout_given = 0, unicorn_mode = 0, use_wine = 0;
+  s32 opt;
+  u8  mem_limit_given = 0, timeout_given = 0, unicorn_mode = 0, use_wine = 0,
+     del_limit_given = 0;
   char **use_argv;
 
   char **argv = argv_cpy_dup(argc, argv_orig);
@@ -846,7 +851,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   SAYF(cCYA "afl-tmin" VERSION cRST " by Michal Zalewski\n");
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:B:xeAOQUWXYHh")) > 0) {
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:l:B:xeAOQUWXYHh")) > 0) {
 
     switch (opt) {
 
@@ -1053,6 +1058,24 @@ int main(int argc, char **argv_orig, char **envp) {
         if (mask_bitmap) { FATAL("Multiple -B options not supported"); }
         mask_bitmap = ck_alloc(map_size);
         read_bitmap(optarg, mask_bitmap, map_size);
+        break;
+
+      case 'l':
+        if (del_limit_given) { FATAL("Multiple -l options not supported"); }
+        del_limit_given = 1;
+
+        if (!optarg) { FATAL("Wrong usage of -l"); }
+
+        if (optarg[0] == '-') { FATAL("Dangerously low value of -l"); }
+
+        del_len_limit = atoi(optarg);
+
+        if (del_len_limit < 1 || del_len_limit >= TMIN_MAX_FILE) {
+
+          FATAL("Value of -l out of range between 1 and TMIN_MAX_FILE");
+
+        }
+
         break;
 
       case 'h':


### PR DESCRIPTION
- Introduce the -l option to set min block deletion length using powers of 2 (e.g., 1, 2, 4, 8, 16, ...).
- This enables a trade-off between minimization thoroughness and speed.
- Adjusting del_len_limit allows for faster processing, as doubling it roughly halves the minimization time.
closes #2032  