### PR TITLE
Remove macros for old compiler versions from cmplog passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1; 
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
   check-compiler-passes (new):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-compiler-passes (old):
+  check-compiler-passes-old:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -39,10 +39,12 @@ jobs:
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1; 
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+      - name: Check llvm passes
+        run: make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
-  check-compiler-passes (new):
+  check-compiler-passes-new:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -75,6 +77,8 @@ jobs:
         run: gcc -v; echo; clang -v
       - name: build afl++
         run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+      - name: Check llvm passes
+        run: make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all || exit 1
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
   check-compiler-passes-2:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: build afl++
-        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+        run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all || exit 1
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
   check-compiler-passes-2:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-compiler-passes-1:
+  check-compiler-passes (old):
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
         run: export NO_NYX=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
-  check-compiler-passes-2:
+  check-compiler-passes (new):
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -345,6 +345,11 @@ llvm:
 	-$(MAKE) -j$(nproc) -f GNUmakefile.llvm
 	@test -e afl-cc || { echo "[-] Compiling afl-cc failed. You seem not to have a working compiler." ; exit 1; }
 
+llvm-build-test:
+	$(MAKE) -j$(nproc) -f GNUmakefile.llvm
+	@test -e afl-cc || { echo "[-] Compiling afl-cc failed. You seem not to have a working compiler." ; exit 1; }
+
+
 .PHONY: gcc_plugin
 gcc_plugin:
 ifneq "$(SYS)" "Darwin"

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -31,31 +31,17 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-#if LLVM_MAJOR >= 11
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Pass.h"
 #include "llvm/Analysis/ValueTracking.h"
-#if LLVM_VERSION_MAJOR >= 14                /* how about stable interfaces? */
-  #include "llvm/Passes/OptimizationLevel.h"
-#endif
+#include "llvm/Passes/OptimizationLevel.h"
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-  #include "llvm/Support/raw_ostream.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <set>
 #include "afl-llvm-common.h"
@@ -66,7 +52,6 @@ namespace {
 
 using DomTreeCallback = function_ref<const DominatorTree *(Function &F)>;
 
-#if LLVM_MAJOR >= 11                                /* use new pass manager */
 class CmpLogInstructions : public PassInfoMixin<CmpLogInstructions> {
 
  public:
@@ -76,38 +61,8 @@ class CmpLogInstructions : public PassInfoMixin<CmpLogInstructions> {
 
   }
 
-#else
-class CmpLogInstructions : public ModulePass {
 
- public:
-  static char ID;
-  CmpLogInstructions() : ModulePass(ID) {
-
-    initInstrumentList();
-
-  }
-
-#endif
-
-#if LLVM_MAJOR >= 11                                /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-
-  bool IsBackEdge(BasicBlock *From, BasicBlock *To, const DominatorTree *DT);
-
-  #if LLVM_VERSION_MAJOR >= 4
-  StringRef getPassName() const override {
-
-  #else
-  const char *getPassName() const override {
-
-  #endif
-    return "cmplog instructions";
-
-  }
-
-#endif
 
  private:
   bool hookInstrs(Module &M, DomTreeCallback DTCallback);
@@ -116,7 +71,6 @@ class CmpLogInstructions : public ModulePass {
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -142,10 +96,6 @@ llvmGetPassPluginInfo() {
           }};
 
 }
-
-#else
-char CmpLogInstructions::ID = 0;
-#endif
 
 template <class Iterator>
 Iterator Unique(Iterator first, Iterator last) {
@@ -203,95 +153,35 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
   #endif
   */
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c2 = M.getOrInsertFunction("__cmplog_ins_hook2", VoidTy, Int16Ty, Int16Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns2 = c2;
-#else
-  Function *cmplogHookIns2 = cast<Function>(c2);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c4 = M.getOrInsertFunction("__cmplog_ins_hook4", VoidTy, Int32Ty, Int32Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns4 = c4;
-#else
-  Function *cmplogHookIns4 = cast<Function>(c4);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c8 = M.getOrInsertFunction("__cmplog_ins_hook8", VoidTy, Int64Ty, Int64Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns8 = c8;
-#else
-  Function *cmplogHookIns8 = cast<Function>(c8);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy, Int128Ty,
                                   Int128Ty, Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                  ,
-                                  NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR < 9
   Function *cmplogHookIns16 = cast<Function>(c16);
-#else
-  FunctionCallee cmplogHookIns16 = c16;
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       cN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy, Int128Ty,
                                  Int128Ty, Int8Ty, Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookInsN = cN;
-#else
-  Function *cmplogHookInsN = cast<Function>(cN);
-#endif
 
   GlobalVariable *AFLCmplogPtr = M.getNamedGlobal("__afl_cmp_map");
 
@@ -344,9 +234,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
       IRBuilder<> IRB2(selectcmpInst->getParent());
       IRB2.SetInsertPoint(selectcmpInst);
       LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
           PointerType::get(Int8Ty, 0),
-#endif
           AFLCmplogPtr);
       CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
       auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -421,17 +309,13 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
 
           }
 
-#if (LLVM_VERSION_MAJOR >= 12)
           vector_cnt = tt->getElementCount().getKnownMinValue();
           ty0 = tt->getElementType();
-#endif
 
         }
 
         if (ty0->isHalfTy()
-#if LLVM_VERSION_MAJOR >= 11
             || ty0->isBFloatTy()
-#endif
         )
           max_size = 16;
         else if (ty0->isFloatTy())
@@ -442,11 +326,9 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
           max_size = 80;
         else if (ty0->isFP128Ty() || ty0->isPPC_FP128Ty())
           max_size = 128;
-#if (LLVM_VERSION_MAJOR >= 12)
         else if (ty0->getTypeID() != llvm::Type::PointerTyID && !be_quiet)
           fprintf(stderr, "Warning: unsupported cmp type for cmplog: %u!\n",
                   ty0->getTypeID());
-#endif
 
         attr += 8;
         is_fp = 1;
@@ -456,7 +338,6 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
 
         if (ty0->isVectorTy()) {
 
-#if (LLVM_VERSION_MAJOR >= 12)
           VectorType *tt = dyn_cast<VectorType>(ty0);
           if (!tt) {
 
@@ -467,7 +348,6 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
 
           vector_cnt = tt->getElementCount().getKnownMinValue();
           ty1 = ty0 = tt->getElementType();
-#endif
 
         }
 
@@ -482,15 +362,12 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
 
         } else {
 
-#if (LLVM_VERSION_MAJOR >= 12)
           if (ty0->getTypeID() != llvm::Type::PointerTyID && !be_quiet) {
 
             fprintf(stderr, "Warning: unsupported cmp type for cmplog: %u\n",
                     ty0->getTypeID());
 
           }
-
-#endif
 
         }
 
@@ -692,14 +569,8 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
 
 }
 
-#if LLVM_MAJOR >= 11                                /* use new pass manager */
 PreservedAnalyses CmpLogInstructions::run(Module                &M,
                                           ModuleAnalysisManager &MAM) {
-
-#else
-bool CmpLogInstructions::runOnModule(Module &M) {
-
-#endif
 
   auto &FAM = MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
   auto  DTCallback = [&FAM](Function &F) -> const DominatorTree  *{
@@ -716,36 +587,8 @@ bool CmpLogInstructions::runOnModule(Module &M) {
   bool ret = hookInstrs(M, DTCallback);
   verifyModule(M);
 
-#if LLVM_MAJOR >= 11                                /* use new pass manager */
   if (ret == false)
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
-
 }
-
-#if LLVM_MAJOR < 11                                 /* use old pass manager */
-static void registerCmpLogInstructionsPass(const PassManagerBuilder &,
-                                           legacy::PassManagerBase &PM) {
-
-  auto p = new CmpLogInstructions();
-  PM.add(p);
-
-}
-
-static RegisterStandardPasses RegisterCmpLogInstructionsPass(
-    PassManagerBuilder::EP_OptimizerLast, registerCmpLogInstructionsPass);
-
-static RegisterStandardPasses RegisterCmpLogInstructionsPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerCmpLogInstructionsPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterCmpLogInstructionsPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerCmpLogInstructionsPass);
-  #endif
-#endif
-

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -175,7 +175,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
       c16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy, Int128Ty,
                                   Int128Ty, Int8Ty
       );
-  Function *cmplogHookIns16 = cast<Function>(c16);
+  FunctionCallee *cmplogHookIns16 = c16;
 
   FunctionCallee
       cN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy, Int128Ty,

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -175,7 +175,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
       c16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy, Int128Ty,
                                   Int128Ty, Int8Ty
       );
-  FunctionCallee *cmplogHookIns16 = c16;
+  FunctionCallee cmplogHookIns16 = c16;
 
   FunctionCallee
       cN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy, Int128Ty,

--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -27,14 +27,9 @@
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -46,15 +41,8 @@
 #include "llvm/Analysis/ValueTracking.h"
 
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
 
 #include <set>
 #include "afl-llvm-common.h"
@@ -63,42 +51,16 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class CmpLogRoutines : public PassInfoMixin<CmpLogRoutines> {
 
  public:
   CmpLogRoutines() {
 
-#else
-class CmpLogRoutines : public ModulePass {
-
- public:
-  static char ID;
-  CmpLogRoutines() : ModulePass(ID) {
-
-#endif
-
     initInstrumentList();
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-
-  #if LLVM_VERSION_MAJOR >= 4
-  StringRef getPassName() const override {
-
-  #else
-  const char *getPassName() const override {
-
-  #endif
-    return "cmplog routines";
-
-  }
-
-#endif
 
  private:
   bool hookRtns(Module &M);
@@ -107,7 +69,6 @@ class CmpLogRoutines : public ModulePass {
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -134,10 +95,6 @@ llvmGetPassPluginInfo() {
 
 }
 
-#else
-char CmpLogRoutines::ID = 0;
-#endif
-
 bool CmpLogRoutines::hookRtns(Module &M) {
 
   std::vector<CallInst *> calls, llvmStdStd, llvmStdC, gccStdStd, gccStdC,
@@ -150,148 +107,52 @@ bool CmpLogRoutines::hookRtns(Module &M) {
   IntegerType *Int64Ty = IntegerType::getInt64Ty(C);
   PointerType *i8PtrTy = PointerType::get(Int8Ty, 0);
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c = M.getOrInsertFunction("__cmplog_rtn_hook", VoidTy, i8PtrTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                ,
-                                NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookFn = c;
-#else
-  Function *cmplogHookFn = cast<Function>(c);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c1 = M.getOrInsertFunction("__cmplog_rtn_llvm_stdstring_stdstring",
                                  VoidTy, i8PtrTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogLlvmStdStd = c1;
-#else
-  Function *cmplogLlvmStdStd = cast<Function>(c1);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c2 = M.getOrInsertFunction("__cmplog_rtn_llvm_stdstring_cstring", VoidTy,
                                  i8PtrTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogLlvmStdC = c2;
-#else
-  Function *cmplogLlvmStdC = cast<Function>(c2);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c3 = M.getOrInsertFunction("__cmplog_rtn_gcc_stdstring_stdstring", VoidTy,
                                  i8PtrTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogGccStdStd = c3;
-#else
-  Function *cmplogGccStdStd = cast<Function>(c3);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c4 = M.getOrInsertFunction("__cmplog_rtn_gcc_stdstring_cstring", VoidTy,
                                  i8PtrTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogGccStdC = c4;
-#else
-  Function *cmplogGccStdC = cast<Function>(c4);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c5 = M.getOrInsertFunction("__cmplog_rtn_hook_n", VoidTy, i8PtrTy,
                                  i8PtrTy, Int64Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookFnN = c5;
-#else
-  Function *cmplogHookFnN = cast<Function>(c5);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c6 = M.getOrInsertFunction("__cmplog_rtn_hook_strn", VoidTy, i8PtrTy,
                                  i8PtrTy, Int64Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookFnStrN = c6;
-#else
-  Function *cmplogHookFnStrN = cast<Function>(c6);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c7 = M.getOrInsertFunction("__cmplog_rtn_hook_str", VoidTy, i8PtrTy,
                                  i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookFnStr = c7;
-#else
-  Function *cmplogHookFnStr = cast<Function>(c7);
-#endif
 
   GlobalVariable *AFLCmplogPtr = M.getNamedGlobal("__afl_cmp_map");
 
@@ -503,9 +364,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -534,9 +393,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -569,9 +426,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -600,9 +455,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -635,9 +488,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -665,9 +516,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -695,9 +544,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -725,9 +572,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     IRB2.SetInsertPoint(callInst);
 
     LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
         PointerType::get(Int8Ty, 0),
-#endif
         AFLCmplogPtr);
     CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
     auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -751,13 +596,8 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
 }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses CmpLogRoutines::run(Module &M, ModuleAnalysisManager &MAM) {
 
-#else
-bool CmpLogRoutines::runOnModule(Module &M) {
-
-#endif
 
   if (getenv("AFL_QUIET") == NULL)
     printf("Running cmplog-routines-pass by andreafioraldi@gmail.com\n");
@@ -766,36 +606,9 @@ bool CmpLogRoutines::runOnModule(Module &M) {
   bool ret = hookRtns(M);
   verifyModule(M);
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   if (ret == false)
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
 
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerCmpLogRoutinesPass(const PassManagerBuilder &,
-                                       legacy::PassManagerBase &PM) {
-
-  auto p = new CmpLogRoutines();
-  PM.add(p);
-
-}
-
-static RegisterStandardPasses RegisterCmpLogRoutinesPass(
-    PassManagerBuilder::EP_OptimizerLast, registerCmpLogRoutinesPass);
-
-static RegisterStandardPasses RegisterCmpLogRoutinesPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerCmpLogRoutinesPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterCmpLogRoutinesPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerCmpLogRoutinesPass);
-  #endif
-#endif
-

--- a/instrumentation/cmplog-switches-pass.cc
+++ b/instrumentation/cmplog-switches-pass.cc
@@ -28,14 +28,9 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -47,15 +42,8 @@
 #include "llvm/Analysis/ValueTracking.h"
 
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
 
 #include <set>
 #include "afl-llvm-common.h"
@@ -64,41 +52,16 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class CmplogSwitches : public PassInfoMixin<CmplogSwitches> {
 
  public:
   CmplogSwitches() {
 
-#else
-class CmplogSwitches : public ModulePass {
-
- public:
-  static char ID;
-  CmplogSwitches() : ModulePass(ID) {
-
-#endif
     initInstrumentList();
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-
-  #if LLVM_VERSION_MAJOR < 4
-  const char *getPassName() const override {
-
-  #else
-  StringRef getPassName() const override {
-
-  #endif
-    return "cmplog switch split";
-
-  }
-
-#endif
 
  private:
   bool hookInstrs(Module &M);
@@ -107,7 +70,6 @@ class CmplogSwitches : public ModulePass {
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -133,10 +95,6 @@ llvmGetPassPluginInfo() {
           }};
 
 }
-
-#else
-char CmplogSwitches::ID = 0;
-#endif
 
 template <class Iterator>
 Iterator Unique(Iterator first, Iterator last) {
@@ -164,77 +122,29 @@ bool CmplogSwitches::hookInstrs(Module &M) {
   IntegerType *Int32Ty = IntegerType::getInt32Ty(C);
   IntegerType *Int64Ty = IntegerType::getInt64Ty(C);
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c1 = M.getOrInsertFunction("__cmplog_ins_hook1", VoidTy, Int8Ty, Int8Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns1 = c1;
-#else
-  Function *cmplogHookIns1 = cast<Function>(c1);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c2 = M.getOrInsertFunction("__cmplog_ins_hook2", VoidTy, Int16Ty, Int16Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns2 = c2;
-#else
-  Function *cmplogHookIns2 = cast<Function>(c2);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c4 = M.getOrInsertFunction("__cmplog_ins_hook4", VoidTy, Int32Ty, Int32Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns4 = c4;
-#else
-  Function *cmplogHookIns4 = cast<Function>(c4);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c8 = M.getOrInsertFunction("__cmplog_ins_hook8", VoidTy, Int64Ty, Int64Ty,
                                  Int8Ty
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee cmplogHookIns8 = c8;
-#else
-  Function *cmplogHookIns8 = cast<Function>(c8);
-#endif
 
   GlobalVariable *AFLCmplogPtr = M.getNamedGlobal("__afl_cmp_map");
 
@@ -299,9 +209,7 @@ bool CmplogSwitches::hookInstrs(Module &M) {
       IRB2.SetInsertPoint(SI);
 
       LoadInst *CmpPtr = IRB2.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
           PointerType::get(Int8Ty, 0),
-#endif
           AFLCmplogPtr);
       CmpPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
       auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
@@ -352,11 +260,7 @@ bool CmplogSwitches::hookInstrs(Module &M) {
       for (SwitchInst::CaseIt i = SI->case_begin(), e = SI->case_end(); i != e;
            ++i) {
 
-#if LLVM_VERSION_MAJOR < 5
-        ConstantInt *cint = i.getCaseValue();
-#else
         ConstantInt *cint = i->getCaseValue();
-#endif
 
         if (cint) {
 
@@ -435,13 +339,8 @@ bool CmplogSwitches::hookInstrs(Module &M) {
 
 }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses CmplogSwitches::run(Module &M, ModuleAnalysisManager &MAM) {
 
-#else
-bool CmplogSwitches::runOnModule(Module &M) {
-
-#endif
 
   if (getenv("AFL_QUIET") == NULL)
     printf("Running cmplog-switches-pass by andreafioraldi@gmail.com\n");
@@ -450,36 +349,9 @@ bool CmplogSwitches::runOnModule(Module &M) {
   bool ret = hookInstrs(M);
   verifyModule(M);
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   if (ret == false)
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
 
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerCmplogSwitchesPass(const PassManagerBuilder &,
-                                       legacy::PassManagerBase &PM) {
-
-  auto p = new CmplogSwitches();
-  PM.add(p);
-
-}
-
-static RegisterStandardPasses RegisterCmplogSwitchesPass(
-    PassManagerBuilder::EP_OptimizerLast, registerCmplogSwitchesPass);
-
-static RegisterStandardPasses RegisterCmplogSwitchesPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerCmplogSwitchesPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterCmplogSwitchesPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerCmplogSwitchesPass);
-  #endif
-#endif
-


### PR DESCRIPTION
I removed all macros which are about llvm versions <= 13 from cmplog passes