### PR TITLE
Fix memory allocation check in aflpp custom mutators

### DIFF
--- a/custom_mutators/aflpp/aflpp.c
+++ b/custom_mutators/aflpp/aflpp.c
@@ -48,7 +48,7 @@ size_t afl_custom_fuzz(my_mutator_t *data, uint8_t *buf, size_t buf_size,
 
     u8 *ptr = realloc(data->buf, max_size);
 
-    if (ptr) {
+    if (!ptr) {
 
       return 0;
 

--- a/custom_mutators/aflpp/standalone/aflpp-standalone.c
+++ b/custom_mutators/aflpp/standalone/aflpp-standalone.c
@@ -53,7 +53,7 @@ size_t afl_custom_fuzz(my_mutator_t *data, uint8_t *buf, size_t buf_size,
 
     u8 *ptr = realloc(data->buf, max_size);
 
-    if (ptr) {
+    if (!ptr) {
 
       return 0;
 


### PR DESCRIPTION
The memory allocation check in afl_custom_fuzz function was incorrect. The condition was erroneously checking if ptr was non-null, whereas it should return 0 when ptr is null. Correct the condition to properly handle memory allocation failures.

Fixes: 32ffa266 ("max_len support")