### PR TITLE
Add env variable SHM_FUZZ_MAP_SIZE

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -424,9 +424,10 @@
 
 #define SHM_ENV_VAR "__AFL_SHM_ID"
 
-/* Environment variable used to pass SHM FUZZ ID to the called program. */
+/* Environment variable used to pass SHM FUZZ ID and the page size to the called program. */
 
 #define SHM_FUZZ_ENV_VAR "__AFL_SHM_FUZZ_ID"
+#define SHM_FUZZ_PAGE_SIZE_ENV_VAR "__AFL_SHM_FUZZ_PAGE_SIZE"
 
 /* Other less interesting, internal-only variables. */
 

--- a/include/config.h
+++ b/include/config.h
@@ -424,7 +424,7 @@
 
 #define SHM_ENV_VAR "__AFL_SHM_ID"
 
-/* Environment variable used to pass SHM FUZZ ID and the page size to the called program. */
+/* Environment variable used to pass SHM FUZZ ID and the mapping size to the called program. */
 
 #define SHM_FUZZ_ENV_VAR "__AFL_SHM_FUZZ_ID"
 #define SHM_FUZZ_MAP_SIZE_ENV_VAR "__AFL_SHM_FUZZ_MAP_SIZE"

--- a/include/config.h
+++ b/include/config.h
@@ -424,10 +424,15 @@
 
 #define SHM_ENV_VAR "__AFL_SHM_ID"
 
-/* Environment variable used to pass SHM FUZZ ID and the mapping size to the called program. */
+/* Environment variable used to pass shared memory fuzz map id
+and the mapping size to the called program. */
 
 #define SHM_FUZZ_ENV_VAR "__AFL_SHM_FUZZ_ID"
 #define SHM_FUZZ_MAP_SIZE_ENV_VAR "__AFL_SHM_FUZZ_MAP_SIZE"
+
+/* Default size of the shared memory fuzz map.
+We add 4 byte for one u32 length field. */
+#define SHM_FUZZ_MAP_SIZE_DEFAULT (MAX_FILE +  4)
 
 /* Other less interesting, internal-only variables. */
 

--- a/include/config.h
+++ b/include/config.h
@@ -427,7 +427,7 @@
 /* Environment variable used to pass SHM FUZZ ID and the page size to the called program. */
 
 #define SHM_FUZZ_ENV_VAR "__AFL_SHM_FUZZ_ID"
-#define SHM_FUZZ_PAGE_SIZE_ENV_VAR "__AFL_SHM_FUZZ_PAGE_SIZE"
+#define SHM_FUZZ_MAP_SIZE_ENV_VAR "__AFL_SHM_FUZZ_MAP_SIZE"
 
 /* Other less interesting, internal-only variables. */
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -296,13 +296,13 @@ static void __afl_map_shm_fuzz() {
 #ifdef USEMMAP
 
     // Newer afl-fuzz versions will set a shm_fuzz page size env, else fall back
-    size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
-    char *page_size_env = getenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
-    if (page_size_env != NULL) {
+    size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+    char *map_size_env = getenv(SHM_FUZZ_MAP_SIZE_ENV_VAR);
+    if (map_size_env != NULL) {
       char* endptr;
       errno = 0;
-      shm_fuzz_page_size = (size_t)strtoul(page_size_env, &endptr, 10);
-      if (errno != 0 || shm_fuzz_page_size == 0) {
+      shm_fuzz_map_size = (size_t)strtoul(map_size_env, &endptr, 10);
+      if (errno != 0 || shm_fuzz_map_size == 0) {
         perror("shm_fuzz page size parsing");
         send_forkserver_error(FS_ERROR_SHM_OPEN);
         _exit(1);
@@ -323,7 +323,7 @@ static void __afl_map_shm_fuzz() {
     }
 
     map =
-        (u8 *)mmap(0, shm_fuzz_page_size, PROT_READ, MAP_SHARED, shm_fd, 0);
+        (u8 *)mmap(0, shm_fuzz_map_size, PROT_READ, MAP_SHARED, shm_fd, 0);
 
 #else
     u32 shm_id = atoi(id_str);

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -303,7 +303,7 @@ static void __afl_map_shm_fuzz() {
       errno = 0;
       shm_fuzz_map_size = (size_t)strtoul(map_size_env, &endptr, 10);
       if (errno != 0 || shm_fuzz_map_size == 0) {
-        perror("shm_fuzz page size parsing");
+        perror("shm_fuzz mapping size parsing");
         send_forkserver_error(FS_ERROR_SHM_OPEN);
         _exit(1);
       }

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -296,7 +296,7 @@ static void __afl_map_shm_fuzz() {
 #ifdef USEMMAP
 
     // Newer afl-fuzz versions will set a shm_fuzz page size env, else fall back
-    size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+    size_t shm_fuzz_map_size = SHM_FUZZ_MAP_SIZE_DEFAULT;
     char *map_size_env = getenv(SHM_FUZZ_MAP_SIZE_ENV_VAR);
     if (map_size_env != NULL) {
       char* endptr;

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -294,6 +294,21 @@ static void __afl_map_shm_fuzz() {
     u8 *map = NULL;
 
 #ifdef USEMMAP
+
+    // Newer afl-fuzz versions will set a shm_fuzz page size env, else fall back
+    size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
+    int page_size_env = getenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
+    if (page_size_env != NULL) {
+      char* endptr;
+      errno = 0;
+      shm_fuzz_page_size = (size_t)strtoul(page_size_env, &endptr, 10);
+      if (errno != 0 || shm_fuzz_page_size == 0) {
+        perror("shm_fuzz page size parsing");
+        send_forkserver_error(FS_ERROR_SHM_OPEN);
+        _exit(1);
+      }
+    }
+
     const char *shm_file_path = id_str;
     int         shm_fd = -1;
 
@@ -308,7 +323,7 @@ static void __afl_map_shm_fuzz() {
     }
 
     map =
-        (u8 *)mmap(0, MAX_FILE + sizeof(u32), PROT_READ, MAP_SHARED, shm_fd, 0);
+        (u8 *)mmap(0, shm_fuzz_page_size, PROT_READ, MAP_SHARED, shm_fd, 0);
 
 #else
     u32 shm_id = atoi(id_str);

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -297,7 +297,7 @@ static void __afl_map_shm_fuzz() {
 
     // Newer afl-fuzz versions will set a shm_fuzz page size env, else fall back
     size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
-    int page_size_env = getenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
+    char *page_size_env = getenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
     if (page_size_env != NULL) {
       char* endptr;
       errno = 0;

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2921,7 +2921,7 @@ void setup_testcase_shmem(afl_state_t *afl) {
 
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%zu", shm_fuzz_map_size);
   setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
   ck_free(shm_fuzz_map_size_str);
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2915,15 +2915,15 @@ void setup_testcase_shmem(afl_state_t *afl) {
   afl->shm_fuzz = ck_alloc(sizeof(sharedmem_t));
 
   // we need to set the non-instrumented mode to not overwrite the SHM_ENV_VAR
-  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
-  u8 *map = afl_shm_init(afl->shm_fuzz, shm_fuzz_page_size, 1);
+  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(afl->shm_fuzz, shm_fuzz_map_size, 1);
   afl->shm_fuzz->shmemfuzz_mode = 1;
 
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
-  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
-  ck_free(shm_fuzz_page_size_str);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
+  ck_free(shm_fuzz_map_size_str);
 
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, afl->shm_fuzz->g_shm_file_path, 1);

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2915,7 +2915,7 @@ void setup_testcase_shmem(afl_state_t *afl) {
   afl->shm_fuzz = ck_alloc(sizeof(sharedmem_t));
 
   // we need to set the non-instrumented mode to not overwrite the SHM_ENV_VAR
-  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  size_t shm_fuzz_map_size = SHM_FUZZ_MAP_SIZE_DEFAULT;
   u8 *map = afl_shm_init(afl->shm_fuzz, shm_fuzz_map_size, 1);
   afl->shm_fuzz->shmemfuzz_mode = 1;
 

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -2915,10 +2915,15 @@ void setup_testcase_shmem(afl_state_t *afl) {
   afl->shm_fuzz = ck_alloc(sizeof(sharedmem_t));
 
   // we need to set the non-instrumented mode to not overwrite the SHM_ENV_VAR
-  u8 *map = afl_shm_init(afl->shm_fuzz, MAX_FILE + sizeof(u32), 1);
+  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(afl->shm_fuzz, shm_fuzz_page_size, 1);
   afl->shm_fuzz->shmemfuzz_mode = 1;
 
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
+
+  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
+  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
+  ck_free(shm_fuzz_page_size_str);
 
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, afl->shm_fuzz->g_shm_file_path, 1);

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -71,6 +71,7 @@ void afl_shm_deinit(sharedmem_t *shm) {
   if (shm->shmemfuzz_mode) {
 
     unsetenv(SHM_FUZZ_ENV_VAR);
+    unsetenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
 
   } else {
 

--- a/src/afl-sharedmem.c
+++ b/src/afl-sharedmem.c
@@ -71,7 +71,7 @@ void afl_shm_deinit(sharedmem_t *shm) {
   if (shm->shmemfuzz_mode) {
 
     unsetenv(SHM_FUZZ_ENV_VAR);
-    unsetenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR);
+    unsetenv(SHM_FUZZ_MAP_SIZE_ENV_VAR);
 
   } else {
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1540,9 +1540,15 @@ int main(int argc, char **argv_orig, char **envp) {
   shm_fuzz->cmplog_mode = 0;
   atexit(at_exit_handler);
 
-  u8 *map = afl_shm_init(shm_fuzz, MAX_FILE + sizeof(u32), 1);
+  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_page_size, 1);
   shm_fuzz->shmemfuzz_mode = true;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
+
+  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
+  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
+  ck_free(shm_fuzz_page_size_str);
+
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);
 #else

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1540,14 +1540,14 @@ int main(int argc, char **argv_orig, char **envp) {
   shm_fuzz->cmplog_mode = 0;
   atexit(at_exit_handler);
 
-  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
-  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_page_size, 1);
+  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_map_size, 1);
   shm_fuzz->shmemfuzz_mode = true;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
-  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
-  ck_free(shm_fuzz_page_size_str);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
+  ck_free(shm_fuzz_map_size_str);
 
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1545,7 +1545,7 @@ int main(int argc, char **argv_orig, char **envp) {
   shm_fuzz->shmemfuzz_mode = true;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%zu", shm_fuzz_map_size);
   setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
   ck_free(shm_fuzz_map_size_str);
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1540,7 +1540,7 @@ int main(int argc, char **argv_orig, char **envp) {
   shm_fuzz->cmplog_mode = 0;
   atexit(at_exit_handler);
 
-  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  size_t shm_fuzz_map_size = SHM_FUZZ_MAP_SIZE_DEFAULT;
   u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_map_size, 1);
   shm_fuzz->shmemfuzz_mode = true;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1482,7 +1482,7 @@ int main(int argc, char **argv_orig, char **envp) {
   /* initialize cmplog_mode */
   shm_fuzz->cmplog_mode = 0;
 
-  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  size_t shm_fuzz_map_size = SHM_FUZZ_MAP_SIZE_DEFAULT;
   u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_map_size, 1);
   shm_fuzz->shmemfuzz_mode = 1;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1487,7 +1487,7 @@ int main(int argc, char **argv_orig, char **envp) {
   shm_fuzz->shmemfuzz_mode = 1;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%zu", shm_fuzz_map_size);
   setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
   ck_free(shm_fuzz_map_size_str);
 

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1482,14 +1482,14 @@ int main(int argc, char **argv_orig, char **envp) {
   /* initialize cmplog_mode */
   shm_fuzz->cmplog_mode = 0;
 
-  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
-  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_page_size, 1);
+  size_t shm_fuzz_map_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_map_size, 1);
   shm_fuzz->shmemfuzz_mode = 1;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
 
-  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
-  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
-  ck_free(shm_fuzz_page_size_str);
+  u8 *shm_fuzz_map_size_str = alloc_printf("%d", shm_fuzz_map_size);
+  setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
+  ck_free(shm_fuzz_map_size_str);
 
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1481,9 +1481,16 @@ int main(int argc, char **argv_orig, char **envp) {
 
   /* initialize cmplog_mode */
   shm_fuzz->cmplog_mode = 0;
-  u8 *map = afl_shm_init(shm_fuzz, MAX_FILE + sizeof(u32), 1);
+
+  size_t shm_fuzz_page_size = MAX_FILE + sizeof(u32);
+  u8 *map = afl_shm_init(shm_fuzz, shm_fuzz_page_size, 1);
   shm_fuzz->shmemfuzz_mode = 1;
   if (!map) { FATAL("BUG: Zero return from afl_shm_init."); }
+
+  u8 *shm_fuzz_page_size_str = alloc_printf("%d", shm_fuzz_page_size);
+  setenv(SHM_FUZZ_PAGE_SIZE_ENV_VAR, shm_fuzz_page_size_str, 1);
+  ck_free(shm_fuzz_page_size_str);
+
 #ifdef USEMMAP
   setenv(SHM_FUZZ_ENV_VAR, shm_fuzz->g_shm_file_path, 1);
 #else


### PR DESCRIPTION
The SHM_FUZZ_MAP_SIZE env variable tells the forkserver about the size the max shm input page has.

This is related to the discussion in:
https://github.com/AFLplusplus/LibAFL/pull/3229

The same is done in LibAFL in
https://github.com/AFLplusplus/LibAFL/pull/3235