### PR TITLE
Fix dynamic_lookup linker flag for Apple clang

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2366,8 +2366,7 @@ static void add_aflpplib(aflcc_state_t *aflcc) {
     insert_param(aflcc, afllib);
 
 #ifdef __APPLE__
-    insert_param(aflcc, "-Wl,-undefined");
-    insert_param(aflcc, "dynamic_lookup");
+    insert_param(aflcc, "-Wl,-undefined,dynamic_lookup");
 #endif
 
   }


### PR DESCRIPTION
Fixes #2098 

The `dynamic_lookup` flag wasn't being forwarded to the linker causing the compilation to fail when using the `-fsanitize=fuzzer` flag.

See issue linked above for a more detailed description.