### PR TITLE
Fix linker error

### DIFF
--- a/qemu_mode/README.deferred_initialization_example.md
+++ b/qemu_mode/README.deferred_initialization_example.md
@@ -40,7 +40,7 @@ ALPINE_ROOT=<your-alpine-sysroot-directory>
 FUZZ=<your-path-to-the-code>
 sudo systemd-nspawn -D $ALPINE_ROOT --bind=$FUZZ:/fuzz
 CC=$(which clang) CFLAGS="-g" LDSHARED="clang -shared" python3 -m pip install /fuzz
-clang $(python3-config --embed --cflags) $(python3-config --embed --ldflags) -o /fuzz/fuzz_harness /fuzz/fuzz_harness.c
+clang $(python3-config --embed --cflags) -o /fuzz/fuzz_harness /fuzz/fuzz_harness.c $(python3-config --embed --ldflags)
 exit
 ```
 


### PR DESCRIPTION
This pull request fixes a linker error in the QEMU deferred initialization example.

Before:

```bash
alpinesysroot:~# clang $(python3-config --embed --cflags) $(python3-config --embed --ldflags) -o /fuzz/fuzz_harness /fuzz/fuzz_harness.c
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /tmp/fuzz_harness-cbf277.o: in function `main':
/fuzz/fuzz_harness.c:9:(.text+0x44): undefined reference to `Py_Initialize'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /fuzz/fuzz_harness.c:10:(.text+0x50): undefined reference to `PyUnicode_DecodeFSDefault'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /fuzz/fuzz_harness.c:11:(.text+0x5c): undefined reference to `PyImport_Import'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /tmp/fuzz_harness-cbf277.o: in function `Py_DECREF':
/usr/include/python3.12/object.h:705:(.text+0xa0): undefined reference to `_Py_Dealloc'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /tmp/fuzz_harness-cbf277.o: in function `main':
/fuzz/fuzz_harness.c:15:(.text+0xc0): undefined reference to `PyObject_GetAttrString'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /fuzz/fuzz_harness.c:18:(.text+0x104): undefined reference to `PyBytes_FromStringAndSize'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /fuzz/fuzz_harness.c:21:(.text+0x128): undefined reference to `PyObject_CallFunctionObjArgs'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /tmp/fuzz_harness-cbf277.o: in function `Py_DECREF':
/usr/include/python3.12/object.h:705:(.text+0x184): undefined reference to `_Py_Dealloc'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /usr/include/python3.12/object.h:705:(.text+0x1c8): undefined reference to `_Py_Dealloc'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /usr/include/python3.12/object.h:705:(.text+0x208): undefined reference to `_Py_Dealloc'
/usr/lib/gcc/armv7-alpine-linux-musleabihf/14.2.0/../../../../armv7-alpine-linux-musleabihf/bin/ld: /tmp/fuzz_harness-cbf277.o: in function `Py_XDECREF':
/usr/include/python3.12/object.h:705:(.text+0x280): undefined reference to `_Py_Dealloc'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Now:
```bash
alpinesysroot:~# clang $(python3-config --embed --cflags) -o /fuzz/fuzz_harness /fuzz/fuzz_harness.c $(python3-config --embed --ldflags)
alpinesysroot:~# 
```
