### PR TITLE
Fix incorrect comment in unicorn-afl python script.

### DIFF
--- a/unicorn_mode/samples/python_simple/simple_test_harness.py
+++ b/unicorn_mode/samples/python_simple/simple_test_harness.py
@@ -114,6 +114,7 @@ def main():
     # ---------------------------------------------------
     # Load the binary to emulate and map it into memory
 
+    # Load the binary to emulate
     print("Loading data input from {}".format(args.input_file))
     binary_file = open(BINARY_FILE, "rb")
     binary_code = binary_file.read()
@@ -124,7 +125,7 @@ def main():
         print("Binary code is too large (> {} bytes)".format(CODE_SIZE_MAX))
         return
 
-    # Write the mutated command into the data buffer
+    # Map the binary into memory
     uc.mem_map(CODE_ADDRESS, CODE_SIZE_MAX)
     uc.mem_write(CODE_ADDRESS, binary_code)
 

--- a/unicorn_mode/samples/python_simple/simple_test_harness_alt.py
+++ b/unicorn_mode/samples/python_simple/simple_test_harness_alt.py
@@ -142,6 +142,7 @@ def main():
     # ---------------------------------------------------
     # Load the binary to emulate and map it into memory
 
+    # Load the binary to emulate
     print("Loading data input from {}".format(args.input_file))
     binary_file = open(BINARY_FILE, "rb")
     binary_code = binary_file.read()
@@ -152,7 +153,7 @@ def main():
         print("Binary code is too large (> {} bytes)".format(CODE_SIZE_MAX))
         return
 
-    # Write the mutated command into the data buffer
+    # Map the binary into memory
     uc.mem_map(CODE_ADDRESS, CODE_SIZE_MAX)
     uc.mem_write(CODE_ADDRESS, binary_code)
 


### PR DESCRIPTION
The comment is written where the code loads binary. 
I have fixed the comment and added a new comment to adapt the top comment. ( # Load the binary to emulate and map it into memory.)
