### PR TITLE
Use `permissive_create` in `mark_as_variable`

### DIFF
--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -367,9 +367,8 @@ void mark_as_variable(afl_state_t *afl, struct queue_entry *q) {
 
   if (symlink(ldest, fn)) {
 
-    s32 fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
-    if (fd < 0) { PFATAL("Unable to create '%s'", fn); }
-    close(fd);
+    s32 fd = permissive_create(afl, fn);
+    if (fd >= 0) { close(fd); }
 
   }
 


### PR DESCRIPTION
This appears to be a case I missed in #2086.

I have not experienced failures running locally, but I have in CI: https://github.com/trailofbits/test-fuzz/actions/runs/10282678713/job/28454887232#step:11:1988

I'll propose the same offer I did before: would you like me to write some tests for the `AFL_SHA1_FILENAMES` option?