### PR TITLE
Make `__AFL_COVERAGE_START_OFF` work for targets with "small" maps

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -630,21 +630,21 @@ static void __afl_map_shm(void) {
 
       __afl_area_ptr_dummy = (u8 *)malloc(__afl_map_size);
 
-      if (__afl_area_ptr_dummy) {
+    }
 
-        if (__afl_selective_coverage_start_off) {
+    if (__afl_area_ptr_dummy) {
 
-          __afl_area_ptr = __afl_area_ptr_dummy;
+      if (__afl_selective_coverage_start_off) {
 
-        }
-
-      } else {
-
-        fprintf(stderr, "Error: __afl_selective_coverage failed!\n");
-        __afl_selective_coverage = 0;
-        // continue;
+        __afl_area_ptr = __afl_area_ptr_dummy;
 
       }
+
+    } else {
+
+      fprintf(stderr, "Error: __afl_selective_coverage failed!\n");
+      __afl_selective_coverage = 0;
+      // continue;
 
     }
 


### PR DESCRIPTION
Currently `__AFL_COVERAGE_START_OFF` will only work for targets with map sizes greater than `MAP_INITIAL_SIZE` (see [here](https://github.com/AFLplusplus/AFLplusplus/blob/78b7e14c73baacf1d88b3c03955e78f5080d17ba/instrumentation/afl-compiler-rt.o.c#L629-L635)).

Using `test/test-cmplog.c` as an example:

```patch
diff --git a/test/test-cmplog.c b/test/test-cmplog.c
index 0c91b21c..91bef7d0 100644
--- a/test/test-cmplog.c
+++ b/test/test-cmplog.c
@@ -6,6 +6,9 @@
 #include <stdint.h>
 #include <unistd.h>

+__AFL_COVERAGE();
+__AFL_COVERAGE_START_OFF();
+
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t i) {

   if (i < 15) return -1;
```

With the patch above and based on the documentation I would have expected no coverage to be collected, but:

```
$ mkdir /tmp/in && echo "AAA" > /tmp/in/A
$ afl-clang-fast test/test-cmplog.c -o test-cmplog
$ afl-showmap -i /tmp/in -o ./map.out -- ./test-cmplog
afl-showmap++4.22a by Michal Zalewski
[*] Executing './test-cmplog'...
[+] Persistent mode binary detected.
[*] Reading from directory '/tmp/in'...
[*] Scanning '/tmp/in'...
-- Program output begins --
-- Program output ends --
[+] Processed 1 input files.
[+] Captured 4 tuples (map size 28, highest value 1, total values 4) in './map.out'.
```

With this PR this turns into:

```
$ afl-clang-fast test/test-cmplog.c -o test-cmplog
$ afl-showmap -i /tmp/in -o ./map.out -- ./test-cmplog
afl-showmap++4.22a by Michal Zalewski
[*] Executing './test-cmplog'...
[+] Persistent mode binary detected.
[*] Reading from directory '/tmp/in'...
[*] Scanning '/tmp/in'...
-- Program output begins --
-- Program output ends --
[+] Processed 1 input files.

[-] PROGRAM ABORT : No instrumentation detected
         Location : main(), src/afl-showmap.c:1771
```