### PR TITLE
Delete initial call to LLVMFuzzerTestOneInput in aflpp driver

### DIFF
--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -392,10 +392,6 @@ __attribute__((weak)) int LLVMFuzzerRunDriver(
 
   __afl_manual_init();
 
-  // Call LLVMFuzzerTestOneInput here so that coverage caused by initialization
-  // on the first execution of LLVMFuzzerTestOneInput is ignored.
-  callback(dummy_input, 4);
-
   __asan_poison_memory_region(__afl_fuzz_ptr, MAX_FILE);
   size_t prev_length = 0;
 


### PR DESCRIPTION
@vanhauser-thc 
as we discussed this call doesn't make sense with how afl++ works