### PR TITLE
fix infinite loop when custom mutator rejects smallest_favored

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Thank you! (For people sending pull requests - please add yourself to this list
     Ruben ten Hove                        Joey Jiao
     fuzzah                                @intrigus-lgtm
     Yaakov Saxon                          Sergej Schumilo
-    Ziqiao Kong
+    Ziqiao Kong                           Ryan Berger
   ```
 
 </details>

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -356,8 +356,12 @@ u8 fuzz_one_original(afl_state_t *afl) {
       if (el->afl_custom_queue_get &&
           !el->afl_custom_queue_get(el->data, afl->queue_cur->fname)) {
 
-        return 1;
-
+        /* Abandon the entry and return that we skipped it.
+           If we don't do this then when the entry is smallest_favored then
+           we get caught in an infinite loop calling afl_custom_queue_get
+           on smallest_favored */
+        ret_val = 1;
+        goto abandon_entry;
       }
 
     });


### PR DESCRIPTION
When running with custom mutators, afl-fuzz delegates the responsibility of queuing to` afl_custom_queue_get` implemented by the mutator. If any mutator cannot process the input, then it is rejected. After an input is rejected then a new suitable item to queue must be found. Before this PR, that would be `smallest_favored`. However, if `smallest_favored` were rejected, it would not be cleared from its position as  `smallest_favored` meaning it would be attempted to be queued again catching afl-fuzz in an infinite loop.

To fix it, we simply return that we skipped the entry, along with using a `goto abandon_entry` to clean the entry up so that the fuzzer never considers the input again