### PR TITLE
Fix runtime underflow & -V exiting before syncing

### DIFF
--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -1193,4 +1193,3 @@ common_fuzz_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
   return 0;
 
 }
-

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1806,7 +1806,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   afl->fsrv.use_fauxsrv = afl->non_instrumented_mode == 1 || afl->no_forkserver;
   afl->fsrv.max_length = afl->max_length;
-   
+
   #ifdef __linux__
   if (!afl->fsrv.nyx_mode) {
 
@@ -2593,14 +2593,6 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         sync_fuzzers(afl);
-
-        if (!afl->queue_cycle && afl->afl_env.afl_import_first) {
-
-          // real start time, we reset, so this works correctly with -V
-          afl->start_time = get_cur_time();
-
-        }
-
       }
 
       ++afl->queue_cycle;
@@ -3115,4 +3107,3 @@ stop_fuzzing:
 }
 
 #endif                                                          /* !AFL_LIB */
-


### PR DESCRIPTION
print_stats sets exit_soon even while syncing, this leaves -V 0 still broken, as we don't finish syncing.

Additionally, the change that introduced the previous -V fix also broke the runtime tracking, as runtime needs to include all time including sync, splice etc. This caused an underflow in the reported runtime. When resetting the runtime in afl-fuzz.c