### PR TITLE
Let user pass their own CPU_TARGET in test-pre.sh

### DIFF
--- a/test/test-pre.sh
+++ b/test/test-pre.sh
@@ -17,9 +17,9 @@ test -z "" 2>/dev/null || { echo Error: test command not found ; exit 1 ; }
 GREP=`type grep > /dev/null 2>&1 && echo OK`
 test "$GREP" = OK || { echo Error: grep command not found ; exit 1 ; }
 echo foobar | grep -qE 'asd|oob' 2>/dev/null || { echo Error: grep command does not support -q and/or -E option ; exit 1 ; }
-test -e ./test-all.sh || cd $(dirname $0) || exit 1
+test -e ./test-all.sh || cd $(dirname "$0") || exit 1
 test -e ./test-all.sh || { echo Error: you must be in the test/ directory ; exit 1 ; }
-export AFL_PATH=`pwd`/..
+export AFL_PATH="$(pwd)/.."
 export AFL_TRY_AFFINITY=1 # workaround for travis that fails for no avail cores
 
 echo 1 > test.1
@@ -59,7 +59,7 @@ $ECHO \\101 2>&1 | grep -qE '^A' || {
     $ECHO "\\101" 2>&1 | grep -qE '^A' || ECHO=
   }
 }
-test -z "$ECHO" && { printf Error: printf command does not support octal character codes ; exit 1 ; }
+test -z "$ECHO" && { echo Error: printf command does not support octal character codes ; exit 1 ; }
 
 export AFL_EXIT_WHEN_DONE=1
 export AFL_EXIT_ON_TIME=60
@@ -109,7 +109,7 @@ test -n "$TRAVIS_OS_NAME" && {
 
 # on OpenBSD we need to work with llvm from /usr/local/bin
 test -e /usr/local/bin/opt && {
-  test `uname -s` = 'Darwin' || export PATH="/usr/local/bin:${PATH}"
+  test "$(uname -s)" = 'Darwin' || export PATH="/usr/local/bin:${PATH}"
 }
 AFL_COMPILER=afl-clang-fast
 
@@ -124,7 +124,7 @@ if test -n "$CPU_TARGET"; then
     $ECHO "${RESET}${GREY}[*] Using environment variable CPU_TARGET=$CPU_TARGET for SYS"
     SYS="$CPU_TARGET"
 else
-    SYS=`uname -m`
+    SYS=$(uname -m)
 fi
 
 MEM_LIMIT=none

--- a/test/test-pre.sh
+++ b/test/test-pre.sh
@@ -113,14 +113,19 @@ test -e /usr/local/bin/opt && {
 }
 AFL_COMPILER=afl-clang-fast
 
-SYS=`uname -m`
-
 GREY="\\033[1;90m"
 BLUE="\\033[1;94m"
 GREEN="\\033[0;32m"
 RED="\\033[0;31m"
 YELLOW="\\033[1;93m"
 RESET="\\033[0m"
+
+if test -n "$CPU_TARGET"; then
+    $ECHO "${RESET}${GREY}[*] Using environment variable CPU_TARGET=$CPU_TARGET for SYS"
+    SYS="$CPU_TARGET"
+else
+    SYS=`uname -m`
+fi
 
 MEM_LIMIT=none
 


### PR DESCRIPTION
The target system might be different from the host system. For example, you can fuzz Linux binaries compiled for *mipsel*, while your host is *x86_64*.

Some of the tests depend on specific platforms to run correctly. For example, the afl-fuzz qemu_mode cmplog test only works on Intel or ARM systems. The `SYS` variable is populated using `uname -m` and the test cases then consult this variable to decide whether to run the test or not.

If you want to test afl-fuzz for qemu_mode on mipsel, you might want to make sure that Intel or ARM tests don't run. With this patch, you can supply your own `SYS` environment variable and skip platform specific tests.

This allows you to add tests for *mipsel* or other niche platforms in the future as well.

Sample usage:

```
$ cd qemu_mode && env CPU_TARGET=mipsel ./build_qemu_support.sh
$ cd ../test && env SYS=mipsel ./test-qemu-mode.sh
[*] Using user supplied environment variable SYS=mipsel
[*] starting AFL++ test framework ...
[*] Testing: qemu_mode
...
```