### PR TITLE
Add support for iOS builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,6 +70,11 @@ ifdef CODE_COVERAGE
   override CFLAGS += -D__AFL_CODE_COVERAGE=1
 endif
 
+IS_IOS:=$(findstring ios, $(shell $(CC) --version 2>/dev/null))
+ifdef IS_IOS
+  override CFLAGS += -DTARGET_OS_IPHONE -DTARGET_OS_IOS
+endif
+
 ifeq "$(findstring android, $(shell $(CC) --version 2>/dev/null))" ""
 ifeq "$(shell echo 'int main() {return 0; }' | $(CC) $(CFLAGS) -Werror -x c - -flto=full -o .test 2>/dev/null && echo 1 || echo 0 ; rm -f .test )" "1"
 	CFLAGS_FLTO ?= -flto=full
@@ -101,17 +106,19 @@ else
   SPECIAL_PERFORMANCE :=
 endif
 
-ifneq "$(SYS)" "Darwin"
- #ifeq "$(HAVE_MARCHNATIVE)" "1"
- #  SPECIAL_PERFORMANCE += -march=native
- #endif
- #ifndef DEBUG
- #  override CFLAGS_OPT += -D_FORTIFY_SOURCE=1
- #endif
-else
-  # On some odd MacOS system configurations, the Xcode sdk path is not set correctly
-  SDK_LD = -L$(shell xcrun --show-sdk-path)/usr/lib
-  override LDFLAGS += $(SDK_LD)
+ifndef IS_IOS
+  ifneq "$(SYS)" "Darwin"
+   #ifeq "$(HAVE_MARCHNATIVE)" "1"
+   #  SPECIAL_PERFORMANCE += -march=native
+   #endif
+   #ifndef DEBUG
+   #  override CFLAGS_OPT += -D_FORTIFY_SOURCE=1
+   #endif
+  else
+    # On some odd MacOS system configurations, the Xcode sdk path is not set correctly
+    SDK_LD = -L$(shell xcrun --show-sdk-path)/usr/lib
+    override LDFLAGS += $(SDK_LD)
+  endif
 endif
 
 COMPILER_TYPE=$(shell $(CC) --version|grep "Free Software Foundation")
@@ -479,18 +486,33 @@ src/afl-sharedmem.o : $(COMM_HDR) src/afl-sharedmem.c include/sharedmem.h
 
 afl-fuzz: $(COMM_HDR) include/afl-fuzz.h $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o -o $@ $(PYFLAGS) $(LDFLAGS) -lm
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 afl-showmap: src/afl-showmap.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) src/$@.c src/afl-fuzz-mutators.c src/afl-fuzz-python.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o -o $@ $(PYFLAGS) $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 afl-tmin: src/afl-tmin.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) src/$@.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o -o $@ $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 afl-analyze: src/afl-analyze.c src/afl-common.o src/afl-sharedmem.o src/afl-performance.o src/afl-forkserver.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) src/$@.c src/afl-common.o src/afl-sharedmem.o src/afl-performance.o src/afl-forkserver.o -o $@ $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 afl-gotcpu: src/afl-gotcpu.c src/afl-common.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) src/$@.c src/afl-common.o -o $@ $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 .PHONY: document
 document:	afl-fuzz-document
@@ -498,6 +520,9 @@ document:	afl-fuzz-document
 # document all mutations and only do one run (use with only one input file!)
 afl-fuzz-document: $(COMM_HDR) include/afl-fuzz.h $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-performance.o | test_x86
 	$(CC) -D_DEBUG=\"1\" -D_AFL_DOCUMENT_MUTATIONS $(CFLAGS) $(CFLAGS_FLTO) $(AFL_FUZZ_FILES) src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.c src/afl-performance.o -o afl-fuzz-document $(PYFLAGS) $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 test/unittests/unit_maybe_alloc.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_maybe_alloc.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_maybe_alloc.c -o test/unittests/unit_maybe_alloc.o
@@ -505,6 +530,9 @@ test/unittests/unit_maybe_alloc.o : $(COMM_HDR) include/alloc-inl.h test/unittes
 unit_maybe_alloc: test/unittests/unit_maybe_alloc.o
 	@$(CC) $(CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_maybe_alloc.o -o test/unittests/unit_maybe_alloc $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_maybe_alloc
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 test/unittests/unit_hash.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_hash.c $(AFL_FUZZ_FILES) src/afl-performance.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) $(SPECIAL_PERFORMANCE) -c test/unittests/unit_hash.c -o test/unittests/unit_hash.o
@@ -512,6 +540,9 @@ test/unittests/unit_hash.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit
 unit_hash: test/unittests/unit_hash.o src/afl-performance.o
 	@$(CC) $(CFLAGS) $(SPECIAL_PERFORMANCE) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_hash $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_hash
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 test/unittests/unit_rand.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_rand.c $(AFL_FUZZ_FILES) src/afl-performance.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) $(SPECIAL_PERFORMANCE) -c test/unittests/unit_rand.c -o test/unittests/unit_rand.o
@@ -519,6 +550,9 @@ test/unittests/unit_rand.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit
 unit_rand: test/unittests/unit_rand.o src/afl-common.o src/afl-performance.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) $(SPECIAL_PERFORMANCE) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_rand  $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_rand
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 test/unittests/unit_list.o : $(COMM_HDR) include/list.h test/unittests/unit_list.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_list.c -o test/unittests/unit_list.o
@@ -526,6 +560,9 @@ test/unittests/unit_list.o : $(COMM_HDR) include/list.h test/unittests/unit_list
 unit_list: test/unittests/unit_list.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_list.o -o test/unittests/unit_list  $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_list
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 test/unittests/unit_preallocable.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_preallocable.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_preallocable.c -o test/unittests/unit_preallocable.o
@@ -533,6 +570,9 @@ test/unittests/unit_preallocable.o : $(COMM_HDR) include/alloc-inl.h test/unitte
 unit_preallocable: test/unittests/unit_preallocable.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_preallocable.o -o test/unittests/unit_preallocable $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_preallocable
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 .PHONY: unit_clean
 unit_clean:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ endif
 
 IS_IOS:=$(findstring ios, $(shell $(CC) --version 2>/dev/null))
 ifdef IS_IOS
-  override CFLAGS += -DTARGET_OS_IPHONE -DTARGET_OS_IOS
+  override CFLAGS += -DTARGET_OS_IPHONE -DTARGET_OS_IOS -isysroot $(IOS_SDK_PATH)
 endif
 
 ifeq "$(findstring android, $(shell $(CC) --version 2>/dev/null))" ""

--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -278,6 +278,8 @@ else
         AFL_CLANG_DEBUG_PREFIX =
 endif
 
+IS_IOS          := $(findstring ios, $(shell $(CC) --version 2>/dev/null))
+
 CFLAGS          ?= -O3 -funroll-loops -fPIC
 # -D_FORTIFY_SOURCE=1
 CFLAGS_SAFE     := -Wall -g -Wno-cast-qual -Wno-variadic-macros -Wno-pointer-sign \
@@ -291,6 +293,10 @@ CFLAGS_SAFE     := -Wall -g -Wno-cast-qual -Wno-variadic-macros -Wno-pointer-sig
                    -Wno-unused-function $(AFL_CLANG_DEBUG_PREFIX)
 ifndef LLVM_DEBUG
   CFLAGS_SAFE += -Wno-deprecated
+endif
+
+ifdef IOS_SDK_PATH
+  override CFLAGS_SAFE += -isysroot $(IOS_SDK_PATH)
 endif
 
 ifdef CODE_COVERAGE
@@ -309,6 +315,10 @@ CXXFLAGS          ?= -O3 -funroll-loops -fPIC
 override CXXFLAGS += -Wall -g -I ./include/ \
                      -DVERSION=\"$(VERSION)\" -Wno-variadic-macros -Wno-deprecated-copy-with-dtor \
                      -DLLVM_MINOR=$(LLVM_MINOR) -DLLVM_MAJOR=$(LLVM_MAJOR)
+
+ifdef IOS_SDK_PATH
+  override CXXFLAGS += -isysroot $(IOS_SDK_PATH)
+endif
 
 ifneq "$(shell $(LLVM_CONFIG) --includedir) 2> /dev/null" ""
   CLANG_CFL  = -I$(shell $(LLVM_CONFIG) --includedir)
@@ -356,7 +366,7 @@ ifeq "$(TEST_MMAP)" "1"
         LDFLAGS += -Wno-deprecated-declarations
 endif
 
-PROGS_ALWAYS = ./afl-cc ./afl-compiler-rt.o ./afl-compiler-rt-32.o ./afl-compiler-rt-64.o 
+PROGS_ALWAYS = ./afl-cc ./afl-compiler-rt.o ./afl-compiler-rt-32.o ./afl-compiler-rt-64.o
 PROGS        = $(PROGS_ALWAYS) ./afl-llvm-pass.so ./SanitizerCoveragePCGUARD.so ./split-compares-pass.so ./split-switches-pass.so ./cmplog-routines-pass.so ./cmplog-instructions-pass.so ./cmplog-switches-pass.so ./afl-llvm-dict2file.so ./compare-transform-pass.so ./afl-ld-lto ./afl-llvm-lto-instrumentlist.so ./SanitizerCoverageLTO.so ./injection-pass.so
 
 # If prerequisites are not given, warn, do not build anything, and exit with code 0
@@ -431,29 +441,44 @@ ifeq "$(LLVM_LTO)" "1"
 	@ln -sf afl-cc ./afl-lto++
 endif
 endif
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 instrumentation/afl-llvm-common.o: instrumentation/afl-llvm-common.cc instrumentation/afl-llvm-common.h
-	$(CXX) $(CFLAGS) $(CPPFLAGS) $$($(LLVM_CONFIG) --cxxflags) -fno-rtti -fPIC -std=$(LLVM_STDCXX) -c $< -o $@ 
+	$(CXX) $(CFLAGS) $(CPPFLAGS) $$($(LLVM_CONFIG) --cxxflags) -fno-rtti -fPIC -std=$(LLVM_STDCXX) -c $< -o $@
 
 ./afl-llvm-pass.so: instrumentation/afl-llvm-pass.so.cc instrumentation/afl-llvm-common.o | test_deps
 ifeq "$(LLVM_MIN_4_0_1)" "0"
 	$(info [!] N-gram branch coverage instrumentation is not available for llvm version $(LLVMVER))
 endif
 	$(CXX) $(CLANG_CPPFL) -Wdeprecated -fno-rtti -fPIC -std=$(LLVM_STDCXX) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 ./SanitizerCoveragePCGUARD.so: instrumentation/SanitizerCoveragePCGUARD.so.cc instrumentation/afl-llvm-common.o | test_deps
 ifeq "$(LLVM_13_OK)" "1"
 	-$(CXX) $(CLANG_CPPFL) -fno-rtti -fPIC -std=$(LLVM_STDCXX) -shared $< -o $@ $(CLANG_LFL) -Wno-deprecated-copy-dtor -Wdeprecated instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 endif
 
 ./afl-llvm-lto-instrumentlist.so: instrumentation/afl-llvm-lto-instrumentlist.so.cc instrumentation/afl-llvm-common.o
 ifeq "$(LLVM_LTO)" "1"
 	$(CXX) $(CLANG_CPPFL) -fno-rtti -fPIC -std=$(LLVM_STDCXX) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 endif
 
 ./afl-ld-lto: src/afl-ld-lto.c
 ifeq "$(LLVM_LTO)" "1"
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 endif
 
 ./SanitizerCoverageLTO.so: instrumentation/SanitizerCoverageLTO.so.cc instrumentation/afl-llvm-common.o
@@ -462,31 +487,58 @@ ifeq "$(LLVM_LTO)" "1"
 	$(CLANG_BIN) $(CFLAGS_SAFE) $(CPPFLAGS) -Wno-unused-result -O0 $(AFL_CLANG_FLTO) -fPIC -c instrumentation/afl-llvm-rt-lto.o.c -o ./afl-llvm-rt-lto.o
 	@$(CLANG_BIN) $(CFLAGS_SAFE) $(CPPFLAGS) -Wno-unused-result -O0 $(AFL_CLANG_FLTO) -m64 -fPIC -c instrumentation/afl-llvm-rt-lto.o.c -o ./afl-llvm-rt-lto-64.o 2>/dev/null; if [ "$$?" = "0" ]; then : ; fi
 	@$(CLANG_BIN) $(CFLAGS_SAFE) $(CPPFLAGS) -Wno-unused-result -O0 $(AFL_CLANG_FLTO) -m32 -fPIC -c instrumentation/afl-llvm-rt-lto.o.c -o ./afl-llvm-rt-lto-32.o 2>/dev/null; if [ "$$?" = "0" ]; then : ; fi
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 endif
 
 # laf
 ./split-switches-pass.so:	instrumentation/split-switches-pass.so.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 ./compare-transform-pass.so:	instrumentation/compare-transform-pass.so.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 ./split-compares-pass.so:	instrumentation/split-compares-pass.so.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 # /laf
 
 ./cmplog-routines-pass.so:	instrumentation/cmplog-routines-pass.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 ./cmplog-instructions-pass.so:	instrumentation/cmplog-instructions-pass.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 ./cmplog-switches-pass.so:	instrumentation/cmplog-switches-pass.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 afl-llvm-dict2file.so:	instrumentation/afl-llvm-dict2file.so.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 ./injection-pass.so:	instrumentation/injection-pass.cc instrumentation/afl-llvm-common.o | test_deps
 	$(CXX) $(CLANG_CPPFL) -shared $< -o $@ $(CLANG_LFL) instrumentation/afl-llvm-common.o
+ifdef IS_IOS
+	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 .PHONY: document
 document:
@@ -509,6 +561,9 @@ document:
 test_build: $(PROGS)
 	@echo "[*] Testing the CC wrapper and instrumentation output..."
 	unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_PATH=. AFL_LLVM_LAF_ALL=1 ./afl-cc $(CFLAGS) $(CPPFLAGS) ./test-instr.c -o test-instr $(LDFLAGS)
+ifdef IS_IOS
+	@ldid -Sentitlements.plist test-instr && echo "[+] Signed test-instr" || echo "[-] Failed to sign test-instr"
+endif
 	ASAN_OPTIONS=detect_leaks=0 ./afl-showmap -m none -q -o .test-instr0 ./test-instr < /dev/null
 	echo 1 | ASAN_OPTIONS=detect_leaks=0 ./afl-showmap -m none -q -o .test-instr1 ./test-instr
 	@rm -f test-instr

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -169,3 +169,45 @@ and definitely don't look POSIX-compliant. This means two things:
 User emulation mode of QEMU does not appear to be supported on macOS, so
 black-box instrumentation mode (`-Q`) will not work. However, FRIDA mode (`-O`)
 works on both x86 and arm64 macOS boxes.
+
+## iOS on arm64 and arm64e
+
+**Option 1: Compilation on jailbroken iOS (recommended)**
+To compile directly on a jailbroken iOS device, it is recommended to use a jailbreak that supports Procursus,
+as Procursus provides up-to-date pre-built packages for the required tools.
+
+Ensure `openssh` is installed on your iOS device, then SSH into it.
+Install the following packages:
+
+```shell
+sudo apt install wget git make cmake clang gawk llvm ldid coreutils build-essential xz-utils
+```
+
+Configure the environment for compilation:
+
+```shell
+export IOS_SDK_PATH="/usr/share/SDKs/iPhoneOS.sdk"
+export CC=clang
+export CXX=clang++
+```
+
+Then build following the general Linux instructions.
+
+**Option 2: Cross-Compilation on macOS for Jailbroken iOS**
+In addition to the packages required for a macOS build, install `ldid` for signing binaries:
+
+```shell
+brew install ldid-procursus
+```
+
+Configure the environment for compilation:
+
+```shell
+export IOS_SDK_PATH="$(xcrun --sdk iphoneos --show-sdk-path)"
+export CC="$(xcrun --sdk iphoneos -f clang) -target arm64-apple-ios14.0"
+export CXX="$(xcrun --sdk iphoneos -f clang++) -target arm64-apple-ios14.0"
+export HOST_CC=cc
+```
+
+Then build following the general Linux instructions.
+Finally, transfer the binaries to your iOS device.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -173,6 +173,7 @@ works on both x86 and arm64 macOS boxes.
 ## iOS on arm64 and arm64e
 
 **Option 1: Compilation on jailbroken iOS (recommended)**
+
 To compile directly on a jailbroken iOS device, it is recommended to use a jailbreak that supports Procursus,
 as Procursus provides up-to-date pre-built packages for the required tools.
 
@@ -194,6 +195,7 @@ export CXX=clang++
 Then build following the general Linux instructions.
 
 **Option 2: Cross-Compilation on macOS for Jailbroken iOS**
+
 In addition to the packages required for a macOS build, install `ldid` for signing binaries:
 
 ```shell

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>research.com.apple.license-to-operate</key> <true/>
+	<key>application-identifier</key> <string>aflplusplus</string>
+	<key>com.apple.asl.access_as_root</key> <true/>
+	<key>com.apple.backboardd.launchapplications</key> <true/>
+	<key>com.apple.companionappd.connect.allow</key> <true/>
+	<key>com.apple.multitasking.termination</key> <true/>
+	<key>com.apple.private.security.container-required</key> <false/>
+	<key>com.apple.seld.cm</key> <true/>
+	<key>com.apple.sh</key> <true/>
+	<key>com.apple.private.thread-set-state</key> <true/>
+	<key>com.apple.private.cs.debugger</key> <true/>
+	<key>com.apple.springboard.debugapplications</key> <true/>
+	<key>com.apple.springboard.launchapplications</key> <true/>
+	<key>com.apple.springboard.opensensitiveurl</key> <true/>
+	<key>dynamic-codesigning</key> <true/>
+	<key>get-task-allow</key> <true/>
+	<key>platform-application</key> <true/>
+	<key>run-unsigned-code</key> <true/>
+	<key>task_for_pid-allow</key> <true/>
+	<key>com.apple.private.skip-library-validation</key> <true/>
+	<key>com.apple.private.amfi.can-load-cdhash</key> <true/>
+	<key>com.apple.private.amfi.can-execute-cdhash</key> <true/>
+	<key>com.apple.private.security.no-container</key> <true/>
+</dict>
+</plist>

--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -114,6 +114,8 @@ ifdef IS_IOS
    ARCH := arm64
   endif
  endif
+ override CFLAGS += -isysroot $(IOS_SDK_PATH)
+ override LDFLAGS += -L$(IOS_SDK_PATH)/usr/lib
 else ifeq "$(shell uname)" "Darwin"
  OS:=macos
  AFL_CFLAGS:=$(AFL_CFLAGS) -Wno-deprecated-declarations
@@ -402,7 +404,9 @@ $(AFL_PERFORMANCE_OBJ): $(AFL_PERFORMANCE_SRC)
 $(BIN2C): $(BIN2C_SRC)
 	$(HOST_CC) -D_GNU_SOURCE -o $@ $<
 ifdef IS_IOS
+ifeq ($(HOST_CC),$(TARGET_CC))
 	@ldid -S../entitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 endif
 
 $(JS_SRC): $(JS) $(BIN2C)| $(BUILD_DIR)

--- a/frida_mode/GNUmakefile
+++ b/frida_mode/GNUmakefile
@@ -19,11 +19,15 @@ TARGET_CC?=$(CC)
 TARGET_CXX?=$(CXX)
 HOST_CC?=$(CC)
 HOST_CXX?=$(CXX)
-IS_ANDROID:=$(findstring android, $(shell $(TARGET_CC) --version 2>/dev/null))
-IS_x86:=$(findstring i686, $(shell $(TARGET_CC) --version 2>/dev/null))
-IS_x86_64:=$(findstring x86_64, $(shell $(TARGET_CC) --version 2>/dev/null))
-IS_ARM:=$(findstring arm, $(shell $(TARGET_CC) --version 2>/dev/null))
-IS_ARM64:=$(findstring aarch64, $(shell $(TARGET_CC) --version 2>/dev/null))
+TARGET_CC_INFO=$(shell $(TARGET_CC) --version)
+IS_IOS:=$(findstring ios, $(TARGET_CC_INFO))
+IS_SIMULATOR:=$(findstring sim, $(TARGET_CC_INFO))
+IS_ANDROID:=$(findstring android, $(TARGET_CC_INFO))
+IS_x86:=$(findstring i686, $(TARGET_CC_INFO))
+IS_x86_64:=$(findstring x86_64, $(TARGET_CC_INFO))
+IS_ARM:=$(findstring arm, $(TARGET_CC_INFO))
+IS_ARM64E:=$(findstring arm64e, $(TARGET_CC_INFO))
+IS_ARM64 := $(or $(findstring aarch64,$(TARGET_CC_INFO)), $(findstring arm64,$(TARGET_CC_INFO)))
 CFLAGS+=-fPIC \
 		-D_GNU_SOURCE \
 		-D_FORTIFY_SOURCE=2 \
@@ -95,7 +99,22 @@ endif
 
 GUM_ARCH="-$(ARCH)"
 
-ifeq "$(shell uname)" "Darwin"
+ifdef IS_IOS
+ OS:=ios
+ ifdef IS_SIMULATOR
+  ifdef IS_x86_64
+   ARCH := x86_64-simulator
+  else ifdef IS_ARM64
+   ARCH := arm64-simulator
+  endif
+ else
+  ifdef IS_ARM64E
+   ARCH := arm64e
+  else ifdef IS_ARM64
+   ARCH := arm64
+  endif
+ endif
+else ifeq "$(shell uname)" "Darwin"
  OS:=macos
  AFL_CFLAGS:=$(AFL_CFLAGS) -Wno-deprecated-declarations
  GUM_ARCH:=""
@@ -382,6 +401,9 @@ $(AFL_PERFORMANCE_OBJ): $(AFL_PERFORMANCE_SRC)
 
 $(BIN2C): $(BIN2C_SRC)
 	$(HOST_CC) -D_GNU_SOURCE -o $@ $<
+ifdef IS_IOS
+	@ldid -S../entitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 $(JS_SRC): $(JS) $(BIN2C)| $(BUILD_DIR)
 	cd $(JS_DIR) && $(BIN2C) api_js $(JS) $@
@@ -422,8 +444,10 @@ $(FRIDA_TRACE): $(GUM_DEVIT_LIBRARY) $(GUM_DEVIT_HEADER) $(OBJS) $(JS_OBJ) $(AFL
 		$(TRACE_LDFLAGS) \
 		$(LDFLAGS) \
 		$(LDSCRIPT) \
-		-o $@ \
-
+		-o $@
+ifdef IS_IOS
+	@ldid -S../entitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 	cp -v $(FRIDA_TRACE) $(ROOT)
 
 $(FRIDA_TRACE_LIB): $(GUM_DEVIT_LIBRARY) $(GUM_DEVIT_HEADER) $(OBJS) $(JS_OBJ) $(AFL_COMPILER_RT_OBJ) $(AFL_PERFORMANCE_OBJ) GNUmakefile | $(BUILD_DIR)
@@ -439,9 +463,15 @@ $(FRIDA_TRACE_LIB): $(GUM_DEVIT_LIBRARY) $(GUM_DEVIT_HEADER) $(OBJS) $(JS_OBJ) $
 
 $(AFLPP_FRIDA_DRIVER_HOOK_OBJ): $(AFLPP_FRIDA_DRIVER_HOOK_SRC) $(GUM_DEVIT_HEADER) | $(BUILD_DIR)
 	$(TARGET_CC) $(CFLAGS) $(LDFLAGS) -I $(FRIDA_BUILD_DIR) $< -o $@
+ifdef IS_IOS
+	@ldid -S../entitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 $(AFLPP_QEMU_DRIVER_HOOK_OBJ): $(AFLPP_QEMU_DRIVER_HOOK_SRC) | $(BUILD_DIR)
 	$(TARGET_CC) $(CFLAGS) $(LDFLAGS) $< -o $@
+ifdef IS_IOS
+	@ldid -S../entitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
+endif
 
 hook: $(AFLPP_FRIDA_DRIVER_HOOK_OBJ) $(AFLPP_QEMU_DRIVER_HOOK_OBJ)
 

--- a/utils/aflpp_driver/GNUmakefile
+++ b/utils/aflpp_driver/GNUmakefile
@@ -20,6 +20,10 @@ endif
 
 CFLAGS := -O3 -funroll-loops -g -fPIC
 
+ifdef IOS_SDK_PATH
+  CFLAGS += -isysroot $(IOS_SDK_PATH)
+endif
+
 all:	libAFLDriver.a libAFLQemuDriver.a aflpp_qemu_driver_hook.so
 
 aflpp_driver.o:	aflpp_driver.c


### PR DESCRIPTION
This pull request introduces support for iOS builds by adding necessary flags and signing steps in the `GNUmakefile` and `GNUmakefile.llvm` files.

Key changes include:

### iOS Support:
* Added detection for iOS in the `GNUmakefile` and `GNUmakefile.llvm` files, setting appropriate flags when iOS is detected. [[1]](diffhunk://#diff-e3445fc75aa9c3e4a60fbe5394dcce12693022018216a8fbe0000fe9952850a6R73-R77) [[2]](diffhunk://#diff-df59777df6fde079ea6fa66de4cabe471ce9ddaff0d4e2e80fd0dd3558a10ff2R281-R282)
* Updated `frida_mode/GNUmakefile` to detect iOS and set appropriate architecture and flags. [[1]](diffhunk://#diff-183db3ca4941f790dec4c5bcf0d2a83834ec769f84121cc4c7071cf17482170eL22-R30) [[2]](diffhunk://#diff-183db3ca4941f790dec4c5bcf0d2a83834ec769f84121cc4c7071cf17482170eL98-R117)
* Added signing steps using `ldid` to ensure the binaries are properly signed for iOS. [[1]](diffhunk://#diff-e3445fc75aa9c3e4a60fbe5394dcce12693022018216a8fbe0000fe9952850a6R489-R575) [[2]](diffhunk://#diff-df59777df6fde079ea6fa66de4cabe471ce9ddaff0d4e2e80fd0dd3558a10ff2R444-R446) [[3]](diffhunk://#diff-183db3ca4941f790dec4c5bcf0d2a83834ec769f84121cc4c7071cf17482170eR404-R406) [[4]](diffhunk://#diff-183db3ca4941f790dec4c5bcf0d2a83834ec769f84121cc4c7071cf17482170eL425-R450)

### Entitlements:
* Added a new `entitlements.plist` file to specify the necessary entitlements for iOS binaries. My selection of entitlements is larger than currently needed, but this should not have a negative impact.
---
## Setup Instructions
### Environment
- **Tested On:** Jailbroken iPhone 12 mini (iOS 14.2.1, Taurine Jailbreak).
- **Alternative:** Cross-compile on macOS and transfer binaries to the device.
- **Recommendation:** For compiling on device a Procursus Jailbreak makes things a lot easier because we do not have to compile all the build tools and dependencies on our own.

### Install built tools / dependencies on target device
`sudo apt install wget git make cmake clang gawk llvm ldid coreutils build-essential xz-utils`

### Build Process
```
export CC=clang CXX=clang++
CFLAGS="-DUSEMMAP=1" IOS_SDK_PATH="/usr/share/SDKs/iPhoneOS.sdk" make
cd frida_mode
CFLAGS="-DUSEMMAP=1" make
```

## What works 

* Successful build and execution of default binaries (afl-fuzz, etc.). Solves https://github.com/AFLplusplus/AFLplusplus/issues/1869.
* Building with llvm-14 (LLVM_CONFIG=/usr/lib/llvm-14/bin/llvm-config) does succeed.
* Building Frida mode does succeed.

## What does not work (yet)

* Building with llvm-16 does fail.
* Both LLVM mode and Frida mode use DYLD_INSERT_LIBRARIES to inject the shared object files. This fails on iOS due to iOS sandbox restrictions (`could not load inserted library .. into hardened process because no suitable image found.  Did find: ... file system sandbox blocked mmap() of ...` ).

## Next Steps

- Investigate DYLD_INSERT_LIBRARIES sandbox bypass strategies. Help is appreciated.
- Add support for LLVM-16 on iOS.