### PR TITLE
To support AFL instrumentation, add default settings of map_size in forkserver.

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1338,6 +1338,10 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
           fsrv->map_size = tmp_map_size;
 
+        } else {
+           
+           fsrv->real_map_size = fsrv->map_size = MAP_SIZE;
+           
         }
 
         if ((status & FS_OPT_AUTODICT) == FS_OPT_AUTODICT) {
@@ -1444,6 +1448,11 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         }
 
+      } else {
+
+         // The binary is most likely instrumented using AFL's tool, and we will set map_size to MAP_SIZE.
+         fsrv->real_map_size = fsrv->map_size = MAP_SIZE;
+         
       }
 
     }


### PR DESCRIPTION
Hello, when aflpp uses a binary instrumented by AFL, the binary's returned status variable is 0. 

Therefore, the bitmap size for aflpp is the default 8 /* 1024 /* 1024, which severely affects the running speed. 

For compatibility, I have added a default bitmap size setting in forkserver.( ◠‿◠ )

ps: I noticed that it can be resolved by setting AFL_SKIP_BIN_CHECK. However, after setting AFL_SKIP_BIN_CHECK, aflpp will no longer check persistent mode. Therefore, I think this setting is more reasonable.