### PR TITLE
Enable afl-gcc and afl-clang for ARM

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -525,7 +525,7 @@ void find_built_deps(aflcc_state_t *aflcc) {
 
   char *ptr = NULL;
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__ || defined(__arm__))
   if ((ptr = find_object(aflcc, "afl-as")) != NULL) {
 
   #ifndef __APPLE__


### PR DESCRIPTION
# Enable afl-gcc and afl-clang for 32-bit ARM

This issue was closed before, so I will provide proof that both instrumenting and fuzzing works.
I used an example AFL++ exercise to instrument and fuzz libexif. In addition, I will use the output of afl-fuzz to show coverage.

Note: AFL shows the execution as slow since the docker container utilizes qemu for system emulation

https://github.com/antonio-morales/Fuzzing101/blob/main/Exercise%202/Readme.md

## Compiling:

`root@b3f9e48be050:~/fuzzing_libexif/libexif-libexif-0_6_14-release# make && make install`

![2024-07-08T16:21:19,983908100-05:00](https://github.com/AFLplusplus/AFLplusplus/assets/37560904/8d522b91-a6a5-4121-86a2-2e0497cbaea8)

`root@b3f9e48be050:~/fuzzing_libexif/exif-exif-0_6_15-release# make && make install`

![2024-07-08T16:22:40,980235278-05:00](https://github.com/AFLplusplus/AFLplusplus/assets/37560904/4f02e159-c824-43a1-a6ef-ee93bb1be1ca)


## Fuzzing:

`afl-fuzz -i $HOME/fuzzing_libexif/exif-samples-master/jpg/ -o $HOME/fuzzing_libexif/out/ -s 123 -- $HOME/fuzzing_libexif/install/bin/exif @@`

![2024-07-08T16:10:41,744936228-05:00](https://github.com/AFLplusplus/AFLplusplus/assets/37560904/c6fe3aa2-478e-4f8b-ba69-36d16df00b6c)

## Coverage

![2024-07-08T16:19:49,985004511-05:00](https://github.com/AFLplusplus/AFLplusplus/assets/37560904/781d34cf-f1df-4b8f-b23d-292a663b2bc6)
