### PR TITLE
Replace gettimeofday with clock_gettime

### DIFF
--- a/custom_mutators/gramatron/test.c
+++ b/custom_mutators/gramatron/test.c
@@ -8,8 +8,8 @@
 state *create_pda(u8 *automaton_file) {
 
   struct json_object *parsed_json;
-  state *             pda;
-  json_object *       source_obj, *attr;
+  state              *pda;
+  json_object        *source_obj, *attr;
   int                 arraylen, ii, ii2, trigger_len, error;
 
   printf("\n[GF] Automaton file passed:%s", automaton_file);
@@ -41,7 +41,7 @@ state *create_pda(u8 *automaton_file) {
   enum json_type type;
   json_object_object_foreach(source_obj, key, val) {
 
-    state *  state_ptr;
+    state   *state_ptr;
     trigger *trigger_ptr;
     int      offset;
 
@@ -97,12 +97,12 @@ state *create_pda(u8 *automaton_file) {
 
 void SanityCheck(char *automaton_path) {
 
-  state *        pda = create_pda(automaton_path);
+  state         *pda = create_pda(automaton_path);
   int            count = 0, state;
   Get_Dupes_Ret *getdupesret;
-  IdxMap_new *   statemap;
-  IdxMap_new *   statemap_ptr;
-  terminal *     term_ptr;
+  IdxMap_new    *statemap;
+  IdxMap_new    *statemap_ptr;
+  terminal      *term_ptr;
 
   while (count < NUMINPUTS) {
 
@@ -117,12 +117,9 @@ void SanityCheck(char *automaton_path) {
 
 int main(int argc, char *argv[]) {
 
-  char *         mode;
-  char *         automaton_path;
-  char *         output_dir = NULL;
-  struct timeval tv;
-  struct timeval tz;
-  // gettimeofday(&tv, &tz);
+  char *mode;
+  char *automaton_path;
+  char *output_dir = NULL;
   srand(1337);
   if (argc == 3) {
 

--- a/custom_mutators/symqemu/symqemu.c
+++ b/custom_mutators/symqemu/symqemu.c
@@ -196,12 +196,11 @@ void afl_custom_splice_optout(void *data) {
 
 inline u64 get_cur_time(void) {
 
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
 
-  gettimeofday(&tv, &tz);
+  clock_gettime(CLOCK_REALTIME, &spec);
 
-  return (tv.tv_sec * 1000ULL) + (tv.tv_usec / 1000);
+  return (spec.tv_sec * 1000ULL) + (spec.tv_nsec / 1000000ULL);
 
 }
 

--- a/frida_mode/test/unstable/unstable.c
+++ b/frida_mode/test/unstable/unstable.c
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
+#include <time.h>
 
 #ifdef __APPLE__
   #define TESTINSTR_SECTION
@@ -22,17 +22,21 @@
   #define TESTINSTR_SECTION __attribute__((section(".testinstr")))
 #endif
 
-void LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+void LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   if (size < 1) return;
 
-  struct timeval tv = {0};
-  if (gettimeofday(&tv, NULL) < 0) return;
+  struct timespec spec = {0};
+  if (clock_gettime(CLOCK_REALTIME, &spec) < 0) return;
 
-  if ((tv.tv_usec % 2) == 0) {
-    printf ("Hooray all even\n");
+  if ((spec.tv_nsec % 2) == 0) {
+
+    printf("Hooray all even\n");
+
   } else {
-    printf ("Hmm that's odd\n");
+
+    printf("Hmm that's odd\n");
+
   }
 
   // we support three input cases
@@ -45,26 +49,33 @@ void LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
 }
 
-void run_test(char * file) {
+void run_test(char *file) {
+
   fprintf(stderr, "Running: %s\n", file);
   FILE *f = fopen(file, "r");
   assert(f);
   fseek(f, 0, SEEK_END);
   size_t len = ftell(f);
   fseek(f, 0, SEEK_SET);
-  unsigned char *buf = (unsigned char*)malloc(len);
-  size_t n_read = fread(buf, 1, len, f);
+  unsigned char *buf = (unsigned char *)malloc(len);
+  size_t         n_read = fread(buf, 1, len, f);
   fclose(f);
   assert(n_read == len);
   LLVMFuzzerTestOneInput(buf, len);
   free(buf);
   fprintf(stderr, "Done:    %s: (%zd bytes)\n", file, n_read);
+
 }
 
 int main(int argc, char **argv) {
+
   srand(1);
   fprintf(stderr, "StandaloneFuzzTargetMain: running %d inputs\n", argc - 1);
   for (int i = 1; i < argc; i++) {
+
     run_test(argv[i]);
+
   }
+
 }
+

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -64,7 +64,6 @@
 #include <netinet/in.h>
 
 #include <sys/wait.h>
-#include <sys/time.h>
 #ifndef USEMMAP
   #include <sys/shm.h>
 #endif

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -32,12 +32,12 @@
 #include "debug.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <list>
 #include <string>
 #include <fstream>
-#include <sys/time.h>
 
 #include "llvm/Config/llvm-config.h"
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 5
@@ -211,14 +211,13 @@ bool AFLCoverage::runOnModule(Module &M) {
   IntegerType *IntLocTy =
       IntegerType::getIntNTy(C, sizeof(PREV_LOC_T) * CHAR_BIT);
 #endif
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
   u32             rand_seed;
   unsigned int    cur_loc = 0;
 
   /* Setup random() so we get Actually Random(TM) outputs from AFL_R() */
-  gettimeofday(&tv, &tz);
-  rand_seed = tv.tv_sec ^ tv.tv_usec ^ getpid();
+  clock_gettime(CLOCK_REALTIME, &spec);
+  rand_seed = spec.tv_sec ^ spec.tv_nsec ^ getpid();
   AFL_SR(rand_seed);
 
   /* Show a banner */

--- a/src/afl-as.c
+++ b/src/afl-as.c
@@ -52,7 +52,6 @@
 #include <fcntl.h>
 
 #include <sys/wait.h>
-#include <sys/time.h>
 
 static u8 **as_params;              /* Parameters passed to the real 'as'   */
 
@@ -557,8 +556,7 @@ int main(int argc, char **argv) {
   int status;
   u8 *inst_ratio_str = getenv("AFL_INST_RATIO");
 
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
 
   clang_mode = !!getenv(CLANG_ENV_VAR);
 
@@ -609,9 +607,9 @@ int main(int argc, char **argv) {
 
   }
 
-  gettimeofday(&tv, &tz);
+  clock_gettime(CLOCK_REALTIME, &spec);
 
-  rand_seed = tv.tv_sec ^ tv.tv_usec ^ getpid();
+  rand_seed = spec.tv_sec ^ spec.tv_nsec ^ getpid();
   // in fast systems where pids can repeat in the same seconds we need this
   for (i = 1; (s32)i < argc; i++)
     for (j = 0; j < strlen(argv[i]); j++)

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -976,12 +976,11 @@ void read_bitmap(u8 *fname, u8 *map, size_t len) {
 
 inline u64 get_cur_time(void) {
 
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
 
-  gettimeofday(&tv, &tz);
+  clock_gettime(CLOCK_REALTIME, &spec);
 
-  return (tv.tv_sec * 1000ULL) + (tv.tv_usec / 1000);
+  return (spec.tv_sec * 1000ULL) + (spec.tv_nsec / 1000000ULL);
 
 }
 
@@ -989,19 +988,17 @@ inline u64 get_cur_time(void) {
 
 inline u64 get_cur_time_us(void) {
 
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
 
-  gettimeofday(&tv, &tz);
+  clock_gettime(CLOCK_REALTIME, &spec);
 
-  return (tv.tv_sec * 1000000ULL) + tv.tv_usec;
+  return (spec.tv_sec * 1000000ULL) + (spec.tv_nsec / 1000ULL);
 
 }
 
 /* Describe integer. The buf should be
    at least 6 bytes to fit all ints we randomly see.
    Will return buf for convenience. */
-
 u8 *stringify_int(u8 *buf, size_t len, u64 val) {
 \
 #define CHK_FORMAT(_divisor, _limit_mult, _fmt, _cast)     \

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -555,8 +555,7 @@ int main(int argc, char **argv_orig, char **envp) {
   char  *frida_afl_preload = NULL;
   char **use_argv;
 
-  struct timeval  tv;
-  struct timezone tz;
+  struct timespec spec;
 
   doc_path = access(DOC_PATH, F_OK) != 0 ? (u8 *)"docs" : (u8 *)DOC_PATH;
 
@@ -603,8 +602,8 @@ int main(int argc, char **argv_orig, char **envp) {
   SAYF(cCYA "afl-fuzz" VERSION cRST
             " based on afl by Michal Zalewski and a large online community\n");
 
-  gettimeofday(&tv, &tz);
-  rand_set_seed(afl, tv.tv_sec ^ tv.tv_usec ^ getpid());
+  clock_gettime(CLOCK_REALTIME, &spec);
+  rand_set_seed(afl, spec.tv_sec ^ spec.tv_nsec ^ getpid());
 
   afl->shmem_testcase_mode = 1;  // we always try to perform shmem fuzzing
 


### PR DESCRIPTION
This PR replaces `gettimeofday` with `clock_gettime` in all source files. `gettimeofday` was deprecated in POSIX 2017 (that was 7 years ago) and has been [removed in POSIX 2024](https://sortix.org/blog/posix-2024/). It's about time we switch away.