### PR TITLE
Fix pid in at_exit()

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -170,7 +170,7 @@ static void at_exit() {
 
   if (pid2 > 0) {
 
-    pgrp = getpgid(pid1);
+    pgrp = getpgid(pid2);
     if (pgrp > 0) { killpg(pgrp, kill_signal); }
     kill(pid2, kill_signal);
 


### PR DESCRIPTION
This block of killing fuzz target used ```pid1``` instead of ```pid2```.