### PR TITLE
Adding CI for testing from llvm 14 to llvm 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: install llvm-tools 
         # because llvm 18.1.8 (installed by the script above) is broken for us
-        if matrix.version == '18'
+        if: matrix.version == '18'
         run: sudo apt install -y llvm-18 clang-18 llvm-config-18 libclang-rt-18-dev
       - name: install clang-rt (for llvm 15)
         # because ubuntu-22.04 already has this package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{ env.version }} all
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.version }} 200
+          sudo ./llvm.sh ${{ matrix.version }} all
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
-          sudo apt install libclang-rt-${{ matrix.version }}-dev
+          sudo apt install -y libclang-rt-${{ matrix.version }}-dev
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-compiler-passes:
+  check-compiler-passes (14 - 16):
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20]
+        version: [14, 15, 16]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
@@ -31,20 +31,35 @@ jobs:
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
       - name: install llvm-tools (except for llvm 18)
-        if: matrix.version != '18'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{ matrix.version }}
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
-      - name: install llvm-tools 
-        # because llvm 18.1.8 (installed by the script above) is broken for us
-        if: matrix.version == '18'
-        run: sudo apt install -y llvm-18 clang-18 llvm-config-18 libclang-rt-18-dev
+        run: sudo apt install clang-${{ matrix.version }} llvm-${{ matrix.version }}
       - name: install clang-rt (for llvm 15)
         # because ubuntu-22.04 already has this package
         if: matrix.version != '15'
         run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
+      - name: compiler installed
+        run: gcc -v; echo; clang -v
+      - name: build afl++
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+      - name: run tests
+        run: sudo -E ./afl-system-config; make tests
+  check-compiler-passes (17 - 20):
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        version: [17, 18, 19, 20]
+    env:
+      AFL_SKIP_CPUFREQ: 1
+      AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: update
+        run: sudo apt-get update && sudo apt-get upgrade -y
+      - name: debug
+        run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
+      - name: install packages
+        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+      - name: install llvm-tools (except for llvm 18)
+        run: sudo apt install clang-${{ matrix.version }} llvm-${{ matrix.version }}
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: install clang-rt
         # because ubuntu-22.04 already has this package
-        if: ${{ matrix.version}} != '15'
+        if: matrix.version != '15'
         run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20]
+        version: [17, 18, 19, 20]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: [14, 15, 16]
+        version: [14, 15]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        version: [17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
-      - name: install clang-rust
+      - name: install clang-rt
         # because ubuntu-22.04 already has this package
-        if: ${{ matrix.version}} != 15
+        if: ${{ matrix.version}} != '15'
         run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
@@ -68,7 +68,7 @@ jobs:
       - name: install gcc plugin
         run: sudo apt-get install -y -m -f --install-suggests $(readlink /usr/bin/gcc)-plugin-dev
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-12; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-12 distrib
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-15; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-15 distrib
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
   macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - dev # No need for stable-pull-request, as that equals dev-push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-compiler-passes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,12 @@ jobs:
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: install llvm-tools
-        run: clang-${{ matrix.version }} llvm-${{ matrix.version }}-dev  llvm-config-${{ matrix.version }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ env.MAIN_LLVM_VERSION }} all
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.MAIN_LLVM_VERSION }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
+          sudo apt install libclang-rt-${{ matrix.version }}-dev
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} distrib
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ concurrency:
 
 jobs:
   check-compiler-passes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: [17, 18, 19, 20]
+        version: [14, 15, 16, 17, 18, 19, 20]
     env:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
-          sudo apt install -y libclang-rt-${{ matrix.version }}-dev
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
+      - name: install clang-rust
+        # because ubuntu-22.04 already has this package
+        if: ${{ matrix.version}} != 15
+          run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-compiler-passes (14 - 16):
+  check-compiler-passes-1:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
         run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
-  check-compiler-passes (17 - 20):
+  check-compiler-passes-2:
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{ matrix.version }} all
+          sudo ./llvm.sh ${{ matrix.version }}
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
       - name: install llvm-tools (except for llvm 18)
-        if matrix.version != '18'
+        if: matrix.version != '18'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
       - name: debug
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
-        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
       - name: install llvm-tools (except for llvm 18)
-        run: sudo apt install clang-${{ matrix.version }} llvm-${{ matrix.version }}
+        run: sudo apt install -y clang-${{ matrix.version }} llvm-${{ matrix.version }}
       - name: install clang-rt (for llvm 15)
         # because ubuntu-22.04 already has this package
         if: matrix.version != '15'
-        run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
+        run: sudo apt install -y libclang-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
@@ -57,9 +57,11 @@ jobs:
       - name: debug
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
-        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
       - name: install llvm-tools (except for llvm 18)
-        run: sudo apt install clang-${{ matrix.version }} llvm-${{ matrix.version }}
+        run: sudo apt install -y clang-${{ matrix.version }} llvm-${{ matrix.version }}
+      - name: install clang-rt (for llvm 15)
+        run: sudo apt install -y libclang-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
-      - name: install llvm-tools (except for llvm 18)
+      - name: install llvm-tools
         run: sudo apt install -y clang-${{ matrix.version }} llvm-${{ matrix.version }}
       - name: install clang-rt (for llvm 15)
         # because ubuntu-22.04 already has this package
@@ -58,9 +58,18 @@ jobs:
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
-      - name: install llvm-tools (except for llvm 18)
+      - name: install llvm-tools (20)
+        if: matrix.version == '20'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.version }}
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
+      - name: install llvm-tools
+        if: matrix.version != '20'
         run: sudo apt install -y clang-${{ matrix.version }} llvm-${{ matrix.version }}
-      - name: install clang-rt (for llvm 15)
+      - name: install clang-rt
+        if: matrix.version != '20'
         run: sudo apt install -y libclang-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: install clang-rust
         # because ubuntu-22.04 already has this package
         if: ${{ matrix.version}} != 15
-          run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
+        run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
       - name: install llvm-tools
-        run: clang-${{ matrix.fuzzer }} llvm-${{ matrix.version }}-dev  llvm-config-${{ matrix.fuzzer }}
+        run: clang-${{ matrix.version }} llvm-${{ matrix.version }}-dev  llvm-config-${{ matrix.version }}
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.fuzzer }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.fuzzer }} distrib
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} distrib
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{ env.MAIN_LLVM_VERSION }} all
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.MAIN_LLVM_VERSION }} 200
+          sudo ./llvm.sh ${{ env.version }} all
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.version }} 200
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: install llvm-tools
         run: clang-${{ matrix.version }} llvm-${{ matrix.version }}-dev  llvm-config-${{ matrix.version }}
       - name: compiler installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,31 @@ on:
       - dev # No need for stable-pull-request, as that equals dev-push
 
 jobs:
+  check-compiler-passes:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        version: [14, 15, 16, 17, 18, 19, 20]
+    env:
+      AFL_SKIP_CPUFREQ: 1
+      AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: update
+        run: sudo apt-get update && sudo apt-get upgrade -y
+      - name: debug
+        run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
+      - name: install packages
+        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+      - name: install llvm-tools
+        run: clang-${{ matrix.fuzzer }} llvm-${{ matrix.version }}-dev  llvm-config-${{ matrix.fuzzer }}
+      - name: compiler installed
+        run: gcc -v; echo; clang -v
+      - name: build afl++
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.fuzzer }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.fuzzer }} distrib
+      - name: run tests
+        run: sudo -E ./afl-system-config; make tests
+
   linux:
     runs-on: "${{ matrix.os }}"
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,18 @@ jobs:
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
         run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
-      - name: install llvm-tools
+      - name: install llvm-tools (except for llvm 18)
+        if matrix.version != '18'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.version }} 200
-      - name: install clang-rt
+      - name: install llvm-tools 
+        # because llvm 18.1.8 (installed by the script above) is broken for us
+        if matrix.version == '18'
+        run: sudo apt install -y llvm-18 clang-18 llvm-config-18 libclang-rt-18-dev
+      - name: install clang-rt (for llvm 15)
         # because ubuntu-22.04 already has this package
         if: matrix.version != '15'
         run: sudo apt install -y libclang-rt-${{ matrix.version }}-dev

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - dev # No need for stable-pull-request, as that equals dev-push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-format-check:
     name: Check code format

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - dev # No need for stable-pull-request, as that equals dev-push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - dev # No need for stable-pull-request, as that equals dev-push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test-amd64:
     name: Test amd64 image

--- a/.github/workflows/rust_custom_mutator.yml
+++ b/.github/workflows/rust_custom_mutator.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - dev # No need for stable-pull-request, as that equals dev-push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Rust Custom Mutator Support


### PR DESCRIPTION
Adding CI in `check-compiler-passes` jobs.
I used ubuntu22.04 because ubuntu24.04 doesn't have package from llvm 14 up to llvm 16