### PR TITLE
Update fuzzing_in_depth.md for a typo

### DIFF
--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -632,7 +632,7 @@ crash or timeout during startup.
 
 Also, it is recommended to set `export AFL_IMPORT_FIRST=1` to load test cases
 from other fuzzers in the campaign first. But note that can slow down the start
-of the first fuzz by quite a lot of you have many fuzzers and/or many seeds.
+of the first fuzz by quite a lot if you have many fuzzers and/or many seeds.
 
 If you have a large corpus, a corpus from a previous run or are fuzzing in a CI,
 then also set `export AFL_CMPLOG_ONLY_NEW=1` and `export AFL_FAST_CAL=1`.


### PR DESCRIPTION
Documents section 3-c, it is said: "But note that can slow down the start of the first fuzz by quite a lot {of} you have many fuzzers and/or many seeds."
I think {of} should be {if}.