### PR TITLE
check the sync_id length once

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2717,7 +2717,11 @@ void fix_up_sync(afl_state_t *afl) {
 
   }
 
-  if (strlen(afl->sync_id) > 32) { FATAL("Fuzzer ID too long"); }
+  if (strlen(afl->sync_id) > 50) {
+
+    FATAL("sync_id max length is 50 characters");
+
+  }
 
   x = alloc_printf("%s/%s", afl->out_dir, afl->sync_id);
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1610,17 +1610,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   #endif
 
-  if (afl->sync_id) {
-
-    if (strlen(afl->sync_id) > 50) {
-
-      FATAL("sync_id max length is 50 characters");
-
-    }
-
-    fix_up_sync(afl);
-
-  }
+  if (afl->sync_id) { fix_up_sync(afl); }
 
   if (!strcmp(afl->in_dir, afl->out_dir)) {
 


### PR DESCRIPTION
The maximum length of sync_id is now checked once in `fix_up_sync` instead of twice with different sizes.