### PR TITLE
Fix `afl_whatsup` findings timer

### DIFF
--- a/afl-whatsup
+++ b/afl-whatsup
@@ -111,7 +111,13 @@ if [ -z "$NO_COLOR" ]; then
   RESET="$NC"
 fi
 
-CUR_TIME=`cat /proc/uptime | awk '{printf "%.0f\n", $1}'`
+PLATFORM=`uname -s`
+if [ "$PLATFORM" = "Linux" ] ; then
+  CUR_TIME=`cat /proc/uptime | awk '{printf "%.0f\n", $1}'`
+else
+  # This will lead to inacurate results but will prevent the script from breaking on platforms other than Linux
+  CUR_TIME=`date +%s`
+fi
 
 TMP=`mktemp -t .afl-whatsup-XXXXXXXX` || TMP=`mktemp -p /data/local/tmp .afl-whatsup-XXXXXXXX` || TMP=`mktemp -p /data/local/tmp .afl-whatsup-XXXXXXXX` || exit 1
 trap "rm -f $TMP" 1 2 3 13 15

--- a/afl-whatsup
+++ b/afl-whatsup
@@ -111,7 +111,7 @@ if [ -z "$NO_COLOR" ]; then
   RESET="$NC"
 fi
 
-CUR_TIME=`date +%s`
+CUR_TIME=`cat /proc/uptime | awk '{printf "%.0f\n", $1}'`
 
 TMP=`mktemp -t .afl-whatsup-XXXXXXXX` || TMP=`mktemp -p /data/local/tmp .afl-whatsup-XXXXXXXX` || TMP=`mktemp -p /data/local/tmp .afl-whatsup-XXXXXXXX` || exit 1
 trap "rm -f $TMP" 1 2 3 13 15


### PR DESCRIPTION
Since https://github.com/AFLplusplus/AFLplusplus/pull/2043 was merged, AFL++ has been using the computer's [monotonic time](https://www.man7.org/linux/man-pages/man3/clock_gettime.3.html) instead of UNIX time for all timing statistics.

`afl_whatsup` is still using UNIX time for its monitoring operations, and is showing wrong results (e.g. `Time without finds : 19845 days`).

This PR makes `afl_whatsup` use `/proc/uptime`, which is equivalent (on Linux) to the monotonic time used by AFL++.