### PR TITLE
fix: testcache hangs for large test cases

### DIFF
--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -1301,7 +1301,8 @@ inline u8 *queue_testcase_get(afl_state_t *afl, struct queue_entry *q) {
     static u32 do_once = 0;  // because even threaded we would want this. WIP
 
     while (unlikely(
-        afl->q_testcase_cache_size + len >= afl->q_testcase_max_cache_size ||
+        (afl->q_testcase_cache_size + len >= afl->q_testcase_max_cache_size &&
+         afl->q_testcase_cache_count > 1) ||
         afl->q_testcase_cache_count >= afl->q_testcase_max_cache_entries - 1)) {
 
       /* We want a max number of entries to the cache that we learn.


### PR DESCRIPTION
This changes when the test cache will be declared "full", which triggers an eviction. This PR prevents evictions (when they would normally happen based on test cache _size_) when there is only one (large) entry in the test cache. This avoids an edge case where we try to evict the only entry in the cache, but that entry is `afl-> queue_cur`.

Fixes #2101 

I tested this 8x one fuzzbench target for several hours, and it fixes the issue and appears to have no ill side-effects.