### PR TITLE
Fix `/bin/sh:` errors when building without LLVM

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -48,18 +48,25 @@ else
   LLVM_CONFIG ?= $(call detect_newest,llvm-config)
 endif
 
-override LLVM_RAW_VER        := $(shell $(LLVM_CONFIG) --version 2>/dev/null)
-LLVMVER                      := $(subst svn,,$(subst git,,$(LLVM_RAW_VER)))
-LLVM_MAJOR                   := $(firstword $(subst ., ,$(LLVMVER)))
-LLVM_MINOR                   := $(firstword $(subst ., ,$(subst $(LLVM_MAJOR).,,$(LLVMVER))))
-LLVM_TOO_NEW                 := $(shell test $(LLVM_MAJOR) -gt $(LLVM_TOO_NEW_DEFAULT) && echo 1 || echo 0)
-LLVM_TOO_OLD                 := $(shell test $(LLVM_MAJOR) -lt $(LLVM_TOO_OLD_DEFAULT) && echo 1 || echo 0)
-LLVM_NEW_API                 := $(shell test $(LLVM_MAJOR) -ge 10 && echo 1 || echo 0)
-LLVM_NEWER_API               := $(shell test $(LLVM_MAJOR) -ge 16 && echo 1 || echo 0)
-LLVM_13_OK                   := $(shell test $(LLVM_MAJOR) -ge 13 && echo 1 || echo 0)
-LLVM_HAVE_LTO                := $(shell test $(LLVM_MAJOR) -ge 12 && echo 1 || echo 0)
-LLVM_BINDIR                  := $(shell $(LLVM_CONFIG) --bindir 2>/dev/null)
-LLVM_LIBDIR                  := $(shell $(LLVM_CONFIG) --libdir 2>/dev/null)
+ifneq "$(LLVM_CONFIG)" ""
+  override LLVM_RAW_VER        := $(shell $(LLVM_CONFIG) --version 2>/dev/null)
+  LLVMVER                      := $(subst svn,,$(subst git,,$(LLVM_RAW_VER)))
+
+  LLVM_BINDIR                  := $(shell $(LLVM_CONFIG) --bindir 2>/dev/null)
+  LLVM_LIBDIR                  := $(shell $(LLVM_CONFIG) --libdir 2>/dev/null)
+endif
+
+ifneq "$(LLVMVER)" ""
+  LLVM_MAJOR                   := $(firstword $(subst ., ,$(LLVMVER)))
+  LLVM_MINOR                   := $(firstword $(subst ., ,$(subst $(LLVM_MAJOR).,,$(LLVMVER))))
+  LLVM_TOO_NEW                 := $(shell test $(LLVM_MAJOR) -gt $(LLVM_TOO_NEW_DEFAULT) && echo 1 || echo 0)
+  LLVM_TOO_OLD                 := $(shell test $(LLVM_MAJOR) -lt $(LLVM_TOO_OLD_DEFAULT) && echo 1 || echo 0)
+  LLVM_NEW_API                 := $(shell test $(LLVM_MAJOR) -ge 10 && echo 1 || echo 0)
+  LLVM_NEWER_API               := $(shell test $(LLVM_MAJOR) -ge 16 && echo 1 || echo 0)
+  LLVM_13_OK                   := $(shell test $(LLVM_MAJOR) -ge 13 && echo 1 || echo 0)
+  LLVM_HAVE_LTO                := $(shell test $(LLVM_MAJOR) -ge 12 && echo 1 || echo 0)
+endif
+
 LLVM_STDCXX                  := gnu++11
 LLVM_LTO                     := 0
 LLVM_UNSUPPORTED             := $(shell echo "$(LLVMVER)" | grep -E -q '^[0-2]\.|^3\.[0-8]\.' && echo 1 || echo 0)


### PR DESCRIPTION
In `GNUmakefile.llvm`, several variables are unconditionally populated by expanding `$(LLVMVER)` and `$(LLVM_CONFIG)` inside shell commands. However, when LLVM is not present, both those variables are empty, meaning that the shell commands end up malformed and emit harmless, but noisy, errors like this one:

```
/bin/sh: --: invalid option
Usage:	/bin/sh [GNU long option] [option] ...
	/bin/sh [GNU long option] [option] script-file ...
GNU long options:
	--debug
	--debugger
	--dump-po-strings
	--dump-strings
	--help
	--init-file
	--login
	--noediting
	--noprofile
	--norc
	--posix
	--pretty-print
	--rcfile
	--rpm-requires
	--restricted
	--verbose
	--version
Shell options:
	-ilrsD or -c command or -O shopt_option		(invocation only)
	-abefhkmnptuvxBCHP or -o option
/bin/sh: line 1: test: -gt: unary operator expected
/bin/sh: line 1: test: -lt: unary operator expected
/bin/sh: line 1: test: -ge: unary operator expected
/bin/sh: line 1: test: -ge: unary operator expected
```

Fix the problem by only populating the "downstream" variables if the upstream ones have values.

This contribution is on behalf of my company.