### PR TITLE
fix: correct rescoring logic with minimal executions

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -721,6 +721,8 @@ typedef struct afl_state {
 
   struct queue_entry **top_rated;           /* Top entries for bitmap bytes */
 
+  u32 **top_rated_candidates;               /* Candidate IDs per bitmap index */
+
   struct extra_data *extras;            /* Extra tokens to fuzz with        */
   u32                extras_cnt;        /* Total number of tokens read      */
 
@@ -861,6 +863,8 @@ typedef struct afl_state {
   struct havoc_profile *havoc_prof;
 
   struct skipdet_global *skipdet_g;
+
+  s64 last_scored_idx;  /* Index of the last queue entry re-scored */
 
 #ifdef INTROSPECTION
   char  mutation[8072];
@@ -1189,6 +1193,8 @@ void destroy_queue(afl_state_t *);
 void update_bitmap_score(afl_state_t *, struct queue_entry *, bool);
 void cull_queue(afl_state_t *);
 u32  calculate_score(afl_state_t *, struct queue_entry *);
+void recalculate_all_scores(afl_state_t *);
+void update_bitmap_rescore(afl_state_t *, struct queue_entry *, u32);
 
 /* Bitmap */
 

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -117,7 +117,6 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->virgin_crash = ck_alloc(map_size);
   afl->var_bytes = ck_alloc(map_size);
   afl->top_rated = ck_alloc(map_size * sizeof(void *));
-  afl->top_rated_candidates = ck_alloc(map_size * sizeof(u32));
   afl->clean_trace = ck_alloc(map_size);
   afl->clean_trace_custom = ck_alloc(map_size);
   afl->first_trace = ck_alloc(map_size);

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -106,7 +106,8 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->switch_fuzz_mode = STRATEGY_SWITCH_TIME * 1000;
   afl->q_testcase_max_cache_size = TESTCASE_CACHE_SIZE * 1048576UL;
   afl->q_testcase_max_cache_entries = 64 * 1024;
-
+  afl->last_scored_idx = -1;
+  
 #ifdef HAVE_AFFINITY
   afl->cpu_aff = -1;                    /* Selected CPU core                */
 #endif                                                     /* HAVE_AFFINITY */
@@ -116,6 +117,7 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   afl->virgin_crash = ck_alloc(map_size);
   afl->var_bytes = ck_alloc(map_size);
   afl->top_rated = ck_alloc(map_size * sizeof(void *));
+  afl->top_rated_candidates = ck_alloc(map_size * sizeof(u32));
   afl->clean_trace = ck_alloc(map_size);
   afl->clean_trace_custom = ck_alloc(map_size);
   afl->first_trace = ck_alloc(map_size);

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -3227,15 +3227,7 @@ int main(int argc, char **argv_orig, char **envp) {
         }
 
         // we must recalculate the scores of all queue entries
-        for (u32 i = 0; i < afl->queued_items; i++) {
-
-          if (likely(!afl->queue_buf[i]->disabled)) {
-
-            update_bitmap_score(afl, afl->queue_buf[i], false);
-
-          }
-
-        }
+        recalculate_all_scores(afl);
 
       }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1750,6 +1750,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+  if (afl->cycle_schedules) {
+
+    afl->top_rated_candidates = ck_alloc(map_size * sizeof(u32));
+
+  }
+
   afl->n_fuzz_dup = ck_alloc(N_FUZZ_SIZE_BITMAP * sizeof(u8));
   afl->simplified_n_fuzz = ck_alloc(N_FUZZ_SIZE_BITMAP * sizeof(u8));
 


### PR DESCRIPTION
Previous scoring logic did not correctly rescore all queue entries.

This patch ensures rescoring works under the updated scheduling logic, while minimizing executions per feedback from PR #2363.

Based on feedback from: https://github.com/AFLplusplus/AFLplusplus/pull/2363

Since `cycle_schedules` is closer to an optional feature than a default one,
I made sure to avoid modifying default-path functions to minimize any impact on performance.