### PR TITLE
Allow setting different file permissions on command line

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -50,7 +50,9 @@
 #define STRATEGY_SWITCH_TIME 1000
 
 /* Default file permission umode when creating files (default: 0600) */
+#ifndef DEFAULT_PERMISSION
 #define DEFAULT_PERMISSION 0600
+#endif
 
 /* SkipDet's global configuration */
 


### PR DESCRIPTION
Now, we can build with e.g.:
$ make CPPFLAGS=-DDEFAULT_PERMISSION=0644
without these warnings:
./include/config.h:54:9: warning: DEFAULT_PERMISSION macro redefined
  [-Wmacro-redefined]