### PR TITLE
feat: use GH hosted ARM runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,20 +35,41 @@ jobs:
           apt-get install -y libcmocka-dev && 
           make -i tests
           "
+  build-and-test-arm64:
+    name: Test arm64 image
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: aflplusplus:test-arm64
+          load: true
+          cache-to: type=gha,mode=max
+          build-args: |
+            TEST_BUILD=1
+      - name: Test arm64
+        run: >
+          docker run --rm aflplusplus:test-arm64 bash -c "
+          apt-get update && 
+          apt-get install -y libcmocka-dev && 
+          make -i tests
+          "
 
   push:
     name: Push amd64 and arm64 images
     runs-on: ubuntu-latest
     needs:
       - build-and-test-amd64
+      - build-and-test-arm64
     if: ${{ github.event_name == 'push' && github.repository == 'AFLplusplus/AFLplusplus' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      #- name: Set up QEMU
-      #  uses: docker/setup-qemu-action@v2
-      #  with:
-      #    platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to docker.io
@@ -69,8 +90,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
-          #,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.push-tags.outputs.PUSH_TAGS }}
           cache-from: type=gha


### PR DESCRIPTION
Re-enable arm64 docker containers by using GH arm runners.
Also enable CI for arm64.