### PR TITLE
Mutation Chain Tool

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -56,6 +56,10 @@ Here's a quick overview of the stuff you can find in this directory:
 
   - libpng_no_checksum   - a sample patch for removing CRC checks in libpng.
 
+  - mutation_chain       - a tool that backtraces the mutation chain of AFL 
+                           crash files based on the crash/queue file naming
+                           standards and outputs this in a json format.
+
   - persistent_mode      - an example of how to use the LLVM persistent process
                            mode to speed up certain fuzzing jobs.
 

--- a/utils/mutation_chain/mutation_chain.py
+++ b/utils/mutation_chain/mutation_chain.py
@@ -6,8 +6,8 @@
 # Now you can!
 #
 # This tool is developed to support file structures for parallel fuzzing runs using the
-# naming of main/secondary as stated in the AFL docs (fuzzer01, fuzzer02 etc...)
-# In case you want to use it for single instance runs just recreate the directory structure
+# naming of main/secondary nodes as stated in the AFL docs (fuzzer01, fuzzer02 etc...)
+# In case you want to use it for single node runs just recreate the directory structure
 # which is used when parallel fuzzing is used (dump your results in a dir called fuzzer01).
 #
 # author: Maarten Dekker
@@ -88,61 +88,65 @@ def main():
     )
 
     parser.add_argument(
-        "--mode", 
+        "-m", "--mode", 
         choices = ['single', 'all'], 
         help = 'compute chain for one file or all crash files in supplied directory. In single mode the -f argument is required', 
         required = True
     )
 
     parser.add_argument(
-        "--dir",
+        "-i", "--input",
         action = 'store',
-        help = 'AFL output directory',
+        help = 'Input directory for the mutation chain tool (the fuzzer\'s output directory)',
         required = True
     )
 
     parser.add_argument(
-        "--instance",
+        "-n", "--node",
         action = 'store',
-        help = '[Only required in single mode] name of the fuzzer instance that contains the crash file supplied in the --file argument (e.g. \'fuzzer01\')',
+        help = '[Only used in single mode; optinal] name of the fuzzer node that contains the crash file supplied in the --file argument (e.g. \'fuzzer03\'). Defaults to \'fuzzer01\' if not supplied',
         required = False
     )
 
     parser.add_argument(
-        "--file",
+        "-f", "--file",
         action = 'store',
-        help = '[Only required in single mode] filename of specific crash file (e.g. \'id:000008,sig:06,src:000005,op:havoc,rep:8\')',
+        help = '[Only used in single mode; required] filename of specific crash file (e.g. \'id:000008,sig:06,src:000005,op:havoc,rep:8\')',
         required = False
     )
 
     args = parser.parse_args()
 
     if args.mode == "single":
+
+        if args.node == None:
+            args.node = "fuzzer01"
+
         if args.file == None:
             parser.error("'--mode single' requires the '--file' argument.")
-        elif args.instance == None:
-            parser.error("'--mode single' requires the '--instance' argument.")
 
+        crash_file_path = args.input + '/' + args.node + '/crashes/' + args.file
+        if not os.path.isfile(crash_file_path):
+            print("Error: \'" + crash_file_path + "\' does not exist.\nPlease verify whether the node and filename are correct.")
+            return
 
-    afl_output_directory = args.dir
-
-    # Create the interal representation of the various queues of parallel fuzzing instances
-    for dir in os.listdir(afl_output_directory):
+    # Create the interal representation of the various queues of parallel fuzzing nodes
+    for dir in os.listdir(args.input):
         if re.match("^fuzzer\\d+", dir):
-            queues[dir] = fillDictWithFilenameKeys(afl_output_directory + '/' + dir + '/queue')
+            queues[dir] = fillDictWithFilenameKeys(args.input + '/' + dir + '/queue')
 
     if args.mode == "all":
 
-        for dir in os.listdir(afl_output_directory):
+        for dir in os.listdir(args.input):
             if re.match("^fuzzer\\d+", dir):
-                for filename in os.listdir(afl_output_directory + '/' + dir + "/crashes"):
+                for filename in os.listdir(args.input + '/' + dir + "/crashes"):
                     if re.match("^id:\\d+", filename):
                         print(filename)
                         crashes[filename] = compute_mutation_chain(filename, dir, 0)
 
     elif args.mode == "single":
 
-        crashes[args.file] = compute_mutation_chain(args.file, args.instance, 0)
+        crashes[args.file] = compute_mutation_chain(args.file, args.node, 0)
 
     print(json.dumps(crashes, sort_keys=True, indent=4))
 

--- a/utils/mutation_chain/mutation_chain.py
+++ b/utils/mutation_chain/mutation_chain.py
@@ -1,51 +1,44 @@
+#!/usr/bin/env python3
 #
 # MUTATION CHAIN COMPUTATION TOOL
 #
 # Ever wondered what the complete history of your AFL crash file looks like?
 # Now you can!
 #
-# This tool is developed to support file structures for parralel fuzzing runs using the
-# naming of master/slaves as stated in the AFL docs (fuzzer01, fuzzer02 etc...)
-# In case you want to use it for single instance runs slight modifications are required
-# 
-# Best to echo the output of this tool into a json file for further analysis.
+# This tool is developed to support file structures for parallel fuzzing runs using the
+# naming of main/secondary as stated in the AFL docs (fuzzer01, fuzzer02 etc...)
+# In case you want to use it for single instance runs just recreate the directory structure
+# which is used when parallel fuzzing is used (dump your results in a dir called fuzzer01).
 #
 # author: Maarten Dekker
 
-# import required module
+# import required modules
 import os, re, json
-
-# user config section
-afl_output_directory = "INSERT_YOUR_AFL_OUTPUT_DIRECTORY"
+import argparse
 
 crashes = {}
 queues = {}
 
-# Create the interal representation of the various queues of parrallel fuzzing instances
 def fillDictWithFilenameKeys(dir):
     dict = {}
     for filename in os.listdir(dir):
-        if re.match("^id:\d+", filename):
+        if re.match("^id:\\d+", filename):
             dict[filename] = None
     return dict
-
-for dir in os.listdir(afl_output_directory):
-    if re.match("^fuzzer\d+", dir):
-        queues[dir] = fillDictWithFilenameKeys(afl_output_directory + '/' + dir + '/queue')
 
 # recusively compute the chain of queue items that led to the AFL crash file
 def compute_mutation_chain(filename, current_fuzzer, n):
 
-    if re.match(".*src:(\d+),", filename):
+    if re.match(".*src:(\\d+),", filename):
 
-        source_id = re.match(".*src:(\d+),", filename).group(1)
+        source_id = re.match(".*src:(\\d+),", filename).group(1)
         file_we_look_for_rex = "^id:" + source_id + ","
 
         fuzzer_queue = None
 
         # determine if we need to look in the queue of another fuzzer instance
-        if re.match(".*sync:(fuzzer\d+),", filename):
-            fuzzer_queue = re.match(".*sync:(fuzzer\d+),", filename).group(1)
+        if re.match(".*sync:(fuzzer\\d+),", filename):
+            fuzzer_queue = re.match(".*sync:(fuzzer\\d+),", filename).group(1)
         else:
             fuzzer_queue = current_fuzzer
 
@@ -58,9 +51,9 @@ def compute_mutation_chain(filename, current_fuzzer, n):
                 return retval
 
     # if the mutation result is a splice it thas 2 sources
-    elif re.match(".*src:(\d+)\+(\d+)", filename):
+    elif re.match(".*src:(\\d+)\\+(\\d+)", filename):
 
-        sources = re.match(".*src:(\d+)\+(\d+)", filename)
+        sources = re.match(".*src:(\\d+)\\+(\\d+)", filename)
 
         source_id_1 = sources.group(1)
         source_id_2 = sources.group(2)
@@ -82,12 +75,76 @@ def compute_mutation_chain(filename, current_fuzzer, n):
         return retval
 
     else:
-        return "Reached original"
+        return "seed"
 
-for dir in os.listdir(afl_output_directory):
-    if re.match("^fuzzer\d+", dir):
-        for filename in os.listdir(afl_output_directory + '/' + dir + "/crashes"):
-            if re.match("^id:\d+", filename):
-                crashes[filename] = compute_mutation_chain(filename, dir, 0)
 
-print(json.dumps(crashes, sort_keys=True, indent=4))
+def main():
+
+    parser = argparse.ArgumentParser(
+                    prog='mutation_chain.py',
+                    description='Compute the mutation chain of AFL crash files to visulise the mutation history from seed files to crash' +
+                    'This tool just dump json data to the CLI, it is advised to echo them into a file for further analysis (i.e. [command] >> your_file.json)',
+                    epilog='Greetings from old zealand'
+    )
+
+    parser.add_argument(
+        "--mode", 
+        choices = ['single', 'all'], 
+        help = 'compute chain for one file or all crash files in supplied directory. In single mode the -f argument is required', 
+        required = True
+    )
+
+    parser.add_argument(
+        "--dir",
+        action = 'store',
+        help = 'AFL output directory',
+        required = True
+    )
+
+    parser.add_argument(
+        "--instance",
+        action = 'store',
+        help = '[Only required in single mode] name of the fuzzer instance that contains the crash file supplied in the --file argument (e.g. \'fuzzer01\')',
+        required = False
+    )
+
+    parser.add_argument(
+        "--file",
+        action = 'store',
+        help = '[Only required in single mode] filename of specific crash file (e.g. \'id:000008,sig:06,src:000005,op:havoc,rep:8\')',
+        required = False
+    )
+
+    args = parser.parse_args()
+
+    if args.mode == "single":
+        if args.file == None:
+            parser.error("'--mode single' requires the '--file' argument.")
+        elif args.instance == None:
+            parser.error("'--mode single' requires the '--instance' argument.")
+
+
+    afl_output_directory = args.dir
+
+    # Create the interal representation of the various queues of parallel fuzzing instances
+    for dir in os.listdir(afl_output_directory):
+        if re.match("^fuzzer\\d+", dir):
+            queues[dir] = fillDictWithFilenameKeys(afl_output_directory + '/' + dir + '/queue')
+
+    if args.mode == "all":
+
+        for dir in os.listdir(afl_output_directory):
+            if re.match("^fuzzer\\d+", dir):
+                for filename in os.listdir(afl_output_directory + '/' + dir + "/crashes"):
+                    if re.match("^id:\\d+", filename):
+                        print(filename)
+                        crashes[filename] = compute_mutation_chain(filename, dir, 0)
+
+    elif args.mode == "single":
+
+        crashes[args.file] = compute_mutation_chain(args.file, args.instance, 0)
+
+    print(json.dumps(crashes, sort_keys=True, indent=4))
+
+if __name__ == '__main__':
+    main()

--- a/utils/mutation_chain/mutation_chain.py
+++ b/utils/mutation_chain/mutation_chain.py
@@ -1,0 +1,93 @@
+#
+# MUTATION CHAIN COMPUTATION TOOL
+#
+# Ever wondered what the complete history of your AFL crash file looks like?
+# Now you can!
+#
+# This tool is developed to support file structures for parralel fuzzing runs using the
+# naming of master/slaves as stated in the AFL docs (fuzzer01, fuzzer02 etc...)
+# In case you want to use it for single instance runs slight modifications are required
+# 
+# Best to echo the output of this tool into a json file for further analysis.
+#
+# author: Maarten Dekker
+
+# import required module
+import os, re, json
+
+# user config section
+afl_output_directory = "INSERT_YOUR_AFL_OUTPUT_DIRECTORY"
+
+crashes = {}
+queues = {}
+
+# Create the interal representation of the various queues of parrallel fuzzing instances
+def fillDictWithFilenameKeys(dir):
+    dict = {}
+    for filename in os.listdir(dir):
+        if re.match("^id:\d+", filename):
+            dict[filename] = None
+    return dict
+
+for dir in os.listdir(afl_output_directory):
+    if re.match("^fuzzer\d+", dir):
+        queues[dir] = fillDictWithFilenameKeys(afl_output_directory + '/' + dir + '/queue')
+
+# recusively compute the chain of queue items that led to the AFL crash file
+def compute_mutation_chain(filename, current_fuzzer, n):
+
+    if re.match(".*src:(\d+),", filename):
+
+        source_id = re.match(".*src:(\d+),", filename).group(1)
+        file_we_look_for_rex = "^id:" + source_id + ","
+
+        fuzzer_queue = None
+
+        # determine if we need to look in the queue of another fuzzer instance
+        if re.match(".*sync:(fuzzer\d+),", filename):
+            fuzzer_queue = re.match(".*sync:(fuzzer\d+),", filename).group(1)
+        else:
+            fuzzer_queue = current_fuzzer
+
+        for k,v in queues[fuzzer_queue].items():
+
+            if re.match(file_we_look_for_rex, k):
+               
+                retval = {}
+                retval[k] = compute_mutation_chain(k, fuzzer_queue, n+1)
+                return retval
+
+    # if the mutation result is a splice it thas 2 sources
+    elif re.match(".*src:(\d+)\+(\d+)", filename):
+
+        sources = re.match(".*src:(\d+)\+(\d+)", filename)
+
+        source_id_1 = sources.group(1)
+        source_id_2 = sources.group(2)
+
+        file_we_look_for_1_rex = "^id:" + source_id_1 + ","
+        file_we_look_for_2_rex = "^id:" + source_id_2 + ","
+
+        # for mutation with two sources, the sources are never synced form other queues
+        retval = {}
+
+        for k,v in queues[current_fuzzer].items():
+
+            if re.match(file_we_look_for_1_rex, k):
+                retval[k] = compute_mutation_chain(k, current_fuzzer, n+1)
+
+            elif re.match(file_we_look_for_2_rex, k):
+                retval[k] = compute_mutation_chain(k, current_fuzzer, n+1)
+
+        return retval
+
+    else:
+        return "Reached original"
+
+for dir in os.listdir(afl_output_directory):
+    if re.match("^fuzzer\d+", dir):
+        for filename in os.listdir(afl_output_directory + '/' + dir + "/crashes"):
+            if re.match("^id:\d+", filename):
+                crashes[filename] = compute_mutation_chain(filename, dir, 0)
+
+print(json.dumps(crashes, sort_keys=True, indent=4))


### PR DESCRIPTION
Adding a tool I developed to trace the mutation chain of AFL crash files. I needed it to determine some statistics of custom mutators. Example outputs can be found [here](https://github.com/maartendekker1998/easycwmp_fuzzing_results/blob/main/crash_chains_rpc_request.json).