### PR TITLE
Fix macOS env optimization

### DIFF
--- a/src/afl-analyze.c
+++ b/src/afl-analyze.c
@@ -695,14 +695,17 @@ static void set_up_environment(char **argv) {
       ck_free(frida_binary);
 
       setenv("LD_PRELOAD", frida_afl_preload, 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", frida_afl_preload, 1);
-
+#endif
     } else {
 
       /* CoreSight mode uses the default behavior. */
 
       setenv("LD_PRELOAD", getenv("AFL_PRELOAD"), 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", getenv("AFL_PRELOAD"), 1);
+#endif
 
     }
 
@@ -710,7 +713,9 @@ static void set_up_environment(char **argv) {
 
     u8 *frida_binary = find_afl_binary(argv[0], "afl-frida-trace.so");
     setenv("LD_PRELOAD", frida_binary, 1);
+#ifdef __APPLE__
     setenv("DYLD_INSERT_LIBRARIES", frida_binary, 1);
+#endif
     ck_free(frida_binary);
 
   }

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1965,8 +1965,9 @@ int main(int argc, char **argv_orig, char **envp) {
         ck_free(frida_binary);
 
         setenv("LD_PRELOAD", frida_afl_preload, 1);
+#ifdef __APPLE__
         setenv("DYLD_INSERT_LIBRARIES", frida_afl_preload, 1);
-
+#endif
       }
 
     } else {
@@ -1974,7 +1975,9 @@ int main(int argc, char **argv_orig, char **envp) {
       /* CoreSight mode uses the default behavior. */
 
       setenv("LD_PRELOAD", getenv("AFL_PRELOAD"), 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", getenv("AFL_PRELOAD"), 1);
+#endif
 
     }
 
@@ -1992,7 +1995,9 @@ int main(int argc, char **argv_orig, char **envp) {
       u8 *frida_binary = find_afl_binary(argv[0], "afl-frida-trace.so");
       OKF("Injecting %s ...", frida_binary);
       setenv("LD_PRELOAD", frida_binary, 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", frida_binary, 1);
+#endif
       ck_free(frida_binary);
 
     }

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -740,14 +740,18 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
       ck_free(frida_binary);
 
       setenv("LD_PRELOAD", frida_afl_preload, 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", frida_afl_preload, 1);
+#endif
 
     } else {
 
       /* CoreSight mode uses the default behavior. */
 
       setenv("LD_PRELOAD", getenv("AFL_PRELOAD"), 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", getenv("AFL_PRELOAD"), 1);
+#endif
 
     }
 
@@ -755,7 +759,9 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
 
     u8 *frida_binary = find_afl_binary(argv[0], "afl-frida-trace.so");
     setenv("LD_PRELOAD", frida_binary, 1);
+#ifdef __APPLE__
     setenv("DYLD_INSERT_LIBRARIES", frida_binary, 1);
+#endif
     ck_free(frida_binary);
 
   }

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -714,14 +714,18 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
       ck_free(frida_binary);
 
       setenv("LD_PRELOAD", frida_afl_preload, 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", frida_afl_preload, 1);
+#endif
 
     } else {
 
       /* CoreSight mode uses the default behavior. */
 
       setenv("LD_PRELOAD", getenv("AFL_PRELOAD"), 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", getenv("AFL_PRELOAD"), 1);
+#endif
 
     }
 
@@ -729,7 +733,9 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
 
     u8 *frida_binary = find_afl_binary(argv[0], "afl-frida-trace.so");
     setenv("LD_PRELOAD", frida_binary, 1);
+#ifdef __APPLE__
     setenv("DYLD_INSERT_LIBRARIES", frida_binary, 1);
+#endif
     ck_free(frida_binary);
 
   }

--- a/utils/afl_network_proxy/afl-network-server.c
+++ b/utils/afl_network_proxy/afl-network-server.c
@@ -233,8 +233,9 @@ static void set_up_environment(afl_forkserver_t *fsrv) {
     } else {
 
       setenv("LD_PRELOAD", getenv("AFL_PRELOAD"), 1);
+#ifdef __APPLE__
       setenv("DYLD_INSERT_LIBRARIES", getenv("AFL_PRELOAD"), 1);
-
+#endif
     }
 
   }


### PR DESCRIPTION
### Conditional DYLD_INSERT_LIBRARIES Setting for macOS Compatibility

Previously, the code unconditionally applied the DYLD_INSERT_LIBRARIES setting, even on non-macOS platforms. This could lead to unnecessary operations on platforms where this setting is irrelevant.

This PR the following changes:

1.	Wrapped the DYLD_INSERT_LIBRARIES setting in a #ifdef __APPLE__ directive to ensure it is applied only on macOS.
2.	Preserved the existing LD_PRELOAD setting for all platforms without modification.

### Purpose
- Ensures compatibility with macOS while avoiding unnecessary settings on other platforms.
