### PR TITLE
Re-enable i386

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -525,7 +525,7 @@ void find_built_deps(aflcc_state_t *aflcc) {
 
   char *ptr = NULL;
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__i386__)
   if ((ptr = find_object(aflcc, "afl-as")) != NULL) {
 
   #ifndef __APPLE__


### PR DESCRIPTION
Was disabled in 136febaf6855ac1e04c8ea4ecbcb84eb42de2143

Closes: #2081