### PR TITLE
instrumentation: drop removed TODO flag from GCC plugins

### DIFF
--- a/instrumentation/afl-gcc-cmplog-pass.so.cc
+++ b/instrumentation/afl-gcc-cmplog-pass.so.cc
@@ -44,8 +44,7 @@ static const struct pass_data afl_cmplog_pass_data = {
     .properties_provided = 0,
     .properties_destroyed = 0,
     .todo_flags_start = 0,
-    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg | TODO_verify_il |
-                          TODO_rebuild_cgraph_edges),
+    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg | TODO_rebuild_cgraph_edges),
 
 };
 

--- a/instrumentation/afl-gcc-cmptrs-pass.so.cc
+++ b/instrumentation/afl-gcc-cmptrs-pass.so.cc
@@ -44,8 +44,7 @@ static const struct pass_data afl_cmptrs_pass_data = {
     .properties_provided = 0,
     .properties_destroyed = 0,
     .todo_flags_start = 0,
-    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg | TODO_verify_il |
-                          TODO_rebuild_cgraph_edges),
+    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg | TODO_rebuild_cgraph_edges),
 
 };
 

--- a/instrumentation/afl-gcc-pass.so.cc
+++ b/instrumentation/afl-gcc-pass.so.cc
@@ -65,7 +65,6 @@
    The new pass is to be a GIMPLE_PASS.  Given the sort of
    instrumentation it's supposed to do, its todo_flags_finish will
    certainly need TODO_update_ssa, and TODO_cleanup_cfg.
-   TODO_verify_il is probably desirable, at least during debugging.
    TODO_rebuild_cgraph_edges is required only in the out-of-line
    instrumentation mode.
 
@@ -148,7 +147,7 @@ static constexpr struct pass_data afl_pass_data = {
     .properties_provided = 0,
     .properties_destroyed = 0,
     .todo_flags_start = 0,
-    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg | TODO_verify_il),
+    .todo_flags_finish = (TODO_update_ssa | TODO_cleanup_cfg),
 
 };
 


### PR DESCRIPTION
TODO_verify_il was removed in GCC trunk by 9739ae9384dd7cd3bb1c7683d6b80b7a9116eaf8, so drop it here.