### PR TITLE
Enabled afl-gcc and afl-clang for ARM

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -525,7 +525,7 @@ void find_built_deps(aflcc_state_t *aflcc) {
 
   char *ptr = NULL;
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__ || defined(__arm__))
   if ((ptr = find_object(aflcc, "afl-as")) != NULL) {
 
   #ifndef __APPLE__


### PR DESCRIPTION
Enable afl-gcc and afl-clang for 32-bit ARM. Tested and working on Debian armv7 docker image.