### PR TITLE
Fix overflow in execs_ps_last_min calculation

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -747,7 +747,7 @@ typedef struct afl_state {
                                   up to 256 */
 
   unsigned long long int last_avg_exec_update;
-  u64                    last_avg_execs;
+  u64                    last_avg_total_execs;
   double                 last_avg_execs_saved;
 
 /* foreign sync */

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -747,7 +747,7 @@ typedef struct afl_state {
                                   up to 256 */
 
   unsigned long long int last_avg_exec_update;
-  u32                    last_avg_execs;
+  u64                    last_avg_execs;
   double                 last_avg_execs_saved;
 
 /* foreign sync */

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -340,9 +340,9 @@ void write_stats_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
                 cur_time - afl->last_avg_exec_update >= 60000))) {
 
     afl->last_avg_execs_saved =
-        (double)(1000 * (afl->fsrv.total_execs - afl->last_avg_execs)) /
+        (double)(1000 * (afl->fsrv.total_execs - afl->last_avg_total_execs)) /
         (double)(cur_time - afl->last_avg_exec_update);
-    afl->last_avg_execs = afl->fsrv.total_execs;
+    afl->last_avg_total_execs = afl->fsrv.total_execs;
     afl->last_avg_exec_update = cur_time;
 
   }


### PR DESCRIPTION
last_avg_execs should be 64bit, same as total_execs, otherwise there is an overflow once total_execs reaches 2^32. Which can happen in practice for long-running fuzzing campaigns.

Also renames `last_avg_execs` -> `last_avg_total_execs`

Fixes #2275