### PR TITLE
Fixed lsan defaults evaluation

### DIFF
--- a/frida_mode/src/instrument/instrument_coverage.c
+++ b/frida_mode/src/instrument/instrument_coverage.c
@@ -878,7 +878,6 @@ void instrument_coverage_unstable_find_output(void) {
 
   g_dir_close(dir);
   g_free(instance_name);
-  g_free(path_tmp);
   g_free(fds_name);
 
   if (unstable_coverage_fuzzer_stats == NULL) {

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -108,7 +108,7 @@ void set_sanitizer_defaults() {
     if (!have_san_options) { strcpy(buf, default_options); }
     if (have_asan_options) {
 
-      if (NULL != strstr(have_asan_options, "detect_leaks=false")) {
+      if (NULL != strstr(have_asan_options, "detect_leaks=0") || NULL != strstr(have_asan_options, "detect_leaks=false")) {
 
         strcat(buf, "exitcode=" STRINGIFY(LSAN_ERROR) ":fast_unwind_on_malloc=0:print_suppressions=0:detect_leaks=0:malloc_context_size=0:");
 

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -108,7 +108,7 @@ void set_sanitizer_defaults() {
     if (!have_san_options) { strcpy(buf, default_options); }
     if (have_asan_options) {
 
-      if (NULL != strstr(have_asan_options, "detect_leaks=0")) {
+      if (NULL != strstr(have_asan_options, "detect_leaks=false")) {
 
         strcat(buf, "exitcode=" STRINGIFY(LSAN_ERROR) ":fast_unwind_on_malloc=0:print_suppressions=0:detect_leaks=0:malloc_context_size=0:");
 


### PR DESCRIPTION
There is a [bug](https://github.com/AFLplusplus/AFLplusplus/issues/2176) in the evaluation of the lsan default parameters inside void set_sanitizer_defaults().
This is causing the following behavior:
```
pre-DEFAULT: ASAN_ENV: detect_leaks=false
pre-DEFAULT: LSAN_ENV: (null)
DEFAULTs: ASAN_ENV: detect_leaks=false
DEFAULTs: LSAN_ENV: exitcode=23:fast_unwind_on_malloc=0:print_suppressions=0:detect_leaks=1:malloc_context_size=0:
```

While detect_leaks is set to false in the LSAN parameters detect_leaks is set to 1 causing the leak detection being enabled. This prevents FASAN from correctly working for example.

Also removed a bogus free I've introduced with adding unstable coverage for any instance name in frida, because I didn't know getenv strings should not be free'ed.