### PR TITLE
Allow cmplog with unicorn mode

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -587,7 +587,6 @@ typedef struct afl_state {
       no_arith,                         /* Skip most arithmetic ops         */
       shuffle_queue,                    /* Shuffle input queue?             */
       bitmap_changed,                   /* Time to update bitmap?           */
-      unicorn_mode,                     /* Running in Unicorn mode?         */
       use_wine,                         /* Use WINE with QEMU mode          */
       skip_requested,                   /* Skip request, via SIGUSR1        */
       run_over10m,                      /* Run time over 10 minutes?        */

--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -153,6 +153,8 @@ typedef struct afl_forkserver {
 
   bool cs_mode;                      /* if running in CoreSight mode or not */
 
+  bool unicorn_mode;                   /* if running in unicorn mode or not */
+
   bool use_stdin;                       /* use stdin for sending data       */
 
   bool no_unlink;                       /* do not unlink cur_input          */

--- a/src/afl-analyze.c
+++ b/src/afl-analyze.c
@@ -78,6 +78,7 @@ static u8 *target_path;
 static u8  frida_mode;
 static u8  qemu_mode;
 static u8  cs_mode;
+static u8  unicorn_mode;
 static u32 map_size = MAP_SIZE;
 
 static afl_forkserver_t fsrv = {0};   /* The forkserver                     */
@@ -813,7 +814,7 @@ static void usage(u8 *argv0) {
 int main(int argc, char **argv_orig, char **envp) {
 
   s32    opt;
-  u8     mem_limit_given = 0, timeout_given = 0, unicorn_mode = 0, use_wine = 0;
+  u8     mem_limit_given = 0, timeout_given = 0, use_wine = 0;
   char **use_argv;
   char **argv = argv_cpy_dup(argc, argv_orig);
 
@@ -960,6 +961,7 @@ int main(int argc, char **argv_orig, char **envp) {
         if (!mem_limit_given) { mem_limit = MEM_LIMIT_UNICORN; }
 
         unicorn_mode = 1;
+        fsrv.unicorn_mode = unicorn_mode;
         fsrv.mem_limit = mem_limit;
         break;
 
@@ -1102,7 +1104,7 @@ int main(int argc, char **argv_orig, char **envp) {
   }
 
   configure_afl_kill_signals(
-      &fsrv, NULL, NULL, (fsrv.qemu_mode || unicorn_mode) ? SIGKILL : SIGTERM);
+      &fsrv, NULL, NULL, (fsrv.qemu_mode || fsrv.unicorn_mode) ? SIGKILL : SIGTERM);
 
   read_initial_file();
 #ifdef __linux__

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1278,7 +1278,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
       if ((status & FS_OPT_ERROR) == FS_OPT_ERROR)
         report_error_and_exit(FS_OPT_GET_ERROR(status));
 
-      if (fsrv->cmplog_binary && !fsrv->qemu_mode) {
+      if (fsrv->cmplog_binary && !fsrv->qemu_mode && !fsrv->unicorn_mode) {
 
         FATAL("Target was compiled with outdated CMPLOG, recompile it!\n");
 
@@ -1293,7 +1293,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         if ((status & FS_OPT_NEWCMPLOG) == 0 && fsrv->cmplog_binary) {
 
-          if (fsrv->qemu_mode || fsrv->frida_mode) {
+          if (fsrv->qemu_mode || fsrv->frida_mode || fsrv->unicorn_mode) {
 
             report_error_and_exit(FS_ERROR_OLD_CMPLOG_QEMU);
 

--- a/src/afl-fuzz-cmplog.c
+++ b/src/afl-fuzz-cmplog.c
@@ -39,7 +39,7 @@ void cmplog_exec_child(afl_forkserver_t *fsrv, char **argv) {
 
   }
 
-  if (!fsrv->qemu_mode && !fsrv->frida_mode && argv[0] != fsrv->cmplog_binary) {
+  if (!fsrv->qemu_mode && !fsrv->frida_mode && !fsrv->unicorn_mode && argv[0] != fsrv->cmplog_binary) {
 
     fsrv->target_path = argv[0] = fsrv->cmplog_binary;
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -3033,7 +3033,7 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
   }
 
-  if (afl->afl_env.afl_skip_bin_check || afl->use_wine || afl->unicorn_mode ||
+  if (afl->afl_env.afl_skip_bin_check || afl->use_wine || afl->fsrv.unicorn_mode ||
       (afl->fsrv.qemu_mode && getenv("AFL_QEMU_CUSTOM_BIN")) ||
       (afl->fsrv.cs_mode && getenv("AFL_CS_CUSTOM_BIN")) ||
       afl->non_instrumented_mode) {
@@ -3111,7 +3111,7 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
 #endif                                                       /* ^!__APPLE__ */
 
-  if (!afl->fsrv.qemu_mode && !afl->fsrv.frida_mode && !afl->unicorn_mode &&
+  if (!afl->fsrv.qemu_mode && !afl->fsrv.frida_mode && !afl->fsrv.unicorn_mode &&
 #ifdef __linux__
       !afl->fsrv.nyx_mode &&
 #endif

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -450,7 +450,7 @@ void write_stats_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
           t_bytes, afl->fsrv.real_map_size, afl->var_byte_count,
           afl->expand_havoc, afl->a_extras_cnt, afl->q_testcase_cache_size,
           afl->q_testcase_cache_count, afl->q_testcase_evictions,
-          afl->use_banner, afl->unicorn_mode ? "unicorn" : "",
+          afl->use_banner, afl->fsrv.unicorn_mode ? "unicorn" : "",
           afl->fsrv.qemu_mode ? "qemu " : "",
           afl->fsrv.cs_mode ? "coresight" : "",
           afl->non_instrumented_mode ? " non_instrumented " : "",
@@ -458,7 +458,7 @@ void write_stats_file(afl_state_t *afl, u32 t_bytes, double bitmap_cvg,
           afl->persistent_mode ? "persistent " : "",
           afl->shmem_testcase_mode ? "shmem_testcase " : "",
           afl->deferred_mode ? "deferred " : "",
-          (afl->unicorn_mode || afl->fsrv.qemu_mode || afl->fsrv.cs_mode ||
+          (afl->fsrv.unicorn_mode || afl->fsrv.qemu_mode || afl->fsrv.cs_mode ||
            afl->non_instrumented_mode || afl->no_forkserver ||
            afl->crash_mode || afl->persistent_mode || afl->deferred_mode)
               ? ""
@@ -2380,7 +2380,7 @@ void show_init_stats(afl_state_t *afl) {
 
   // SAYF("\n");
 
-  if (avg_us > ((afl->fsrv.cs_mode || afl->fsrv.qemu_mode || afl->unicorn_mode)
+  if (avg_us > ((afl->fsrv.cs_mode || afl->fsrv.qemu_mode || afl->fsrv.unicorn_mode)
                     ? 50000
                     : 10000)) {
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1223,8 +1223,8 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'U':                                             /* Unicorn mode */
 
-        if (afl->unicorn_mode) { FATAL("Multiple -U options not supported"); }
-        afl->unicorn_mode = 1;
+        if (afl->fsrv.unicorn_mode) { FATAL("Multiple -U options not supported"); }
+        afl->fsrv.unicorn_mode = 1;
 
         if (!mem_limit_given) { afl->fsrv.mem_limit = MEM_LIMIT_UNICORN; }
 
@@ -1574,7 +1574,7 @@ int main(int argc, char **argv_orig, char **envp) {
   configure_afl_kill_signals(
       &afl->fsrv, afl->afl_env.afl_child_kill_signal,
       afl->afl_env.afl_fsrv_kill_signal,
-      (afl->fsrv.qemu_mode || afl->unicorn_mode || afl->fsrv.use_fauxsrv
+      (afl->fsrv.qemu_mode || afl->fsrv.unicorn_mode || afl->fsrv.use_fauxsrv
   #ifdef __linux__
        || afl->fsrv.nyx_mode
   #endif
@@ -1660,7 +1660,7 @@ int main(int argc, char **argv_orig, char **envp) {
     if (afl->fsrv.frida_mode) { FATAL("-O and -n are mutually exclusive"); }
     if (afl->fsrv.qemu_mode) { FATAL("-Q and -n are mutually exclusive"); }
     if (afl->fsrv.cs_mode) { FATAL("-A and -n are mutually exclusive"); }
-    if (afl->unicorn_mode) { FATAL("-U and -n are mutually exclusive"); }
+    if (afl->fsrv.unicorn_mode) { FATAL("-U and -n are mutually exclusive"); }
 
   }
 
@@ -1688,7 +1688,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
-  if (strchr(argv[optind], '/') == NULL && !afl->unicorn_mode) {
+  if (strchr(argv[optind], '/') == NULL && !afl->fsrv.unicorn_mode) {
 
     WARNF(cLRD
           "Target binary called without a prefixed path, make sure you are "
@@ -2433,14 +2433,8 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (afl->cmplog_binary) {
 
-    if (afl->unicorn_mode) {
-
-      FATAL("CmpLog and Unicorn mode are not compatible at the moment, sorry");
-
-    }
-
     if (!afl->fsrv.qemu_mode && !afl->fsrv.frida_mode && !afl->fsrv.cs_mode &&
-        !afl->non_instrumented_mode) {
+        !afl->fsrv.unicorn_mode && !afl->non_instrumented_mode) {
 
       check_binary(afl, afl->cmplog_binary);
 
@@ -2496,7 +2490,7 @@ int main(int argc, char **argv_orig, char **envp) {
   }
 
   if (afl->non_instrumented_mode || afl->fsrv.qemu_mode ||
-      afl->fsrv.frida_mode || afl->fsrv.cs_mode || afl->unicorn_mode) {
+      afl->fsrv.frida_mode || afl->fsrv.cs_mode || afl->fsrv.unicorn_mode) {
 
     u32 old_map_size = map_size;
     map_size = afl->fsrv.real_map_size = afl->fsrv.map_size = MAP_SIZE;
@@ -2529,7 +2523,7 @@ int main(int argc, char **argv_orig, char **envp) {
       afl_shm_init(&afl->shm, afl->fsrv.map_size, afl->non_instrumented_mode);
 
   if (!afl->non_instrumented_mode && !afl->fsrv.qemu_mode &&
-      !afl->unicorn_mode && !afl->fsrv.frida_mode && !afl->fsrv.cs_mode &&
+      !afl->fsrv.unicorn_mode && !afl->fsrv.frida_mode && !afl->fsrv.cs_mode &&
       !afl->afl_env.afl_skip_bin_check) {
 
     if (map_size <= DEFAULT_SHMEM_SIZE) {
@@ -2650,7 +2644,7 @@ int main(int argc, char **argv_orig, char **envp) {
       if ((map_size <= DEFAULT_SHMEM_SIZE ||
            afl->san_fsrvs[i].map_size < map_size) &&
           !afl->non_instrumented_mode && !afl->fsrv.qemu_mode &&
-          !afl->fsrv.frida_mode && !afl->unicorn_mode && !afl->fsrv.cs_mode &&
+          !afl->fsrv.frida_mode && !afl->fsrv.unicorn_mode && !afl->fsrv.cs_mode &&
           !afl->afl_env.afl_skip_bin_check) {
 
         afl->san_fsrvs[i].map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
@@ -2728,7 +2722,7 @@ int main(int argc, char **argv_orig, char **envp) {
     if ((map_size <= DEFAULT_SHMEM_SIZE ||
          afl->cmplog_fsrv.map_size < map_size) &&
         !afl->non_instrumented_mode && !afl->fsrv.qemu_mode &&
-        !afl->fsrv.frida_mode && !afl->unicorn_mode && !afl->fsrv.cs_mode &&
+        !afl->fsrv.frida_mode && !afl->fsrv.unicorn_mode && !afl->fsrv.cs_mode &&
         !afl->afl_env.afl_skip_bin_check) {
 
       afl->cmplog_fsrv.map_size = MAX(map_size, (u32)DEFAULT_SHMEM_SIZE);
@@ -2814,7 +2808,7 @@ int main(int argc, char **argv_orig, char **envp) {
     close(afl->fsrv.out_fd);
     afl->fsrv.out_fd = -1;
 
-    if (!afl->unicorn_mode && !afl->fsrv.use_stdin && !default_output) {
+    if (!afl->fsrv.unicorn_mode && !afl->fsrv.use_stdin && !default_output) {
 
       WARNF(
           "You specified -f or @@ on the command line but the target harness "

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1084,7 +1084,7 @@ int main(int argc, char **argv_orig, char **envp) {
   // TODO: u64 mem_limit = MEM_LIMIT;                  /* Memory limit (MB) */
 
   s32  opt, i;
-  bool mem_limit_given = false, timeout_given = false, unicorn_mode = false,
+  bool mem_limit_given = false, timeout_given = false,
        use_wine = false;
   char **use_argv;
 
@@ -1281,9 +1281,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'U':
 
-        if (unicorn_mode) { FATAL("Multiple -U options not supported"); }
+        if (fsrv->unicorn_mode) { FATAL("Multiple -U options not supported"); }
 
-        unicorn_mode = true;
+        fsrv->unicorn_mode = true;
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
@@ -1358,7 +1358,7 @@ int main(int argc, char **argv_orig, char **envp) {
   }
 
   if (fsrv->qemu_mode && !mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_QEMU; }
-  if (unicorn_mode && !mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
+  if (fsrv->unicorn_mode && !mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
 
   check_environment_vars(envp);
 
@@ -1555,7 +1555,7 @@ int main(int argc, char **argv_orig, char **envp) {
   fsrv->shmem_fuzz = map + sizeof(u32);
 
   configure_afl_kill_signals(fsrv, NULL, NULL,
-                             (fsrv->qemu_mode || unicorn_mode
+                             (fsrv->qemu_mode || fsrv->unicorn_mode
 #ifdef __linux__
                               || fsrv->nyx_mode
 #endif
@@ -1563,7 +1563,7 @@ int main(int argc, char **argv_orig, char **envp) {
                                  ? SIGKILL
                                  : SIGTERM);
 
-  if (!fsrv->cs_mode && !fsrv->qemu_mode && !unicorn_mode) {
+  if (!fsrv->cs_mode && !fsrv->qemu_mode && !fsrv->unicorn_mode) {
 
     u32 save_be_quiet = be_quiet;
     be_quiet = !debug;

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1094,7 +1094,7 @@ static void usage(u8 *argv0) {
 int main(int argc, char **argv_orig, char **envp) {
 
   s32 opt;
-  u8  mem_limit_given = 0, timeout_given = 0, unicorn_mode = 0, use_wine = 0,
+  u8  mem_limit_given = 0, timeout_given = 0, use_wine = 0,
      del_limit_given = 0;
   char **use_argv;
 
@@ -1253,10 +1253,10 @@ int main(int argc, char **argv_orig, char **envp) {
 
       case 'U':
 
-        if (unicorn_mode) { FATAL("Multiple -Q options not supported"); }
+        if (fsrv->unicorn_mode) { FATAL("Multiple -U options not supported"); }
         if (!mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
 
-        unicorn_mode = 1;
+        fsrv->unicorn_mode = 1;
         break;
 
       case 'W':                                           /* Wine+QEMU mode */
@@ -1458,7 +1458,7 @@ int main(int argc, char **argv_orig, char **envp) {
   }
 
   configure_afl_kill_signals(
-      fsrv, NULL, NULL, (fsrv->qemu_mode || unicorn_mode) ? SIGKILL : SIGTERM);
+      fsrv, NULL, NULL, (fsrv->qemu_mode || fsrv->unicorn_mode) ? SIGKILL : SIGTERM);
 
   if (getenv("AFL_CRASH_EXITCODE")) {
 
@@ -1526,7 +1526,7 @@ int main(int argc, char **argv_orig, char **envp) {
   (void)check_binary_signatures(fsrv->target_path);
 #endif
 
-  if (!fsrv->qemu_mode && !unicorn_mode) {
+  if (!fsrv->qemu_mode && !fsrv->unicorn_mode) {
 
     fsrv->map_size = 4194304;  // dummy temporary value
     u32 new_map_size =


### PR DESCRIPTION
If AFLplusplus/unicornafl#37 is merged, then we shall use cmplog with unicorn-mode. Removed certain check preventing this.

Moreover, I found that although `qemu_mode`, `frida_mode`, `cs_mode` are defined as fields in forkserver struct, `unicorn_mode` is defined directly in afl struct. This is strange and makes it hard to check unicorn_mode in forkserver logic. This PR also moves unicorn_mode to be field of forkserver struct, making it more consistent.