### PR TITLE
Fix a cmplog rtn instrumentation check if all vectors are empty.

### DIFF
--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -486,7 +486,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
   if (!calls.size() && !gccStdStd.size() && !gccStdC.size() &&
       !llvmStdStd.size() && !llvmStdC.size() && !Memcmp.size() &&
-      Strcmp.size() && Strncmp.size())
+      !Strcmp.size() && !Strncmp.size())
     return false;
 
   /*


### PR DESCRIPTION
Fix a cmplog rtn instrumentation check if all vectors are empty.

The logic here seems to be: if all vectors are empty, then no instrumentation is inserted. I suspect some negations (`!`) might have been accidentally omitted.

In [this commit](https://github.com/AFLplusplus/AFLplusplus/commit/ed10f3783bd8fab33ab5750f56bf87ed008f28ed), support for `memcmp`, `strcmp`, and `strncmp` was added, which introduced this piece of code.

![image-20250616201742353](https://github.com/user-attachments/assets/7af2ed2f-bb23-4cfc-929a-679d61bb1cb3)

In [earlier commit](https://github.com/AFLplusplus/AFLplusplus/commit/1c19804834d2ea4f169be0a99b8ce493a2f10167), the condition in the `if` statement checked whether all arrays were empty:

![image-20250616202050186](https://github.com/user-attachments/assets/7906b422-a5d4-4ba0-bb56-811374fd67b7)

