### PR TITLE
Bump LLVM version to 20 available in prerelease, 19 being latest stable

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -32,7 +32,7 @@ VERSION     = $(shell grep '^$(HASH)define VERSION ' ./config.h | cut -d '"' -f2
 
 SYS = $(shell uname -s)
 
-override LLVM_TOO_NEW_DEFAULT := 18
+override LLVM_TOO_NEW_DEFAULT := 20
 override LLVM_TOO_OLD_DEFAULT := 13
 
 ifeq "$(SYS)" "OpenBSD"
@@ -71,7 +71,7 @@ LLVM_STDCXX                  := gnu++11
 LLVM_LTO                     := 0
 LLVM_UNSUPPORTED             := $(shell echo "$(LLVMVER)" | grep -E -q '^[0-2]\.|^3\.[0-7]\.' && echo 1 || echo 0)
 # Uncomment to see the values assigned above
-# $(foreach var,LLVM_CONFIG LLVMVER LLVM_MAJOR LLVM_MINOR LLVM_TOO_NEW LLVM_TOO_OLD LLVM_TOO_NEW_DEFAULT LLVM_TOO_OLD_DEFAULT LLVM_NEW_API LLVM_NEWER_API LLVM_13_OK LLVM_HAVE_LTO LLVM_BINDIR LLVM_LIBDIR LLVM_STDCXX LLVM_APPLE_XCODE LLVM_LTO LLVM_UNSUPPORTED,$(warning $(var) = $($(var))))
+# $(foreach var,_CLANG_VERSIONS_TO_TEST LLVM_CONFIG LLVMVER LLVM_MAJOR LLVM_MINOR LLVM_TOO_NEW LLVM_TOO_OLD LLVM_TOO_NEW_DEFAULT LLVM_TOO_OLD_DEFAULT LLVM_NEW_API LLVM_NEWER_API LLVM_13_OK LLVM_HAVE_LTO LLVM_BINDIR LLVM_LIBDIR LLVM_STDCXX LLVM_APPLE_XCODE LLVM_LTO LLVM_UNSUPPORTED,$(warning $(var) = $($(var))))
 
 ifeq "$(LLVMVER)" ""
   $(warning [!] llvm_mode needs llvm-config, which was not found. Set LLVM_CONFIG to its path and retry.)


### PR DESCRIPTION
There are plenty of strings referring to versions older than the stated version minimum of 13. Should these also be updated at some point? I.e. in `GNUmakefile` and `GNUmakefile.llvm` references to "ancient" versions of LLVM exist.

Anyone able to test the build on OpenBSD? It's one of the versions which gives a very very low version as minimum in its output strings and related comments ...