### PR TITLE
Save crash log returned by nyx when AFL_CRASHING_SEEDS_AS_NEW_CRASH e…

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -1231,6 +1231,23 @@ void perform_dry_run(afl_state_t *afl) {
           ck_write(fd, use_mem, read_len, crash_fn);
           close(fd);
 
+          if (afl->fsrv.nyx_mode) {
+
+            u8 crash_log_fn[PATH_MAX];
+
+            snprintf(crash_log_fn, PATH_MAX, "%s.log", crash_fn);
+            fd = open(crash_log_fn, O_WRONLY | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
+            if (unlikely(fd < 0)) { PFATAL("Unable to create '%s'", crash_log_fn); }
+
+            u32 nyx_aux_string_len = afl->fsrv.nyx_handlers->nyx_get_aux_string(
+                afl->fsrv.nyx_runner, afl->fsrv.nyx_aux_string,
+                afl->fsrv.nyx_aux_string_len);
+
+            ck_write(fd, afl->fsrv.nyx_aux_string, nyx_aux_string_len, crash_log_fn);
+            close(fd);
+
+          }
+           
           afl->last_crash_time = get_cur_time();
           afl->last_crash_execs = afl->fsrv.total_execs;
 


### PR DESCRIPTION
Save crash log returned by nyx when AFL_CRASHING_SEEDS_AS_NEW_CRASH environment variable is enabled
nyx also returns a crash log when reporting a crash, both files are saved in the afl++ fuzzing run, whereas with the AFL_CRASHING_SEEDS_AS_NEW_CRASH setting, only the crash file is saved in the dry run phase if crashes are included in the supplied seeds.
This commit adds crash log saving to keep the behavior consistent