### PR TITLE
afl-fuzz: fix -a option

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -615,7 +615,7 @@ int main(int argc, char **argv_orig, char **envp) {
   // still available: HjJkKqruvwz
   while (
       (opt = getopt(argc, argv,
-                    "+aw:Ab:B:c:CdDe:E:f:F:g:G:hi:I:l:L:m:M:nNo:Op:P:QRs:S:t:"
+                    "+a:w:Ab:B:c:CdDe:E:f:F:g:G:hi:I:l:L:m:M:nNo:Op:P:QRs:S:t:"
                     "T:uUV:WXx:YzZ")) > 0) {
 
     switch (opt) {


### PR DESCRIPTION
This fixes the option string so -a will be parsed with an argument again, unbreaking the option. The result of the missing : was that optarg would always be NULL and we would abort in stricmp.

Introduced in 1c9925c7d7