### PR TITLE
avoid import already imported foreign corpus

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -668,7 +668,12 @@ void read_foreign_testcases(afl_state_t *afl, int first) {
 
       }
 
-      afl->foreign_syncs[iter].mtime = mtime_max;
+      if (mtime_max > afl->foreign_syncs[iter].mtime) {
+
+        afl->foreign_syncs[iter].mtime = mtime_max;
+
+      }
+
       free(nl);                                              /* not tracked */
 
     }


### PR DESCRIPTION
If no new foreign cases, mtime_max is 0 and this incorrectly reset last import mtime.