### PR TITLE
Fix missed updates of alias table when INTROSPECTION is on

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2815,7 +2815,7 @@ int main(int argc, char **argv_orig, char **envp) {
   // (void)nice(-20);  // does not improve the speed
 
   #ifdef INTROSPECTION
-  u32 prev_saved_crashes = 0, prev_saved_tmouts = 0;
+  u32 prev_saved_crashes = 0, prev_saved_tmouts = 0, stat_prev_queued_items = 0;
   #endif
   u32 prev_queued_items = 0, runs_in_current_cycle = (u32)-1;
   u8  skipped_fuzz;
@@ -3132,10 +3132,11 @@ int main(int argc, char **argv_orig, char **envp) {
 
       } else {
 
-        if (unlikely(afl->queued_items > prev_queued_items)) {
+        if (unlikely(afl->queued_items > stat_prev_queued_items)) {
 
-          afl->queue_cur->stats_finds += afl->queued_items - prev_queued_items;
-          prev_queued_items = afl->queued_items;
+          afl->queue_cur->stats_finds +=
+              afl->queued_items - stat_prev_queued_items;
+          stat_prev_queued_items = afl->queued_items;
 
         }
 


### PR DESCRIPTION
In src/afl-fuzz.c `prev_queued_items` is used to decide whether the alias table should be recreated through the comparison against `afl->queued_items`.
https://github.com/AFLplusplus/AFLplusplus/blob/43f462c91b3699b66e4aa1c5703b30f5189b5618/src/afl-fuzz.c#L3103-L3117

However, this variable is also updated to `afl->queued_items` when INTROSPECTION is enabled and the `fuzz_one` appends seeds.
https://github.com/AFLplusplus/AFLplusplus/blob/43f462c91b3699b66e4aa1c5703b30f5189b5618/src/afl-fuzz.c#L3135-L3140

Due to the update of `prev_queued_items` when INTROSPECTION is on, alias table may not be recreated when it actually should be.

This can lead to potential heap buffer-overflow in `select_next_queue_entry` due to the lack of `afl_realloc` called in `create_alias_table`.

This patch fixes this bug by utilizing another variable for the INTROSPECTION part like other variables such as `prev_saved_tmouts`.