### PR TITLE
Excess `afl_global_id` Increase of LTO-CTX

### DIFF
--- a/instrumentation/SanitizerCoverageLTO.so.cc
+++ b/instrumentation/SanitizerCoverageLTO.so.cc
@@ -2005,8 +2005,11 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
 
     }
 
-    extra_ctx_inst += inst_in_this_func * (call_counter - 1);
-    afl_global_id += extra_ctx_inst;
+    uint32_t extra_ctx_inst_in_this_func =
+        inst_in_this_func * (call_counter - 1);
+
+    extra_ctx_inst += extra_ctx_inst_in_this_func;
+    afl_global_id += extra_ctx_inst_in_this_func;
 
   }
 


### PR DESCRIPTION
These days I've been working on some research based on *CTX* mode of AFL++. However after reading src of `SanitizerCoverageLTO` I found the strange increase of `afl_global_id` when ctx mode on.

With `hello.c`
```c
int bar(int x) {
  ++x;

  if (x > 10)
    return x + 16;
  else if (x > 9)
    return x + 8;
  else if (x > 8)
    return x + 4;
  else
    return x + 2;
}

int barA(int a) {
  if (a > 6)
    return bar(a) >> 1;
  else
    return bar(a) >> 2;
}

int barB(int a) {
  if (a > 5)
    return bar(a) << 1;
  else
    return bar(a) << 2;
}

static int g_flag = 100;

int foo() {
  int a_, b_;

  if (g_flag) {
    a_ = barA(16);
    b_ = barB(32);
  } else {
    a_ = barA(64);
    b_ = barB(128);
  }
  return a_ + b_;
}

int main() { 
  return foo();
}
```
instrumented by `afl-lto`, I made the following figure which describes the change of `afl_global_id`, used for calculating edge ID of target BB, during `SanitizerCoverageLTO` working:
![wrong-global-id-incr](https://github.com/user-attachments/assets/328a4ecc-cfa8-4069-ba16-9a5537d11047)

As you can see, `bar` was instrumented first, followed by `barA`, then `barB`. Edges in `barB` should have ID start from `25`, but actually from `37`. This behavior was introduced in commit 44a769616:
```diff
     extra_ctx_inst += inst_in_this_func * (call_counter - 1);
-    afl_global_id += inst_in_this_func * (call_counter - 1);
+    afl_global_id += extra_ctx_inst;
```
I can't figure out why the extra increase of `afl_global_id` is necessary, so it may be a bug, caused by mistakenly considering `extra_ctx_inst` as being reset per instruemented function.