### PR TITLE
bugfix: update_firda_version can't get the newest version of frida

### DIFF
--- a/frida_mode/update_frida_version.sh
+++ b/frida_mode/update_frida_version.sh
@@ -2,7 +2,7 @@
 test -n "$1" && { echo This script has no options. It updates the referenced Frida version in GNUmakefile to the most current one. ; exit 1 ; }
 
 OLD=$(grep -E '^GUM_DEVKIT_VERSION=' GNUmakefile 2>/dev/null|awk -F= '{print$2}')
-NEW=$(curl https://github.com/frida/frida/releases/ 2>/dev/null|grep -E 'frida-gum-devkit-[0-9.]*-linux-x86_64'|head -n 1|sed 's/.*frida-gum-devkit-//'|sed 's/-linux.*//')
+NEW=$(curl https://github.com/frida/frida/releases/ 2>/dev/null|grep 'Frida\ [0-9.]*'|head -n 1|sed 's/.*Frida\ //'| sed 's/<\/h2>//')
 
 echo Current set version: $OLD
 echo Newest available version: $NEW


### PR DESCRIPTION
The method of getting the newest version of Frida is invalid. Need update.