### PR TITLE
Update local building docs with missing dependencies 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ utils/replay_record/persistent_demo_replay_compat
 utils/replay_record/persistent_demo_replay_argparse
 utils/plot_ui/afl-plot-ui
 vuln_prog
+argv_fuzz_demo
+argv_fuzz_persistent_demo

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,6 +30,9 @@ sudo apt-get install -y build-essential python3-dev automake cmake git flex biso
 sudo apt-get install -y lld-14 llvm-14 llvm-14-dev clang-14 || sudo apt-get install -y lld llvm llvm-dev clang
 sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
 sudo apt-get install -y ninja-build # for QEMU mode
+sudo apt-get install -y cpio libcapstone-dev # for Nyx mode
+sudo apt-get install -y wget curl # for Frida mode
+sudo apt-get install python3-pip # for Unicorn mode
 git clone https://github.com/AFLplusplus/AFLplusplus
 cd AFLplusplus
 make distrib


### PR DESCRIPTION
Existing local building documentation `docs/INSTALL.md` lacks necessary dependencies for Debian-based Linux OS, leading to various errors in different compilation targets. The updated documentation has been tested and passed on Ubuntu 20/22/24. Additionally, some unnecessary intermediate build files have been removed from tracking.