### PR TITLE
Fix undefined behavior by casting to uint64_t before left shift

### DIFF
--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -59,7 +59,7 @@ static inline unsigned int hash(uint64_t key) {
 bool hashmap_search_and_add(uint8_t type, uint64_t key) {
 
   if (unlikely(type >= 8)) return false;
-  uint64_t     val = (key & 0xf8ffffffffffffff) + (type << 56);
+  uint64_t     val = (key & 0xf8ffffffffffffff) + ((uint64_t)type << 56);
   unsigned int index = hash(val);
   HashNode    *node = _hashmap->table[index];
   while (node) {


### PR DESCRIPTION
According to the C standard, left-shifting a value by an amount greater than or equal to the width of its promoted type results in undefined behavior. To prevent potential unexpected results, explicitly cast the uint8_t variable type to uint64_t before performing the left shift operation by 56 bits. This ensures the operation is well-defined and adheres to the standard.

Fixes: 40df85d1 ("adjust cmplog header")