### PR TITLE
Some fixups to the GNUmakefile.llvm

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -32,6 +32,9 @@ VERSION     = $(shell grep '^$(HASH)define VERSION ' ./config.h | cut -d '"' -f2
 
 SYS = $(shell uname -s)
 
+override LLVM_TOO_NEW_DEFAULT := 18
+override LLVM_TOO_OLD_DEFAULT := 13
+
 ifeq "$(SYS)" "OpenBSD"
   LLVM_CONFIG ?= $(BIN_PATH)/llvm-config
   HAS_OPT = $(shell test -x $(BIN_PATH)/opt && echo 0 || echo 1)
@@ -39,24 +42,30 @@ ifeq "$(SYS)" "OpenBSD"
     $(warning llvm_mode needs a complete llvm installation (versions 6.0 up to 13) -> e.g. "pkg_add llvm-7.0.1p9")
   endif
 else
-  LLVM_CONFIG ?= llvm-config
+  # Small function to use Bash to detect the latest available clang and clang++ binaries, if using them by that name fails
+  override _CLANG_VERSIONS_TO_TEST := $(patsubst %,-%,$(shell seq $(LLVM_TOO_NEW_DEFAULT) -1 $(LLVM_TOO_OLD_DEFAULT)))
+  detect_newest=$(shell for v in "" $(_CLANG_VERSIONS_TO_TEST); do test -n "$$(command -v -- $1$$v)" && { echo "$1$$v"; break; }; done)
+  LLVM_CONFIG ?= $(call detect_newest,llvm-config)
 endif
 
-LLVMVER  = $(shell $(LLVM_CONFIG) --version 2>/dev/null | sed 's/git//' | sed 's/svn//' )
-LLVM_MAJOR = $(shell $(LLVM_CONFIG) --version 2>/dev/null | sed 's/\..*//' )
-LLVM_MINOR = $(shell $(LLVM_CONFIG) --version 2>/dev/null | sed 's/.*\.//' | sed 's/git//' | sed 's/svn//' | sed 's/ .*//' | sed 's/rc.*//' )
-LLVM_UNSUPPORTED = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^[0-2]\.|^3.[0-8]\.' && echo 1 || echo 0 )
-LLVM_TOO_NEW = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^19|^2[0-9]' && echo 1 || echo 0 )
-LLVM_TOO_OLD = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^[1-9]\.|^1[012]\.' && echo 1 || echo 0 )
-LLVM_NEW_API = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^1[0-9]' && echo 1 || echo 0 )
-LLVM_NEWER_API = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^1[6-9]' && echo 1 || echo 0 )
-LLVM_13_OK = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^1[3-9]' && echo 1 || echo 0 )
-LLVM_HAVE_LTO = $(shell $(LLVM_CONFIG) --version 2>/dev/null | grep -E -q '^1[2-9]' && echo 1 || echo 0 )
-LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir 2>/dev/null)
-LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir 2>/dev/null)
-LLVM_STDCXX = gnu++11
-LLVM_APPLE_XCODE = $(shell $(CC) -v 2>&1 | grep -q Apple && echo 1 || echo 0)
-LLVM_LTO   = 0
+override LLVM_RAW_VER        := $(shell $(LLVM_CONFIG) --version 2>/dev/null)
+LLVMVER                      := $(subst svn,,$(subst git,,$(LLVM_RAW_VER)))
+LLVM_MAJOR                   := $(firstword $(subst ., ,$(LLVMVER)))
+LLVM_MINOR                   := $(firstword $(subst ., ,$(subst $(LLVM_MAJOR).,,$(LLVMVER))))
+LLVM_TOO_NEW                 := $(shell test $(LLVM_MAJOR) -gt $(LLVM_TO_NEW_LIMIT) && echo 1 || echo 0)
+LLVM_TOO_OLD                 := $(shell test $(LLVM_MAJOR) -lt $(LLVM_TO_OLD_LIMIT) && echo 1 || echo 0)
+LLVM_NEW_API                 := $(shell test $(LLVM_MAJOR) -ge 10 && echo 1 || echo 0)
+LLVM_NEWER_API               := $(shell test $(LLVM_MAJOR) -ge 16 && echo 1 || echo 0)
+LLVM_13_OK                   := $(shell test $(LLVM_MAJOR) -ge 13 && echo 1 || echo 0)
+LLVM_HAVE_LTO                := $(shell test $(LLVM_MAJOR) -ge 12 && echo 1 || echo 0)
+LLVM_BINDIR                  := $(shell $(LLVM_CONFIG) --bindir 2>/dev/null)
+LLVM_LIBDIR                  := $(shell $(LLVM_CONFIG) --libdir 2>/dev/null)
+LLVM_STDCXX                  := gnu++11
+LLVM_APPLE_XCODE             := $(shell $(CC) -v 2>&1 | grep -q Apple && echo 1 || echo 0)
+LLVM_LTO                     := 0
+LLVM_UNSUPPORTED             := $(shell echo "$(LLVMVER)" | grep -E -q '^[0-2]\.|^3\.[0-8]\.' && echo 1 || echo 0)
+# Uncomment to see the values assigned above
+# $(foreach var,LLVM_CONFIG LLVMVER LLVM_MAJOR LLVM_MINOR LLVM_TOO_NEW LLVM_TOO_OLD LLVM_TOO_NEW_DEFAULT LLVM_TOO_OLD_DEFAULT LLVM_NEW_API LLVM_NEWER_API LLVM_13_OK LLVM_HAVE_LTO LLVM_BINDIR LLVM_LIBDIR LLVM_STDCXX LLVM_APPLE_XCODE LLVM_LTO LLVM_UNSUPPORTED,$(warning $(var) = $($(var))))
 
 ifeq "$(LLVMVER)" ""
   $(warning [!] llvm_mode needs llvm-config, which was not found. Set LLVM_CONFIG to its path and retry.)
@@ -245,7 +254,7 @@ endif
 
 AFL_CLANG_FUSELD=
 ifeq "$(LLVM_LTO)" "1"
-  ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=`command -v ld` -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
+  ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=$$(command -v ld) -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
     AFL_CLANG_FUSELD=1
     ifeq "$(shell echo 'int main() {return 0; }' | $(CLANG_BIN) -x c - -fuse-ld=ld.lld --ld-path=$(AFL_REAL_LD) -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
       AFL_CLANG_LDPATH=1
@@ -300,8 +309,8 @@ endif
 ifneq "$(LLVM_CONFIG)" ""
   CLANG_CFL += -I$(shell dirname $(LLVM_CONFIG))/../include
 endif
-CLANG_CPPFL  = `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fno-exceptions -fPIC $(CXXFLAGS) $(CPPFLAGS) -Wno-deprecated-declarations
-CLANG_LFL    = `$(LLVM_CONFIG) --ldflags` $(LDFLAGS)
+CLANG_CPPFL  = $$($(LLVM_CONFIG) --cxxflags) -fno-rtti -fno-exceptions -fPIC $(CXXFLAGS) $(CPPFLAGS) -Wno-deprecated-declarations
+CLANG_LFL    = $$($(LLVM_CONFIG) --ldflags) $(LDFLAGS)
 
 # wasm fuzzing: disable thread-local storage and unset LLVM debug flag
 ifdef WAFL_MODE
@@ -319,7 +328,7 @@ else
 endif
 
 ifeq "$(SYS)" "OpenBSD"
-  CLANG_LFL += `$(LLVM_CONFIG) --libdir`/libLLVM.so
+  CLANG_LFL += $$($(LLVM_CONFIG) --libdir)/libLLVM.so
   CLANG_CPPFL += -mno-retpoline
   CFLAGS += -mno-retpoline
   # Needed for unwind symbols
@@ -417,7 +426,7 @@ endif
 endif
 
 instrumentation/afl-llvm-common.o: instrumentation/afl-llvm-common.cc instrumentation/afl-llvm-common.h
-	$(CXX) $(CFLAGS) $(CPPFLAGS) `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fPIC -std=$(LLVM_STDCXX) -c $< -o $@ 
+	$(CXX) $(CFLAGS) $(CPPFLAGS) $$($(LLVM_CONFIG) --cxxflags) -fno-rtti -fPIC -std=$(LLVM_STDCXX) -c $< -o $@ 
 
 ./afl-llvm-pass.so: instrumentation/afl-llvm-pass.so.cc instrumentation/afl-llvm-common.o | test_deps
 ifeq "$(LLVM_MIN_4_0_1)" "0"


### PR DESCRIPTION
* rely less on the shell and more on GNU make to parse the versions
* fixed retrieval of minor version (for 18.1.8 it gave 8 instead of 1!)
* auto-detection of llvm-config within the supported version range
* replaced backticks by `$(...)` syntax
* tested against `busybox static-sh`, `bash`, `dash` and `csh`

NB: Please advise if there are any rules I failed to observe or so. Didn't notice anything specific to the make files.