### PR TITLE
Offer more explicit core dump handling tip

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2455,12 +2455,7 @@ void check_crash_handling(void) {
         "    To avoid having crashes misinterpreted as timeouts, please \n"
         "    temporarily modify /proc/sys/kernel/core_pattern, like so:\n\n"
 
-        "    core_cmd=\"$(cat /proc/sys/kernel/core_pattern)\"\n"
-        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n\n"
-       
-        "    After fuzz testing is complete, restore the core handling:\n\n"
-
-        "    echo \"$core_cmd\" | sudo tee /proc/sys/kernel/core_pattern\n");
+        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n\n");
 
     if (!getenv("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES")) {
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2455,7 +2455,7 @@ void check_crash_handling(void) {
         "    To avoid having crashes misinterpreted as timeouts, please \n"
         "    temporarily modify /proc/sys/kernel/core_pattern, like so:\n\n"
 
-        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n\n");
+        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n");
 
     if (!getenv("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES")) {
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2443,20 +2443,24 @@ void check_crash_handling(void) {
 
     SAYF(
         "\n" cLRD "[-] " cRST
-        "Hmm, your system is configured to send core dump notifications to an\n"
+        "Your system is configured to send core dump notifications to an\n"
         "    external utility. This will cause issues: there will be an "
         "extended delay\n"
         "    between stumbling upon a crash and having this information "
         "relayed to the\n"
         "    fuzzer via the standard waitpid() API.\n"
-        "    If you're just testing, set "
+        "    If you're experimenting (so missed crashes don't matter), set "
         "'AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1'.\n\n"
 
-        "    To avoid having crashes misinterpreted as timeouts, please log in "
-        "as root\n"
-        "    and temporarily modify /proc/sys/kernel/core_pattern, like so:\n\n"
+        "    To avoid having crashes misinterpreted as timeouts, please \n"
+        "    temporarily modify /proc/sys/kernel/core_pattern, like so:\n\n"
 
-        "    echo core >/proc/sys/kernel/core_pattern\n");
+        "    core_cmd=\"$(cat /proc/sys/kernel/core_pattern)\"\n"
+        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n"
+       
+        "    After fuzz testing is complete, restore the core handling:\n\n"
+
+        "    echo \"$core_cmd\" | sudo tee /proc/sys/kernel/core_pattern\n");
 
     if (!getenv("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES")) {
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2449,14 +2449,14 @@ void check_crash_handling(void) {
         "    between stumbling upon a crash and having this information "
         "relayed to the\n"
         "    fuzzer via the standard waitpid() API.\n"
-        "    If you're experimenting (so missed crashes don't matter), set "
+        "    If you're just experimenting, set "
         "'AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1'.\n\n"
 
         "    To avoid having crashes misinterpreted as timeouts, please \n"
         "    temporarily modify /proc/sys/kernel/core_pattern, like so:\n\n"
 
         "    core_cmd=\"$(cat /proc/sys/kernel/core_pattern)\"\n"
-        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n"
+        "    echo core | sudo tee /proc/sys/kernel/core_pattern\n\n"
        
         "    After fuzz testing is complete, restore the core handling:\n\n"
 


### PR DESCRIPTION
Tweak the core dump handling tip to explicitly allow restoration
of the system's default core dump handling without restarting.

Also switch testing -> experimenting (since even full fuzzing
runs are still a testing activity).