### PR TITLE
reduce skipdet_e memory usage

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1452,6 +1452,18 @@ static inline int permissive_create(afl_state_t *afl, const char *fn) {
 
 }
 
+static inline void bitmap_set(u8 *map, u32 index) {
+
+  map[index / 8] |= (1u << (index % 8));
+
+}
+
+static inline u8 bitmap_read(u8 *map, u32 index) {
+
+  return (map[index / 8] >> (index % 8)) & 1;
+
+}
+
 #if TESTCASE_CACHE == 1
   #error define of TESTCASE_CACHE must be zero or larger than 1
 #endif

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -462,18 +462,6 @@ void write_crash_readme(afl_state_t *afl) {
 
 }
 
-static inline void bitmap_set(u8 *map, u32 index) {
-
-  map[index / 8] |= (1u << (index % 8));
-
-}
-
-static inline u8 bitmap_read(u8 *map, u32 index) {
-
-  return (map[index / 8] >> (index % 8)) & 1;
-
-}
-
 /* Check if the result of an execve() during routine fuzzing is interesting,
    save or queue the input test case for further analysis if so. Returns 1 if
    entry is saved, 0 otherwise. */

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -634,7 +634,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     afl->stage_cur_byte = afl->stage_cur >> 3;
 
-    if (!skip_eff_map[afl->stage_cur_byte]) continue;
+    if (!bitmap_read(skip_eff_map, afl->stage_cur_byte)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -754,7 +754,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     afl->stage_cur_byte = afl->stage_cur >> 3;
 
-    if (!skip_eff_map[afl->stage_cur_byte]) continue;
+    if (!bitmap_read(skip_eff_map, afl->stage_cur_byte)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -793,7 +793,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     afl->stage_cur_byte = afl->stage_cur >> 3;
 
-    if (!skip_eff_map[afl->stage_cur_byte]) continue;
+    if (!bitmap_read(skip_eff_map, afl->stage_cur_byte)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -837,7 +837,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     afl->stage_cur_byte = afl->stage_cur;
 
-    if (!skip_eff_map[afl->stage_cur_byte]) continue;
+    if (!bitmap_read(skip_eff_map, afl->stage_cur_byte)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -858,7 +858,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
   for (i = 0; i < len; i++) {
 
-    if (skip_eff_map[i]) afl->blocks_eff_select += 1;
+    if (bitmap_read(skip_eff_map, i)) afl->blocks_eff_select += 1;
 
   }
 
@@ -887,7 +887,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -930,7 +930,7 @@ u8 fuzz_one_original(afl_state_t *afl) {
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -983,7 +983,7 @@ skip_bitflip:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1067,7 +1067,7 @@ skip_bitflip:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1197,7 +1197,7 @@ skip_bitflip:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1331,7 +1331,7 @@ skip_arith:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1391,7 +1391,7 @@ skip_arith:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1479,7 +1479,7 @@ skip_arith:
 
     /* Let's consult the effector map... */
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1573,7 +1573,7 @@ skip_interest:
 
     u32 last_len = 0;
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1642,7 +1642,7 @@ skip_interest:
 
   for (i = 0; i <= (u32)len; ++i) {
 
-    if (!skip_eff_map[i % len]) continue;
+    if (!bitmap_read(skip_eff_map, i % len)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1708,7 +1708,7 @@ skip_user_extras:
 
     u32 last_len = 0;
 
-    if (!skip_eff_map[i]) continue;
+    if (!bitmap_read(skip_eff_map, i)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 
@@ -1768,7 +1768,7 @@ skip_user_extras:
 
   for (i = 0; i <= (u32)len; ++i) {
 
-    if (!skip_eff_map[i % len]) continue;
+    if (!bitmap_read(skip_eff_map, i % len)) continue;
 
     if (is_det_timeout(before_det_time, 0)) { goto custom_mutator_stage; }
 

--- a/src/afl-fuzz-skipdet.c
+++ b/src/afl-fuzz-skipdet.c
@@ -237,26 +237,26 @@ u8 skip_deterministic_stage(afl_state_t *afl, u8 *orig_buf, u8 *out_buf,
 
   if (!skip_eff_map) {
 
-    skip_eff_map = (u8 *)ck_alloc(sizeof(u8) * len);
+    skip_eff_map = (u8 *)ck_alloc(sizeof(u8) * (len + 7) / 8);
     afl->queue_cur->skipdet_e->skip_eff_map = skip_eff_map;
 
   } else {
 
-    memset(skip_eff_map, 0, sizeof(u8) * len);
+    memset(skip_eff_map, 0, sizeof(u8) * (len + 7) / 8);
 
   }
 
   /* restore the starting point */
   if (!done_inf_map) {
 
-    done_inf_map = (u8 *)ck_alloc(sizeof(u8) * len);
+    done_inf_map = (u8 *)ck_alloc(sizeof(u8) * (len + 7) / 8);
     afl->queue_cur->skipdet_e->done_inf_map = done_inf_map;
 
   } else {
 
     for (afl->stage_cur = 0; afl->stage_cur < len; afl->stage_cur++) {
 
-      if (done_inf_map[afl->stage_cur] == 0) break;
+      if (bitmap_read(done_inf_map, afl->stage_cur) == 0) break;
 
     }
 
@@ -300,7 +300,7 @@ u8 skip_deterministic_stage(afl_state_t *afl, u8 *orig_buf, u8 *out_buf,
       afl->stage_cur_byte = afl->stage_cur;
 
       if (!inf_eff_map[afl->stage_cur_byte] ||
-          skip_eff_map[afl->stage_cur_byte])
+          bitmap_read(skip_eff_map, afl->stage_cur_byte))
         continue;
 
       if (is_det_timeout(before_det_time, 1)) { goto cleanup_skipdet; }
@@ -339,7 +339,7 @@ u8 skip_deterministic_stage(afl_state_t *afl, u8 *orig_buf, u8 *out_buf,
 
       if (afl->queued_items != before_skip_inf) {
 
-        skip_eff_map[afl->stage_cur_byte] = 1;
+        bitmap_set(skip_eff_map, afl->stage_cur_byte);
         afl->queue_cur->skipdet_e->quick_eff_bytes += 1;
 
         if (afl->stage_max < MAXIMUM_QUICK_EFF_EXECS) { afl->stage_max *= 2; }
@@ -349,7 +349,7 @@ u8 skip_deterministic_stage(afl_state_t *afl, u8 *orig_buf, u8 *out_buf,
 
       }
 
-      done_inf_map[afl->stage_cur_byte] = 1;
+      bitmap_set(done_inf_map, afl->stage_cur_byte);
 
     }
 
@@ -375,7 +375,7 @@ cleanup_skipdet:
     while (i < len) {
 
       // assume DWORD size, from i - 3 -> i + 3
-      if (skip_eff_map[i]) {
+      if (bitmap_read(skip_eff_map, i)) {
 
         u32 fill_length = (i + 3 < len) ? 7 : len - i + 2;
         memset(nearby_bytes + i - 3, 1, fill_length);
@@ -389,7 +389,7 @@ cleanup_skipdet:
 
     for (i = 0; i < len; i++) {
 
-      if (nearby_bytes[i] && !non_eff_bytes[i]) skip_eff_map[i] = 1;
+      if (nearby_bytes[i] && !non_eff_bytes[i]) bitmap_set(skip_eff_map, i);
 
     }
 


### PR DESCRIPTION
By using bitmaps, the memory requirement for
`q->skipdet_e->skip_eff_map` and `done_inf_map`, which previously scaled with the corpus size, is reduced to one-eighth of its original size.