### PR TITLE
Add support for post_process in Rust custom mutator

### DIFF
--- a/custom_mutators/rust/Cargo.toml
+++ b/custom_mutators/rust/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "example",
     # Lain needs a nightly toolchain
     # "example_lain",
+    # "example_lain_post_process",
 ]

--- a/custom_mutators/rust/README.md
+++ b/custom_mutators/rust/README.md
@@ -5,7 +5,15 @@ Bindings to create custom mutators in Rust.
 These bindings are documented with rustdoc. To view the documentation run
 ```cargo doc -p custom_mutator --open```.
 
-A minimal example can be found in `example`. Build it using `cargo build --example example_mutator`. 
+A minimal example can be found in `example`. Build it using `cargo build --example example_mutator`.
 
 An example using [lain](https://github.com/microsoft/lain) for structured fuzzing can be found in `example_lain`.
 Since lain requires a nightly rust toolchain, you need to set one up before you can play with it.
+
+An example for the use of the post_process function, using [lain](https://github.com/microsoft/lain) with [serde](https://github.com/serde-rs/serde) and [bincode](https://github.com/bincode-org/bincode) can be found in `example_lain_post_process`.
+In order for it to work you need to:
+
+- disable input trimming with `AFL_DISABLE_TRIM=1`
+- provide an initial instance serialized with `bincode` or use the `AFL_NO_STARTUP_CALIBRATION=1` environment variable.
+
+Note that `bincode` can also be used to serialize/deserialize the lain-generated structure and mutate it rather than generating a new one at each iteration, but it requires some structure serialized with `bincode` as input seed.

--- a/custom_mutators/rust/example_lain_post_process/Cargo.toml
+++ b/custom_mutators/rust/example_lain_post_process/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "example_lain"
+name = "example_lain_post_process"
 version = "0.1.0"
-authors = ["Julius Hohnerlein <julihoh@users.noreply.github.com>"]
+authors = [
+    "Julius Hohnerlein <julihoh@users.noreply.github.com>",
+    "jma <94166787+jma-qb@users.noreply.github.com>",
+]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,8 +12,10 @@ edition = "2021"
 [dependencies]
 custom_mutator = { path = "../custom_mutator" }
 lain = { git = "https://github.com/AFLplusplus/lain.git" }
+bincode = "1.3.3"
+serde = { version = "1.0.214", features = ["derive"] }
 
 [[example]]
-name = "example_lain"
+name = "example_lain_post_process"
 path = "./src/lain_mutator.rs"
 crate-type = ["cdylib"]

--- a/custom_mutators/rust/example_lain_post_process/rust-toolchain
+++ b/custom_mutators/rust/example_lain_post_process/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/custom_mutators/rust/example_lain_post_process/src/lain_mutator.rs
+++ b/custom_mutators/rust/example_lain_post_process/src/lain_mutator.rs
@@ -1,0 +1,70 @@
+#![cfg(unix)]
+
+use custom_mutator::{export_mutator, CustomMutator};
+use lain::{
+    mutator::Mutator,
+    prelude::*,
+    rand::{rngs::StdRng, SeedableRng},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Mutatable, NewFuzzed, BinarySerialize)]
+struct MyStruct {
+    tag: u8,
+    #[lain(ignore)]
+    length: u32,
+    #[lain(min = 0, max = 10)]
+    data: Vec<u8>,
+}
+
+struct LainMutator {
+    mutator: Mutator<StdRng>,
+    buffer: Vec<u8>,
+    post_buffer: Vec<u8>,
+}
+
+impl CustomMutator for LainMutator {
+    type Error = ();
+
+    fn init(seed: u32) -> Result<Self, ()> {
+        Ok(Self {
+            mutator: Mutator::new(StdRng::seed_from_u64(seed as u64)),
+            buffer: Vec::new(),
+            post_buffer: Vec::new(),
+        })
+    }
+
+    fn fuzz<'b, 's: 'b>(
+        &'s mut self,
+        _buffer: &'b mut [u8],
+        _add_buff: Option<&[u8]>,
+        max_size: usize,
+    ) -> Result<Option<&'b [u8]>, ()> {
+        // we just sample an instance of MyStruct, ignoring the current input
+        let instance = MyStruct::new_fuzzed(&mut self.mutator, None);
+        let serialized = bincode::serialize(&instance).unwrap();
+        let size = serialized.len();
+        if size > max_size {
+            return Err(());
+        }
+        self.buffer.clear();
+        self.buffer.reserve(size);
+        self.buffer.extend_from_slice(&serialized);
+        Ok(Some(self.buffer.as_slice()))
+    }
+
+    fn post_process<'b, 's: 'b>(
+        &'s mut self,
+        buffer: &'b mut [u8],
+    ) -> Result<Option<&'b [u8]>, Self::Error> {
+        let mut instance = bincode::deserialize::<MyStruct>(&buffer).unwrap();
+        instance.length = instance.data.len() as u32;
+        let size = instance.serialized_size();
+        self.post_buffer.clear();
+        self.post_buffer.reserve(size);
+        instance.binary_serialize::<_, BigEndian>(&mut self.post_buffer);
+        Ok(Some(&self.post_buffer))
+    }
+}
+
+export_mutator!(LainMutator);


### PR DESCRIPTION
Hi, I added support for the post_process function in the Rust custom mutator bindings.
The existing examples still work and there is a new example, derived from the lain one, using that function.
I also changed lain to reference the fork hosted under AFL++ rather than the crates.io version.