### PR TITLE
Fix get_binary_hash compatibility issue in nyx mode

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -80,7 +80,21 @@ void write_setup_file(afl_state_t *afl, u32 argc, char **argv) {
 
   snprintf(fn2, PATH_MAX, "%s/target_hash", afl->out_dir);
   FILE *f2 = create_ffile(fn2);
-  fprintf(f2, "%p\n", (void *)get_binary_hash(afl->fsrv.target_path));
+
+  u64 target_hash = 0;
+  if (afl->fsrv.nyx_mode) {
+
+    char *tmp = alloc_printf("%s/config.ron", afl->fsrv.target_path);
+    target_hash = get_binary_hash(tmp);
+    free(tmp);
+
+  } else {
+
+    target_hash = get_binary_hash(afl->fsrv.target_path);
+
+  }
+
+  fprintf(f2, "%p\n", (void *)target_hash);
   fclose(f2);
 
   snprintf(fn, PATH_MAX, "%s/fuzzer_setup", afl->out_dir);


### PR DESCRIPTION
The write_setup_file calculates the hash of the target, and the target path is obtained directly from afl->fsrv.target_path, however, in nyx mode, afl->fsrv.target_path is a directory, which will cause the calculation of the get_binary_hash to fail, because get_ binary_hash does not take into account the case where the argument is a folder. So it makes sense to pass the nyx target configuration to the get_binary_hash function for nyx compatibility reasons



bug fix before

![image](https://github.com/user-attachments/assets/6627b41c-9de2-42c4-9a86-13d62e9e9b77)
