### PR TITLE
#2182 - Fix Typo in Image Tag `heigh` Attribute in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # American Fuzzy Lop plus plus (AFL++)
 
-<img align="right" src="https://raw.githubusercontent.com/AFLplusplus/Website/main/static/aflpp_bg.svg" alt="AFL++ logo" width="250" heigh="250">
+<img align="right" src="https://raw.githubusercontent.com/AFLplusplus/Website/main/static/aflpp_bg.svg" alt="AFL++ logo" width="250" height="250">
 
 Release version: [4.21c](https://github.com/AFLplusplus/AFLplusplus/releases)
 


### PR DESCRIPTION
Issue No. #2182 

This pull request corrects a typo in the `README.md` file. The `heigh` attribute in the HTML image tag has been mistakenly used instead of `height`. This change ensures proper display of the AFL++ logo image.

### Changes Made

- Corrected the `heigh` attribute to `height` in the following line:

```html
<img align="right" src="https://raw.githubusercontent.com/AFLplusplus/Website/main/static/aflpp_bg.svg" alt="AFL++ logo" width="250" heigh="250">
