### PR TITLE
Optimize bit counting using __builtin_popcount

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -116,6 +116,10 @@
   #include <TargetConditionals.h>
 #endif
 
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+#endif
+
 #undef LIST_FOREACH                                 /* clashes with FreeBSD */
 #include "list.h"
 #ifndef SIMPLE_FILES

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -75,9 +75,13 @@ u32 count_bits(afl_state_t *afl, u8 *mem) {
 
     }
 
+#if __has_builtin(__builtin_popcount)
+    ret += __builtin_popcount(v);
+#else
     v -= ((v >> 1) & 0x55555555);
     v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
     ret += (((v + (v >> 4)) & 0xF0F0F0F) * 0x01010101) >> 24;
+#endif
 
   }
 


### PR DESCRIPTION
Use the __builtin_popcount intrinsic to optimize the bit counting function if the compiler supports it. This change replaces the manual bit counting algorithm with the more efficient built-in function, which leverages hardware support on compatible processors.

This modification ensures that the code remains backward-compatible by falling back to the original implementation when __builtin_popcount is not available.