### PR TITLE
Better handling of exit codes used by sanitzers

### DIFF
--- a/docs/fuzzing_in_depth.md
+++ b/docs/fuzzing_in_depth.md
@@ -247,6 +247,12 @@ CFISAN. You might need to experiment which sanitizers you can combine in a
 target (which means more instances can be run without a sanitized target, which
 is more effective).
 
+Note that some sanitizers (MSAN and LSAN) exit with a particular exit code
+instead of aborting. afl-fuzz treats these exit codes as a crash when these
+sanitizers are enabled. If the target uses these exit codes there could be false
+positives among the saved crashes. LSAN uses exit code 23 and MSAN uses exit
+code 86.
+
 ### d) Modifying the target
 
 If the target has features that make fuzzing more difficult, e.g., checksums,

--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -137,6 +137,8 @@ typedef struct afl_forkserver {
 
   u8 last_kill_signal;                  /* Signal that killed the child     */
 
+  u8 last_exit_code;               /* Child exit code if counted as a crash */
+
   bool use_shmem_fuzz;                  /* use shared mem for test cases    */
 
   bool support_shmem_fuzz;              /* set by afl-fuzz                  */
@@ -155,7 +157,7 @@ typedef struct afl_forkserver {
 
   bool no_unlink;                       /* do not unlink cur_input          */
 
-  bool uses_asan;                       /* Target uses ASAN?                */
+  u8 uses_asan;     /* Target uses ASAN/LSAN/MSAN? (bit 0/1/2 respectively) */
 
   bool debug;                           /* debug mode?                      */
 


### PR DESCRIPTION
Use more fine-grained detection of sanitizer crashes to reduce false positives.
Explain that a seed crash could be a false positive if it exits with a special sanitizer exit code.
Document that some sanitizers use special exit codes, and that this can result in false positive crash detection.