### PR TITLE
Fix signed integer overflow in radamsa

### DIFF
--- a/custom_mutators/radamsa/libradamsa.c
+++ b/custom_mutators/radamsa/libradamsa.c
@@ -3707,7 +3707,7 @@ typedef intptr_t     wdiff;
   1024 * 1024 * 8         /* static malloc'd heap size if used as a library */
 #define FBITS 24             /* bits in fixnum, on the way to 24 and beyond */
 #define FMAX                                                       \
-  ((1 << FBITS) - 1)  /* maximum fixnum (and most negative fixnum) \
+  ((1U << FBITS) - 1)  /* maximum fixnum (and most negative fixnum) \
                        */
 #define MAXOBJ 0xffff                /* max words in tuple including header */
 #define MAXPAYL                                                \


### PR DESCRIPTION
When UBSan was enabled and 'make test' was executed, the following runtime error was observed:

libradamsa.c:26055:29: runtime error: left shift of 16777215 by 8 places cannot be represented in type 'int'

This issue was caused by a left shift operation on a signed integer. The fix involved changing the integer literal to an unsigned integer by adding a 'U' suffix, ensuring the left shift operation produces the correct value without overflow.

Fixes: 8178f4df ("remove radamsa, add radamsa custom mutator")