### PR TITLE
show stats more frequently when sync foreign

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -658,12 +658,8 @@ void read_foreign_testcases(afl_state_t *afl, int first) {
         munmap(mem, st.st_size);
         close(fd);
 
-        if (st.st_mtime > mtime_max) {
-
-          mtime_max = st.st_mtime;
-          show_stats(afl);
-
-        }
+        if (st.st_mtime > mtime_max) { mtime_max = st.st_mtime; }
+        show_stats(afl);
 
       }
 


### PR DESCRIPTION
otherwise, the stats might have no updates for hours for large foreign directory
