### PR TITLE
Ubuntu 20.04 removed by GitHub

### DIFF
--- a/.github/workflows/rust_custom_mutator.yml
+++ b/.github/workflows/rust_custom_mutator.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: custom_mutators/rust
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust Toolchain


### PR DESCRIPTION
Support for this has been removed by GitHub: https://github.com/actions/runner-images/issues/11101. 
This is now showing up as a failure in PRs i.e #2383.