### PR TITLE
Fix syntax error when compiling without zlib

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2237,7 +2237,6 @@ int main(int argc, char **argv_orig, char **envp) {
       snprintf(fn, PATH_MAX, "%s/fastresume.bin", afl->out_dir);
   #ifdef HAVE_ZLIB
       if ((fr_fd = ZLIBOPEN(fn, "rb")) != NULL) {
-
   #else
       if ((fr_fd = open(fn, O_RDONLY)) >= 0) {
 
@@ -3341,9 +3340,9 @@ stop_fuzzing:
     ACTF("Writing %s ...", fr);
   #ifdef HAVE_ZLIB
     if ((fr_fd = ZLIBOPEN(fr, "wb9")) != NULL) {
-
   #else
     if ((fr_fd = open(fr, O_WRONLY | O_TRUNC | O_CREAT, DEFAULT_PERMISSION)) >=
+        0) {
   #endif
 
       u8   ver_string[8];


### PR DESCRIPTION
commit ecb5854be08fa ("add zlib compression for fast resume"), introduced in #2141, added new logic selected at compile-time when zlib is present. Unfortunately, it also broke the existing logic by removing the last line of a multi-line if statement, resulting in a syntax error when zlib isn't present.

Restore the line as it was.

This contribution is on behalf of my company.