### PR TITLE
Fix incorrect allocation for `top_rated_candidates`

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1745,7 +1745,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (afl->cycle_schedules) {
 
-    afl->top_rated_candidates = ck_alloc(map_size * sizeof(u32));
+    afl->top_rated_candidates = ck_alloc(map_size * sizeof(u32 *));
 
   }
 


### PR DESCRIPTION
This PR fixes an incorrect memory allocation introduced in #2366, where `afl->top_rated_candidates` was allocated with `sizeof(u32)` instead of `sizeof(u32 *)`. On 64-bit systems, this caused memory corruption, potentially leading to segmentation faults.

c.c. @5angjun 