### PR TITLE
build: improve lld version parsing

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -240,7 +240,7 @@ ifeq "$(LLVM_LTO)" "1"
       else
         ifneq "$(shell command -v ld.lld 2>/dev/null)" ""
           AFL_REAL_LD = $(shell command -v ld.lld)
-          TMP_LDLDD_VERSION = $(shell $(AFL_REAL_LD) --version | awk '{ print $$2 }')
+          TMP_LDLDD_VERSION = $(shell $(AFL_REAL_LD) --version | sed -E -ne '/^.*LLD\ ([12]?[0-9]\.[0-9]\.[0-9]).*/s//\1/p')
           ifeq "$(LLVMVER)" "$(TMP_LDLDD_VERSION)"
             $(warning ld.lld found in a weird location ($(AFL_REAL_LD)), but its the same version as LLVM so we will allow it)
           else


### PR DESCRIPTION
Currently, if LLD is in a weird location and has a version string like:
```bash
Ubuntu LLD 18.1.3 (compatible with GNU linkers)
```
or
```bash
Homebrew LLD 20.1.2 (compatible with GNU linkers)
```

The version comparison will fail:
```bash
GNUmakefile.llvm:247: ld.lld found in a weird location (/opt/homebrew/bin/ld.lld) and its of a different version than LLMV (LLD vs. 20.1.2) - cannot enable LTO mode
```

Fix that by replacing the usage of awk, with the same sed command used to retrieve the version of Clang, which fixes the issue:
```bash
GNUmakefile.llvm:245: ld.lld found in a weird location (/opt/homebrew/bin/ld.lld), but its the same version as LLVM so we will allow it
```