### PR TITLE
fix: ensure correct rescoring using latest queue entry execution

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1187,6 +1187,7 @@ void mark_as_redundant(afl_state_t *, struct queue_entry *, u8);
 void add_to_queue(afl_state_t *, u8 *, u32, u8);
 void destroy_queue(afl_state_t *);
 void update_bitmap_score(afl_state_t *, struct queue_entry *);
+void recalculate_all_scores(afl_state_t *);
 void cull_queue(afl_state_t *);
 u32  calculate_score(afl_state_t *, struct queue_entry *);
 

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -938,6 +938,21 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
 
 }
 
+void recalculate_all_scores(afl_state_t *afl) {
+
+  u8 *in_buf;
+
+  for (u32 i = 0; i < afl->queued_items; i++) {
+    if (likely(!afl->queue_buf[i]->disabled)) {
+      in_buf = queue_testcase_get(afl, afl->queue_buf[i]);
+      (void)write_to_testcase(afl, in_buf, afl->queue_buf[i]->len, 1);
+      (void)fuzz_run_target(afl, &afl->fsrv, afl->fsrv.exec_tmout);
+      update_bitmap_score(afl, afl->queue_buf[i]);
+    }
+  }
+  
+}
+
 /* The second part of the mechanism discussed above is a routine that
    goes over afl->top_rated[] entries, and then sequentially grabs winners for
    previously-unseen bytes (temp_v) and marks them as favored, at least

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -938,6 +938,13 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
 
 }
 
+/* Recalculate the bitmap scores for all testcases in the queue.
+ 
+   This function re-runs each enabled testcase and updates its
+   bitmap score, which affects its selection probability during fuzzing.
+   It is typically used when AFL_CYCLE_SCHEDULES=1 to periodically
+   refresh the scores after a full cycle. */
+
 void recalculate_all_scores(afl_state_t *afl) {
 
   u8 *in_buf;
@@ -950,7 +957,7 @@ void recalculate_all_scores(afl_state_t *afl) {
       update_bitmap_score(afl, afl->queue_buf[i]);
     }
   }
-  
+
 }
 
 /* The second part of the mechanism discussed above is a routine that

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -3234,17 +3234,8 @@ int main(int argc, char **argv_orig, char **envp) {
             break;
 
         }
-
-        // we must recalculate the scores of all queue entries
-        for (u32 i = 0; i < afl->queued_items; i++) {
-
-          if (likely(!afl->queue_buf[i]->disabled)) {
-
-            update_bitmap_score(afl, afl->queue_buf[i]);
-
-          }
-
-        }
+        
+        recalculate_all_scores(afl);
 
       }
 


### PR DESCRIPTION
### Problem

The `update_bitmap_score()` function depends on `trace_bits` to determine
if a queue entry should be marked as `top_rated`. However, in the previous
rescoring implementation, `update_bitmap_score()` was called without
re-executing the corresponding queue entry. This meant that `trace_bits`
could belong to a different entry, leading to incorrect `top_rated` selection.

### Fix

This change ensures that each queue entry is executed before calling
`update_bitmap_score()` during rescoring. This guarantees that the
`trace_bits` used match the queue entry being rescored.