### PR TITLE
Fix afl-fuzz -G option not configuring maximum input data size for nyx

### DIFF
--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -188,6 +188,8 @@ typedef struct afl_forkserver {
 
   u8 persistent_mode;
 
+  u32 max_length;
+
 #ifdef __linux__
   nyx_plugin_handler_t *nyx_handlers;
   char                 *out_dir_path;    /* path to the output directory     */

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -578,7 +578,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
     void *nyx_config = fsrv->nyx_handlers->nyx_config_load(fsrv->target_path);
 
     fsrv->nyx_handlers->nyx_config_set_workdir_path(nyx_config, workdir_path);
-    fsrv->nyx_handlers->nyx_config_set_input_buffer_size(nyx_config, MAX_FILE);
+    fsrv->nyx_handlers->nyx_config_set_input_buffer_size(nyx_config, fsrv->max_length);
     fsrv->nyx_handlers->nyx_config_set_input_buffer_write_protection(nyx_config,
                                                                      true);
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1805,7 +1805,8 @@ int main(int argc, char **argv_orig, char **envp) {
   afl_realloc(AFL_BUF_PARAM(ex), min_alloc);
 
   afl->fsrv.use_fauxsrv = afl->non_instrumented_mode == 1 || afl->no_forkserver;
-
+  afl->fsrv.max_length = afl->max_length;
+   
   #ifdef __linux__
   if (!afl->fsrv.nyx_mode) {
 


### PR DESCRIPTION
Here's a quick fix for the issue https://github.com/AFLplusplus/AFLplusplus/issues/2088#issue-2295042016 , not sure if it's coding compliant, but it works correctly in my tests

before
![image](https://github.com/AFLplusplus/AFLplusplus/assets/42004790/8747fde6-17c2-4659-aa7a-9ab7aa37de9e)

after
![image](https://github.com/AFLplusplus/AFLplusplus/assets/42004790/2e79e80a-1a95-406d-9d6b-bb701a93722e)
