### PR TITLE
Fix comments in for SAND

### DIFF
--- a/include/asanfuzz.h
+++ b/include/asanfuzz.h
@@ -37,11 +37,11 @@
 
 enum SanitizerAbstraction {
 
-  SIMPLIFY_TRACE = 0,  // Feed all unique trace to sanitizers, the
-                       // most sensitive
-  UNIQUE_TRACE,
-  COVERAGE_INCREASE  // Feed all coverage increasing cases to sanitizers, the
-                     // least sensitive
+  SIMPLIFY_TRACE = 0,  // Feed all simplified trace to sanitizers, moderate
+                       // sensitive and default for SAND.
+  UNIQUE_TRACE,        // Feed all unique trace to sanitizers, the most sensitive.
+  COVERAGE_INCREASE    // Feed all coverage increasing cases to sanitizers, the
+                       // least sensitive
 
 };
 

--- a/include/asanfuzz.h
+++ b/include/asanfuzz.h
@@ -38,10 +38,11 @@
 enum SanitizerAbstraction {
 
   SIMPLIFY_TRACE = 0,  // Feed all simplified trace to sanitizers, moderate
-                       // sensitive and default for SAND.
-  UNIQUE_TRACE,        // Feed all unique trace to sanitizers, the most sensitive.
+                       // sensitive and default for SAND. Not missing bugs.
+  UNIQUE_TRACE,        // Feed all unique trace to sanitizers, the most sensitive
+                       // and not missing bugs.
   COVERAGE_INCREASE    // Feed all coverage increasing cases to sanitizers, the
-                       // least sensitive
+                       // least sensitive at a risk of missing ~20% bugs.
 
 };
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2605,7 +2605,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   } else {
 
-    WARNF("Unknown abstraction: %s, fallback to unique trace.\n",
+    WARNF("Unknown abstraction: %s, fallback to simplified trace.\n",
           san_abstraction);
     afl->san_abstraction = SIMPLIFY_TRACE;
 


### PR DESCRIPTION
As found by @kcwu , there are a few outdated comments when porting to latest AFL++.

Thanks to him for finding these!