### PR TITLE
Fix sand due to default schedule change

### DIFF
--- a/include/coverage-32.h
+++ b/include/coverage-32.h
@@ -69,20 +69,7 @@ void simplify_trace(afl_state_t *afl, u8 *bytes) {
 }
 
 inline void classify_counts(afl_forkserver_t *fsrv) {
-
-  u32 *mem = (u32 *)fsrv->trace_bits;
-  u32  i = (fsrv->map_size >> 2);
-
-  while (i--) {
-
-    /* Optimize for sparse bitmaps. */
-
-    if (unlikely(*mem)) { *mem = classify_word(*mem); }
-
-    mem++;
-
-  }
-
+  classify_counts_mem((u32 *)fsrv->trace_bits, fsrv->map_size);
 }
 
 /* Updates the virgin bits, then reflects whether a new count or a new tuple is

--- a/include/coverage-32.h
+++ b/include/coverage-32.h
@@ -9,7 +9,6 @@
 
 u32  skim(const u32 *virgin, const u32 *current, const u32 *current_end);
 u32  classify_word(u32 word);
-void classify_counts_mem(u32 *mem, u32 size);
 
 inline u32 classify_word(u32 word) {
 
@@ -21,22 +20,6 @@ inline u32 classify_word(u32 word) {
 
   memcpy(&word, mem16, sizeof(mem16));
   return word;
-
-}
-
-inline void classify_counts_mem(u32 *mem, u32 size) {
-
-  u32 i = (size >> 2);
-
-  while (i--) {
-
-    /* Optimize for sparse bitmaps. */
-
-    if (unlikely(*mem)) { *mem = classify_word(*mem); }
-
-    mem++;
-
-  }
 
 }
 
@@ -69,7 +52,18 @@ void simplify_trace(afl_state_t *afl, u8 *bytes) {
 }
 
 inline void classify_counts(afl_forkserver_t *fsrv) {
-  classify_counts_mem((u32 *)fsrv->trace_bits, fsrv->map_size);
+  u32 *mem = (u32 *)fsrv->trace_bits;
+  u32 i = (fsrv->map_size >> 2);
+
+  while (i--) {
+
+    /* Optimize for sparse bitmaps. */
+
+    if (unlikely(*mem)) { *mem = classify_word(*mem); }
+
+    mem++;
+
+  }
 }
 
 /* Updates the virgin bits, then reflects whether a new count or a new tuple is

--- a/include/coverage-64.h
+++ b/include/coverage-64.h
@@ -13,7 +13,6 @@
 
 u32  skim(const u64 *virgin, const u64 *current, const u64 *current_end);
 u64  classify_word(u64 word);
-void classify_counts_mem(u64 *mem, u32 size);
 
 inline u64 classify_word(u64 word) {
 
@@ -63,12 +62,8 @@ void simplify_trace(afl_state_t *afl, u8 *bytes) {
 }
 
 inline void classify_counts(afl_forkserver_t *fsrv) {
-  classify_counts_mem((u64 *)fsrv->trace_bits, fsrv->map_size);
-}
-
-inline void classify_counts_mem(u64 *mem, u32 size) {
-
-  u32 i = (size >> 3);
+  u64 *mem = (u64 *)fsrv->trace_bits;
+  u32 i = (fsrv->map_size >> 3);
 
   while (i--) {
 
@@ -79,7 +74,6 @@ inline void classify_counts_mem(u64 *mem, u32 size) {
     mem++;
 
   }
-
 }
 
 /* Updates the virgin bits, then reflects whether a new count or a new tuple is

--- a/include/coverage-64.h
+++ b/include/coverage-64.h
@@ -63,20 +63,7 @@ void simplify_trace(afl_state_t *afl, u8 *bytes) {
 }
 
 inline void classify_counts(afl_forkserver_t *fsrv) {
-
-  u64 *mem = (u64 *)fsrv->trace_bits;
-  u32  i = (fsrv->map_size >> 3);
-
-  while (i--) {
-
-    /* Optimize for sparse bitmaps. */
-
-    if (unlikely(*mem)) { *mem = classify_word(*mem); }
-
-    mem++;
-
-  }
-
+  classify_counts_mem((u64 *)fsrv->trace_bits, afl->map_size);
 }
 
 inline void classify_counts_mem(u64 *mem, u32 size) {

--- a/include/coverage-64.h
+++ b/include/coverage-64.h
@@ -63,7 +63,7 @@ void simplify_trace(afl_state_t *afl, u8 *bytes) {
 }
 
 inline void classify_counts(afl_forkserver_t *fsrv) {
-  classify_counts_mem((u64 *)fsrv->trace_bits, afl->map_size);
+  classify_counts_mem((u64 *)fsrv->trace_bits, fsrv->map_size);
 }
 
 inline void classify_counts_mem(u64 *mem, u32 size) {

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -552,7 +552,17 @@ u8 __attribute__((hot)) save_if_interesting(afl_state_t *afl, void *mem,
 
     if (unlikely(afl->san_binary_length) &&
         likely(afl->san_abstraction == UNIQUE_TRACE)) {
-
+      
+      // If schedule is not FAST..EXPLORE, we need to classify here
+      // Note: SAND was evaluated under FAST schedule but should also work
+      //       with other scedules.
+      if (!classified) {
+        classify_counts_mem(
+        (u64*)afl->fsrv.trace_bits,
+          afl->fsrv.map_size
+        );
+        classified = 1;
+      }
       cksum_unique =
           hash32(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
       if (unlikely(!bitmap_read(afl->n_fuzz_dup, cksum) &&
@@ -615,8 +625,12 @@ u8 __attribute__((hot)) save_if_interesting(afl_state_t *afl, void *mem,
 
       /* If we are in coverage increasing abstraction and have fed input to
          sanitizers, we are sure it has new bits.*/
-      new_bits = has_new_bits_unclassified(afl, afl->virgin_bits);
-
+      if (classified) {
+        /* We could have classified the bits in SAND with UNIQUE_TRACE */
+        new_bits = has_new_bits(afl, afl->virgin_bits);
+      } else {
+        new_bits = has_new_bits_unclassified(afl, afl->virgin_bits);
+      }
     }
 
     if (likely(!new_bits)) {

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -553,7 +553,7 @@ u8 __attribute__((hot)) save_if_interesting(afl_state_t *afl, void *mem,
     if (unlikely(afl->san_binary_length) &&
         likely(afl->san_abstraction == UNIQUE_TRACE)) {
       
-      // If schedule is not FAST..EXPLORE, we need to classify here
+      // If schedule is not FAST..RARE, we need to classify counts here
       // Note: SAND was evaluated under FAST schedule but should also work
       //       with other scedules.
       if (!classified) {

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -557,10 +557,7 @@ u8 __attribute__((hot)) save_if_interesting(afl_state_t *afl, void *mem,
       // Note: SAND was evaluated under FAST schedule but should also work
       //       with other scedules.
       if (!classified) {
-        classify_counts_mem(
-        (u64*)afl->fsrv.trace_bits,
-          afl->fsrv.map_size
-        );
+        classify_counts(&afl->fsrv);
         classified = 1;
       }
       cksum_unique =

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -490,7 +490,7 @@ u8 __attribute__((hot)) save_if_interesting(afl_state_t *afl, void *mem,
 
   u8  fn[PATH_MAX];
   u8 *queue_fn = "";
-  u8  new_bits = 0, keeping = 0, res, is_timeout = 0, need_hash = 1;
+  u8  new_bits = 0, keeping = 0, res, is_timeout = 0, classified = 0, need_hash = 1;
   s32 fd;
   u64 cksum = 0;
   u32 cksum_simplified = 0, cksum_unique = 0;


### PR DESCRIPTION
Thanks to the review from @kcwu , this fixes the implementation of `UNIQUE_TRACE` in case the scedule is not `FAST`.

I also reduce the code duplication a bit.