### PR TITLE
Add missing override directive for CFLAGS+= in libdislocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Thank you! (For people sending pull requests - please add yourself to this list
     fuzzah                                @intrigus-lgtm
     Yaakov Saxon                          Sergej Schumilo
     Ziqiao Kong                           Ryan Berger
-    Sangjun Park
+    Sangjun Park                          Scott Guest
   ```
 
 </details>

--- a/utils/libdislocator/Makefile
+++ b/utils/libdislocator/Makefile
@@ -19,11 +19,11 @@ HELPER_PATH  = $(PREFIX)/lib/afl
 VERSION     = $(shell grep '^\#define VERSION ' ../../config.h | cut -d '"' -f2)
 
 CFLAGS      ?= -O3 -funroll-loops -D_FORTIFY_SOURCE=2
-CFLAGS += -I ../../include/ -Wall -g -Wno-pointer-sign
+override CFLAGS += -I ../../include/ -Wall -g -Wno-pointer-sign
 
 CFLAGS_ADD=$(USEHUGEPAGE:1=-DUSEHUGEPAGE)
 CFLAGS_ADD += $(USENAMEDPAGE:1=-DUSENAMEDPAGE)
-CFLAGS += $(CFLAGS_ADD)
+override CFLAGS += $(CFLAGS_ADD)
 
 all: libdislocator.so
 
@@ -41,4 +41,3 @@ install: all
 	install -m 755 -d $${DESTDIR}$(HELPER_PATH)
 	install -m 755 ../../libdislocator.so $${DESTDIR}$(HELPER_PATH)
 	install -m 644 -T README.md $${DESTDIR}$(HELPER_PATH)/README.dislocator.md
-


### PR DESCRIPTION
libdislocator fails to build with a user-provided `CFLAGS`, e.g.
```
make sources-only CFLAGS='-O1'
```
reports
```
...
make[1]: Entering directory '/home/sguest/src/AFLplusplus/utils/libdislocator'
cc -O1  -shared -fPIC libdislocator.so.c -o libdislocator.so 
libdislocator.so.c:76:10: fatal error: config.h: No such file or directory
   76 | #include "config.h"
      |          ^~~~~~~~~~
compilation terminated.
make[1]:` *** [Makefile:31: libdislocator.so] Error 1
...
```
This is fixed by adding an `override` directive to the appropriate `CFLAGS += -I ...`