### PR TITLE
Update macOS linker flags in GNUmakefile.llvm

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -327,7 +327,7 @@ endif
 
 # User teor2345 reports that this is required to make things work on MacOS X.
 ifeq "$(SYS)" "Darwin"
-  CLANG_LFL += -Wl,-flat_namespace -Wl,-undefined,suppress
+  CLANG_LFL += -Wl,-undefined,dynamic_lookup
   override LLVM_HAVE_LTO := 0
   override LLVM_LTO := 0
 else


### PR DESCRIPTION
`-flat_namespace` is effectively deprecated and doesn't really work as
expected these days. Omitting the `-flat_namespace` means that binaries
are built with a two-level namespace, which don't support
`-undefined suppress`.

The idiomatic way of telling the linker to look up undefined symbols at
runtime is using `-undefined dynamic_lookup`, which is supported by a
two-level namespace.

See also:
ocaml/ocaml#10723
mono/mono#21257
