### PR TITLE
Fix build_qemu_support.sh static builds

### DIFF
--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -215,8 +215,10 @@ if [ "$STATIC" = "1" ]; then
   echo Building STATIC binary
 
   # static PIE causes https://github.com/AFLplusplus/AFLplusplus/issues/892
+  # plugin support requires dynamic linking
   QEMU_CONF_FLAGS="$QEMU_CONF_FLAGS \
     --static --disable-pie \
+    --disable-plugins \
     --extra-cflags=-DAFL_QEMU_STATIC_BUILD=1 \
     "
 


### PR DESCRIPTION
The recently added config option '--enable-plugins' breaks static builds (STATIC=1) of qemuafl.

For static builds, override this option with '--disable-plugins'.