### PR TITLE
Bug Fix: Crash when using INTROSPECTION=1 with -z (skip deterministic)

### DIFF
--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -604,6 +604,8 @@ void maybe_update_plot_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
 
 void plot_profile_data(afl_state_t *afl, struct queue_entry *q) {
 
+  if (afl->skip_deterministic) { return; }
+
   u64 current_ms = get_cur_time() - afl->start_time;
 
   u32    current_edges = count_non_255_bytes(afl, afl->virgin_bits);


### PR DESCRIPTION
### Description

This fixes a crash that occurs when AFL++ is built with `INTROSPECTION=1` and fuzzing is run with the `-z` option (skip deterministic stage).  
The issue was caused by an incompatibility between introspection mode (which requires `det_plot_file` to be initialized) and skipping the deterministic stage (`skip_determin`).  
When both are active, the code attempts to write to `det_plot_file`, which was never initialized, resulting in a crash.

### Fix

A conditional check was added to ensure that either:
- the code does not attempt to write to `det_plot_file` when it is not initialized.

### Reproduction

```bash
make all INTROSPECTION=1 -j$(nproc)
afl-fuzz -i in -o out -z -- ./target
```
![image](https://github.com/user-attachments/assets/818cffe6-22b9-480a-8773-5cd35bcf76d4)
