### PR TITLE
WARNF for setting scheduling for main fuzzer instead of FATAL

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1502,7 +1502,7 @@ int main(int argc, char **argv_orig, char **envp) {
   if (afl->is_main_node == 1 && afl->schedule != FAST &&
       afl->schedule != EXPLORE) {
 
-    FATAL("-M is compatible only with fast and explore -p power schedules");
+    WARNF("-M is compatible only with fast and explore -p power schedules");
 
   }
 

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1502,7 +1502,7 @@ int main(int argc, char **argv_orig, char **envp) {
   if (afl->is_main_node == 1 && afl->schedule != FAST &&
       afl->schedule != EXPLORE) {
 
-    WARNF("-M is compatible only with fast and explore -p power schedules");
+    WARNF("When using -M, it is recommended to use only fast or explore -p power schedules");
 
   }
 


### PR DESCRIPTION
Hi, thank you for making AFL++ better and better.

Here is a tiny PR that replaces the FATAL by WARNF when using `-p exploit` on the main fuzzing node (As suggested on Discord).

Best regards,