### PR TITLE
Color `AFL_NO_UI` output

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -411,11 +411,12 @@ u8 fuzz_one_original(afl_state_t *afl) {
     u_simplestring_time_diff(time_tmp, afl->prev_run_time + get_cur_time(),
                              afl->start_time);
     ACTF(
-        "Fuzzing test case #%u (%u total, %llu crashes saved, state: %s, "
+        "Fuzzing test case #%u (%u total, %s%llu crashes saved%s, state: %s, "
         "mode=%s, "
         "perf_score=%0.0f, weight=%0.0f, favorite=%u, was_fuzzed=%u, "
         "exec_us=%llu, hits=%u, map=%u, ascii=%u, run_time=%s)...",
-        afl->current_entry, afl->queued_items, afl->saved_crashes,
+        afl->current_entry, afl->queued_items,
+        afl->saved_crashes != 0 ? cRED : "", afl->saved_crashes, cRST,
         get_fuzzing_state(afl), afl->fuzz_mode ? "exploit" : "explore",
         afl->queue_cur->perf_score, afl->queue_cur->weight,
         afl->queue_cur->favored, afl->queue_cur->was_fuzzed,

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -28,8 +28,13 @@
 #include "envs.h"
 #include <limits.h>
 
-static char fuzzing_state[4][12] = {"started :-)", "in progress", "final phase",
-                                    "finished..."};
+//  7 is the number of characters in a color control code
+// 11 is the number of characters in the fuzzing state itself
+//  5 is the number of characters in `cRST`
+//  1 is for the null character
+static char fuzzing_state[4][7 + 11 + 5 + 1] = {
+
+    "started :-)", "in progress", "final phase", cRED "finished..." cRST};
 
 char *get_fuzzing_state(afl_state_t *afl) {
 


### PR DESCRIPTION
Fixes #2405

Specifically:
- Colors `N crashes saved` red when `N` is positive
- Colors `finished...` red in `state: finished...`

Nits are welcome.