### PR TITLE
Fix persistent qemu_mode test base address on aarch64

### DIFF
--- a/test/test-qemu-mode.sh
+++ b/test/test-qemu-mode.sh
@@ -120,11 +120,16 @@ test -e ../afl-qemu-trace && {
             if file test-instr | grep -q "32-bit"; then
               # for 32-bit reduce 8 nibbles to the lower 7 nibbles
   	      ADDR_LOWER_PART=`nm test-instr | grep "T main" | awk '{print $1}' | sed 's/^.//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
+            elif [ "$SYS" = "aarch64" ]; then
+              # for aarch64 reduce 16 nibbles to the lower 8 nibbles
+  	      ADDR_LOWER_PART=`nm test-instr | grep "T main" | awk '{print $1}' | sed 's/^........//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x55${ADDR_LOWER_PART}`
             else
-              # for 64-bit reduce 16 nibbles to the lower 9 nibbles
+              # for x64 reduce 16 nibbles to the lower 9 nibbles
   	      ADDR_LOWER_PART=`nm test-instr | grep "T main" | awk '{print $1}' | sed 's/^.......//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
             fi
-            export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
           }
           test -n "$IS_STATIC" && {
             export AFL_QEMU_PERSISTENT_ADDR=0x`nm test-instr | grep "T main" |  awk '{print $1}'`
@@ -170,11 +175,16 @@ test -e ../afl-qemu-trace && {
             if file test-instr-exit-at-end | grep -q "32-bit"; then
               # for 32-bit reduce 8 nibbles to the lower 7 nibbles
   	      ADDR_LOWER_PART=`nm test-instr-exit-at-end | grep "T main" | awk '{print $1}' | sed 's/^.//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
+            elif [ "$SYS" = "aarch64" ]; then
+              # for aarch64 reduce 16 nibbles to the lower 8 nibbles
+  	      ADDR_LOWER_PART=`nm test-instr-exit-at-end | grep "T main" | awk '{print $1}' | sed 's/^........//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x55${ADDR_LOWER_PART}`
             else
-              # for 64-bit reduce 16 nibbles to the lower 9 nibbles
+              # for x64 reduce 16 nibbles to the lower 9 nibbles
   	      ADDR_LOWER_PART=`nm test-instr-exit-at-end | grep "T main" | awk '{print $1}' | sed 's/^.......//'`
+              export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
             fi
-            export AFL_QEMU_PERSISTENT_ADDR=`expr 0x4${ADDR_LOWER_PART}`
           }
           test -n "$IS_STATIC" && {
             export AFL_QEMU_PERSISTENT_ADDR=0x`nm test-instr-exit-at-end | grep "T main" |  awk '{print $1}'`


### PR DESCRIPTION
qemu_mode/README.persistent.md documents the different base address, but the test still only had the cases for x86 and x64.