### PR TITLE
refactor!: drop python2

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -255,17 +255,6 @@ ifeq "$(PYTHON_INCLUDE)" ""
   endif
 endif
 
-# Old Ubuntu and others dont have python/python2-config so we hardcode 2.7
-ifeq "$(PYTHON_INCLUDE)" ""
-  ifneq "$(shell command -v python2.7 2>/dev/null)" ""
-    ifneq "$(shell command -v python2.7-config 2>/dev/null)" ""
-      PYTHON_INCLUDE  := $(shell python2.7-config --includes)
-      PYTHON_LIB      := $(shell python2.7-config --ldflags)
-      PYTHON_VERSION  := $(strip $(shell python2.7 --version 2>&1))
-    endif
-  endif
-endif
-
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+%Y-%m-%d" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+%Y-%m-%d" 2>/dev/null || date -u "+%Y-%m-%d")
 else

--- a/custom_mutators/examples/README.md
+++ b/custom_mutators/examples/README.md
@@ -3,8 +3,7 @@
 These are example and helper files for the custom mutator feature.
 See [docs/custom_mutators.md](../../docs/custom_mutators.md) for more information
 
-Note that if you compile with python3.7 you must use python3 scripts, and if
-you use python2.7 to compile python2 scripts!
+Note that if you compile with python3.7 you must use python3 scripts.
 
 simple_example.c - most simplest example. generates a random sized buffer
           filled with 'A'

--- a/custom_mutators/gramatron/build_gramatron_mutator.sh
+++ b/custom_mutators/gramatron/build_gramatron_mutator.sh
@@ -56,7 +56,7 @@ if [ ! -f "../../src/afl-performance.o" ]; then
 
 fi
 
-PYTHONBIN=`command -v python3 || command -v python || command -v python2 || echo python3`
+PYTHONBIN=`command -v python3 || command -v python || echo python3`
 MAKECMD=make
 TARCMD=tar
 

--- a/custom_mutators/grammar_mutator/build_grammar_mutator.sh
+++ b/custom_mutators/grammar_mutator/build_grammar_mutator.sh
@@ -52,7 +52,7 @@ if [ ! -f "../../config.h" ]; then
 
 fi
 
-PYTHONBIN=`command -v python3 || command -v python || command -v python2 || echo python3`
+PYTHONBIN=`command -v python3 || command -v python || echo python3`
 MAKECMD=make
 TARCMD=tar
 

--- a/test/test-unicorn-mode.sh
+++ b/test/test-unicorn-mode.sh
@@ -10,7 +10,7 @@ test -s ../unicorn_mode/unicornafl/build/libunicornafl.a && {
       export AFL_DEBUG_CHILD=1
 
       # some python version should be available now
-      PYTHONS="`command -v python3` `command -v python` `command -v python2`"
+      PYTHONS="`command -v python3` `command -v python`"
       EASY_INSTALL_FOUND=0
       for PYTHON in $PYTHONS ; do
 

--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -65,7 +65,7 @@ if [ ! -f "../afl-showmap" ]; then
 
 fi
 
-PYTHONBIN=`command -v python3 || command -v python || command -v python2 || echo python3`
+PYTHONBIN=`command -v python3 || command -v python || echo python3`
 MAKECMD=make
 TARCMD=tar
 
@@ -116,7 +116,7 @@ for i in $PYTHONBIN automake autoconf git $MAKECMD $TARCMD; do
 done
 
 # some python version should be available now
-PYTHONS="`command -v python3` `command -v python` `command -v python2`"
+PYTHONS="`command -v python3` `command -v python`"
 PIP_FOUND=0
 for PYTHON in $PYTHONS ; do
 

--- a/utils/autodict_ql/autodict-ql.py
+++ b/utils/autodict_ql/autodict-ql.py
@@ -33,7 +33,7 @@ def ensure_dir(dir):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python2 thisfile.py outdir str.txt"
+            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python3 thisfile.py outdir str.txt"
         )
     )
 

--- a/utils/autodict_ql/litan.py
+++ b/utils/autodict_ql/litan.py
@@ -17,7 +17,7 @@ from binascii import unhexlify
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file to analysis and output folder to save corpdirus for constants in the overall project -------  Example usage : python2 thisfile.py outdir o.txt"
+            "Helper - Specify input file to analysis and output folder to save corpdirus for constants in the overall project -------  Example usage : python3 thisfile.py outdir o.txt"
         )
     )
     parser.add_argument(
@@ -25,7 +25,7 @@ def parse_args():
     )
     parser.add_argument(
         "infile",
-        help="Specify file output of codeql analysis - ex. ooo-hex.txt, analysis take place on this file, example : python2 thisfile.py outdir out.txt",
+        help="Specify file output of codeql analysis - ex. ooo-hex.txt, analysis take place on this file, example : python3 thisfile.py outdir out.txt",
     )
     return parser.parse_args()
 

--- a/utils/autodict_ql/memcmp-strings.py
+++ b/utils/autodict_ql/memcmp-strings.py
@@ -25,7 +25,7 @@ def ensure_dir(dir):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python2 thisfile.py outdir str.txt"
+            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python3 thisfile.py outdir str.txt"
         )
     )
     parser.add_argument(
@@ -33,7 +33,7 @@ def parse_args():
     )
     parser.add_argument(
         "infile",
-        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python2 thisfile.py outdir strings.txt",
+        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python3 thisfile.py outdir strings.txt",
     )
 
     return parser.parse_args()

--- a/utils/autodict_ql/stan-strings.py
+++ b/utils/autodict_ql/stan-strings.py
@@ -25,7 +25,7 @@ def ensure_dir(dir):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python2 thisfile.py outdir str.txt"
+            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python3 thisfile.py outdir str.txt"
         )
     )
     parser.add_argument(
@@ -33,7 +33,7 @@ def parse_args():
     )
     parser.add_argument(
         "infile",
-        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python2 thisfile.py outdir strings.txt",
+        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python3 thisfile.py outdir strings.txt",
     )
 
     return parser.parse_args()

--- a/utils/autodict_ql/strcmp-strings.py
+++ b/utils/autodict_ql/strcmp-strings.py
@@ -25,7 +25,7 @@ def ensure_dir(dir):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python2 thisfile.py outdir str.txt"
+            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python3 thisfile.py outdir str.txt"
         )
     )
     parser.add_argument(
@@ -33,7 +33,7 @@ def parse_args():
     )
     parser.add_argument(
         "infile",
-        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python2 thisfile.py outdir strings.txt",
+        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python3 thisfile.py outdir strings.txt",
     )
 
     return parser.parse_args()

--- a/utils/autodict_ql/strncmp-strings.py
+++ b/utils/autodict_ql/strncmp-strings.py
@@ -25,7 +25,7 @@ def ensure_dir(dir):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python2 thisfile.py outdir str.txt"
+            "Helper - Specify input file analysis and output folder to save corpus for strings in the overall project ---------------------------------------------------------------------------  Example usage : python3 thisfile.py outdir str.txt"
         )
     )
     parser.add_argument(
@@ -33,7 +33,7 @@ def parse_args():
     )
     parser.add_argument(
         "infile",
-        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python2 thisfile.py outdir strings.txt",
+        help="Specify file output of codeql analysis - ex. ooo-atr.txt, analysis take place on this file, example : python3 thisfile.py outdir strings.txt",
     )
 
     return parser.parse_args()


### PR DESCRIPTION
<https://www.python.org/doc/sunset-python-2/>

> We have decided that January 1, 2020, was the day that we sunset Python 2. That means that we will not improve it anymore after that day, even if someone finds a security problem in it. You should upgrade to Python 3 as soon as you can.