### PR TITLE
Define WORD_SIZE_64 for more 64-bit arches

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -172,7 +172,8 @@
 
 /* 64bit arch MACRO */
 #if (defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__) || \
-     (defined(__riscv) && __riscv_xlen == 64))
+     (defined(__riscv) && __riscv_xlen == 64) || defined(__powerpc64le__) || \
+     defined(__s390x__) || defined(__loongarch64))
   #define WORD_SIZE_64 1
 #endif
 


### PR DESCRIPTION
This enables 64-bit detection for the following additional systems:

- [PowerPC64 (little endian)](https://en.wikipedia.org/wiki/Ppc64)
- [S390x](https://en.wikipedia.org/wiki/S390x)
- [LoongArch64](https://en.wikipedia.org/wiki/LoongArch64)