### PR TITLE
Define WORD_SIZE_64 for riscv64

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -171,7 +171,8 @@
 #define EXEC_TM_ROUND 20U
 
 /* 64bit arch MACRO */
-#if (defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__))
+#if (defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__) || \
+     (defined(__riscv) && __riscv_xlen == 64))
   #define WORD_SIZE_64 1
 #endif
 


### PR DESCRIPTION
#2295 should actually be fixed by a s390x equivalent of this PR.