### PR TITLE
Auto disable memory limits for FASAN

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1873,6 +1873,13 @@ int main(int argc, char **argv_orig, char **envp) {
 
           OKF("Using Frida Address Sanitizer Mode");
 
+          if (afl->fsrv.mem_limit) {
+
+            WARNF("in the Frida Address Sanitizer Mode we disable all memory limits");
+            afl->fsrv.mem_limit = 0;
+
+          }
+
           fasan_check_afl_preload(afl_preload);
 
           setenv("ASAN_OPTIONS", "detect_leaks=false", 1);


### PR DESCRIPTION
This change automattically disables memory limits of Address Sanitizer Mode is enabled just like if [__SANITIZE_ADDRESS__](https://github.com/AFLplusplus/AFLplusplus/blob/36db3428ab16156dd72196213d2a02a5eadaed11/src/afl-fuzz.c#L1462C1-L1468C4) is defined.