### PR TITLE
Clarify that oss-fuzz doesn't randomize builds anymore

### DIFF
--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -958,7 +958,7 @@ too long for your overall available fuzz run time.
    campaign but not good for short CI runs.
 
 How this can look like can, e.g., be seen at AFL++'s setup in Google's
-[oss-fuzz](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/compile_afl)
+[previous oss-fuzz version](https://github.com/google/oss-fuzz/blob/3e2c5312417d1a6f9564472f3df1fd27759b289d/infra/base-images/base-builder/compile_afl)
 and
 [clusterfuzz](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py).
 


### PR DESCRIPTION
Hello!

oss-fuzz doesn't randomize the afl build args, it was removed a while ago. I figured this after a bit of frustation not understanding why my builds weren't randomized even though it is mentioned both in aflplusplus documentation and clusterfuzz documentation ( https://google.github.io/clusterfuzz/setting-up-fuzzing/libfuzzer-and-afl/ )

So, a minor update in the documentation that should clarify for future readers and still provide access to the example. 