### PR TITLE
Remove macros for old compiler versions from afl-llvm-* passes 

### DIFF
--- a/instrumentation/afl-llvm-common.cc
+++ b/instrumentation/afl-llvm-common.cc
@@ -85,10 +85,7 @@ char *getBBName(const llvm::BasicBlock *BB) {
   std::string        Str;
   raw_string_ostream OS(Str);
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7)
   BB->printAsOperand(OS, false);
-#endif
   name = strdup(OS.str().c_str());
   return name;
 
@@ -339,8 +336,6 @@ void scanForDangerousFunctions(llvm::Module *M) {
 
   if (!M) return;
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
 
   for (GlobalIFunc &IF : M->ifuncs()) {
 
@@ -408,8 +403,6 @@ void scanForDangerousFunctions(llvm::Module *M) {
 
   }
 
-#endif
-
 }
 
 static std::string getSourceName(llvm::Function *F) {
@@ -420,8 +413,6 @@ static std::string getSourceName(llvm::Function *F) {
   IRBuilder<>          IRB(&(*IP));
   DebugLoc             Loc = IP->getDebugLoc();
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7)
   if (Loc) {
 
     StringRef   instFilename;
@@ -441,20 +432,6 @@ static std::string getSourceName(llvm::Function *F) {
     return instFilename.str();
 
   }
-
-#else
-  if (!Loc.isUnknown()) {
-
-    DILocation cDILoc(Loc.getAsMDNode(F->getContext()));
-
-    StringRef instFilename = cDILoc.getFilename();
-
-    /* Continue only if we know where we actually are */
-    return instFilename.str();
-
-  }
-
-#endif
 
   return std::string("");
 

--- a/instrumentation/afl-llvm-common.h
+++ b/instrumentation/afl-llvm-common.h
@@ -18,9 +18,6 @@
 #include <sys/time.h>
 
 #include "llvm/Config/llvm-config.h"
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 5
-typedef long double max_align_t;
-#endif
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -32,27 +29,16 @@ typedef long double max_align_t;
   #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #endif
 
-#if LLVM_VERSION_MAJOR > 3 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/DebugInfo.h"
-  #include "llvm/IR/CFG.h"
-#else
-  #include "llvm/DebugInfo.h"
-  #include "llvm/Support/CFG.h"
-#endif
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/CFG.h"
 
-#if LLVM_VERSION_MAJOR >= 11
-  #define MNAME M.getSourceFileName()
-  #define FMNAME F.getParent()->getSourceFileName()
-  #if LLVM_VERSION_MAJOR >= 16
-// None becomes deprecated
-// the standard std::nullopt_t is recommended instead
-// from C++17 and onwards.
-constexpr std::nullopt_t None = std::nullopt;
-  #endif
-#else
-  #define MNAME std::string("")
-  #define FMNAME std::string("")
+#define MNAME M.getSourceFileName()
+#define FMNAME F.getParent()->getSourceFileName()
+#if LLVM_VERSION_MAJOR >= 16
+  // None becomes deprecated
+  // the standard std::nullopt_t is recommended instead
+  // from C++17 and onwards.
+  constexpr std::nullopt_t None = std::nullopt;
 #endif
 
 char *getBBName(const llvm::BasicBlock *BB);

--- a/instrumentation/afl-llvm-dict2file.so.cc
+++ b/instrumentation/afl-llvm-dict2file.so.cc
@@ -39,13 +39,9 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DebugInfo.h"
@@ -72,7 +68,6 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class AFLdict2filePass : public PassInfoMixin<AFLdict2filePass> {
 
   std::ofstream of;
@@ -81,35 +76,15 @@ class AFLdict2filePass : public PassInfoMixin<AFLdict2filePass> {
  public:
   AFLdict2filePass() {
 
-#else
-
-class AFLdict2filePass : public ModulePass {
-
-  std::ofstream of;
-  void          dict2file(u8 *, u32);
-
- public:
-  static char ID;
-
-  AFLdict2filePass() : ModulePass(ID) {
-
-#endif
-
     if (getenv("AFL_DEBUG")) debug = 1;
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-#endif
-
 };
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -117,9 +92,6 @@ llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-  #if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-  #endif
             PB.registerOptimizerLastEPCallback([](ModulePassManager &MPM,
                                                   OptimizationLevel  OL
   #if LLVM_VERSION_MAJOR >= 20
@@ -135,10 +107,6 @@ llvmGetPassPluginInfo() {
           }};
 
 }
-
-#else
-char AFLdict2filePass::ID = 0;
-#endif
 
 void AFLdict2filePass::dict2file(u8 *mem, u32 len) {
 
@@ -179,13 +147,7 @@ void AFLdict2filePass::dict2file(u8 *mem, u32 len) {
 
 }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses AFLdict2filePass::run(Module &M, ModuleAnalysisManager &MAM) {
-
-#else
-bool AFLdict2filePass::runOnModule(Module &M) {
-
-#endif
 
   DenseMap<Value *, std::string *> valueMap;
   char                            *ptr;
@@ -213,12 +175,8 @@ bool AFLdict2filePass::runOnModule(Module &M) {
 
   if (!ptr) {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
     auto PA = PreservedAnalyses::all();
     return PA;
-#else
-    return true;
-#endif
 
   }
 
@@ -754,32 +712,7 @@ bool AFLdict2filePass::runOnModule(Module &M) {
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   auto PA = PreservedAnalyses::all();
   return PA;
-#else
-  return false;
-#endif
 
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerAFLdict2filePass(const PassManagerBuilder &,
-                                     legacy::PassManagerBase &PM) {
-
-  PM.add(new AFLdict2filePass());
-
-}
-
-static RegisterPass<AFLdict2filePass> X("afl-dict2file",
-                                        "AFL++ dict2file instrumentation pass",
-                                        false, false);
-
-static RegisterStandardPasses RegisterAFLdict2filePass(
-    PassManagerBuilder::EP_OptimizerLast, registerAFLdict2filePass);
-
-static RegisterStandardPasses RegisterAFLdict2filePass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerAFLdict2filePass);
-
-#endif
-

--- a/instrumentation/afl-llvm-lto-instrumentlist.so.cc
+++ b/instrumentation/afl-llvm-lto-instrumentlist.so.cc
@@ -43,9 +43,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/CFG.h"
-#if LLVM_VERSION_MAJOR >= 14                /* how about stable interfaces? */
-  #include "llvm/Passes/OptimizationLevel.h"
-#endif
+#include "llvm/Passes/OptimizationLevel.h"
 
 #include "afl-llvm-common.h"
 
@@ -80,9 +78,6 @@ llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-#if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-#endif
             PB.registerOptimizerLastEPCallback([](ModulePassManager &MPM,
                                                   OptimizationLevel  OL
 #if LLVM_VERSION_MAJOR >= 20
@@ -135,16 +130,8 @@ PreservedAnalyses AFLcheckIfInstrument::run(Module                &M,
 
       auto         &Ctx = F.getContext();
       AttributeList Attrs = F.getAttributes();
-#if LLVM_VERSION_MAJOR >= 14
       AttributeList NewAttrs = Attrs.addFnAttribute(Ctx, "skipinstrument");
       F.setAttributes(NewAttrs);
-#else
-      AttrBuilder NewAttrs;
-      NewAttrs.addAttribute("skipinstrument");
-      F.setAttributes(
-          Attrs.addAttributes(Ctx, AttributeList::FunctionIndex, NewAttrs));
-#endif
-
     }
 
   }
@@ -153,21 +140,4 @@ PreservedAnalyses AFLcheckIfInstrument::run(Module                &M,
   return PA;
 
 }
-
-#if 0
-static void registerAFLcheckIfInstrumentpass(const PassManagerBuilder &,
-                                             legacy::PassManagerBase &PM) {
-
-  PM.add(new AFLcheckIfInstrument());
-
-}
-
-static RegisterStandardPasses RegisterAFLcheckIfInstrumentpass(
-    PassManagerBuilder::EP_ModuleOptimizerEarly,
-    registerAFLcheckIfInstrumentpass);
-
-static RegisterStandardPasses RegisterAFLcheckIfInstrumentpass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0,
-    registerAFLcheckIfInstrumentpass);
-#endif
 

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -38,30 +38,17 @@ typedef long double max_align_t;
 #endif
 
 #include "llvm/Pass.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
-#if LLVM_VERSION_MAJOR >= 14                /* how about stable interfaces? */
-  #include "llvm/Passes/OptimizationLevel.h"
-#endif
+#include "llvm/Passes/OptimizationLevel.h"
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/DebugInfo.h"
-  #include "llvm/IR/CFG.h"
-#else
-  #include "llvm/DebugInfo.h"
-  #include "llvm/Support/CFG.h"
-#endif
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/CFG.h"
 
 #include "llvm/IR/IRBuilder.h"
 
@@ -72,30 +59,16 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class AFLCoverage : public PassInfoMixin<AFLCoverage> {
 
  public:
   AFLCoverage() {
 
-#else
-class AFLCoverage : public ModulePass {
-
- public:
-  static char ID;
-  AFLCoverage() : ModulePass(ID) {
-
-#endif
-
     initInstrumentList();
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-#endif
 
  protected:
   uint32_t    ngram_size = 0;
@@ -109,7 +82,6 @@ class AFLCoverage : public ModulePass {
 
 }  // namespace
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
 
   return {LLVM_PLUGIN_API_VERSION, "AFLCoverage", "v0.1",
@@ -117,9 +89,6 @@ extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
           [](PassBuilder &PB) {
 
   #if 1
-    #if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-    #endif
     #if LLVM_VERSION_MAJOR >= 16
             PB.registerOptimizerEarlyEPCallback(
     #else
@@ -135,70 +104,14 @@ extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
                   MPM.addPass(AFLCoverage());
 
                 });
-
-  /* TODO LTO registration */
-  #else
-            using PipelineElement = typename PassBuilder::PipelineElement;
-            PB.registerPipelineParsingCallback([](StringRef          Name,
-                                                  ModulePassManager &MPM,
-                                                  ArrayRef<PipelineElement>) {
-
-              if (Name == "AFLCoverage") {
-
-                MPM.addPass(AFLCoverage());
-                return true;
-
-              } else {
-
-                return false;
-
-              }
-
-            });
-
-  #endif
-
           }};
 
 }
 
-#else
-
-char AFLCoverage::ID = 0;
-#endif
-
-/* needed up to 3.9.0 */
-#if LLVM_VERSION_MAJOR == 3 && \
-    (LLVM_VERSION_MINOR < 9 || \
-     (LLVM_VERSION_MINOR == 9 && LLVM_VERSION_PATCH < 1))
-uint64_t PowerOf2Ceil(unsigned in) {
-
-  uint64_t in64 = in - 1;
-  in64 |= (in64 >> 1);
-  in64 |= (in64 >> 2);
-  in64 |= (in64 >> 4);
-  in64 |= (in64 >> 8);
-  in64 |= (in64 >> 16);
-  in64 |= (in64 >> 32);
-  return in64 + 1;
-
-}
-
-#endif
-
 /* #if LLVM_VERSION_STRING >= "4.0.1" */
-#if LLVM_VERSION_MAJOR >= 5 || \
-    (LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_PATCH >= 1)
-  #define AFL_HAVE_VECTOR_INTRINSICS 1
-#endif
+#define AFL_HAVE_VECTOR_INTRINSICS 1
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses AFLCoverage::run(Module &M, ModuleAnalysisManager &MAM) {
-
-#else
-bool AFLCoverage::runOnModule(Module &M) {
-
-#endif
 
   LLVMContext &C = M.getContext();
 
@@ -224,23 +137,12 @@ bool AFLCoverage::runOnModule(Module &M) {
 
   if (getenv("AFL_DEBUG")) debug = 1;
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   if (getenv("AFL_LLVM_ONLY_FSRV")) {
 
     if (debug) { fprintf(stderr, "Instrumentation disabled\n"); }
     return PreservedAnalyses::all();
 
   }
-
-#else
-  if (getenv("AFL_LLVM_ONLY_FSRV")) {
-
-    if (debug) { fprintf(stderr, "Instrumentation disabled\n"); }
-    return true;
-
-  }
-
-#endif
 
   if ((isatty(2) && !getenv("AFL_QUIET")) || getenv("AFL_DEBUG") != NULL) {
 
@@ -277,9 +179,6 @@ bool AFLCoverage::runOnModule(Module &M) {
 
   }
 
-#if LLVM_VERSION_MAJOR < 9
-  char *neverZero_counters_str = getenv("AFL_LLVM_NOT_ZERO");
-#endif
   skip_nozero = getenv("AFL_LLVM_SKIP_NEVERZERO");
   use_threadsafe_counters = getenv("AFL_LLVM_THREADSAFE_INST");
 
@@ -399,10 +298,8 @@ bool AFLCoverage::runOnModule(Module &M) {
   int PrevLocVecSize = PowerOf2Ceil(PrevLocSize);
   if (ngram_size)
     PrevLocTy = VectorType::get(IntLocTy, PrevLocVecSize
-  #if LLVM_VERSION_MAJOR >= 12
                                 ,
                                 false
-  #endif
     );
 #endif
 
@@ -410,10 +307,8 @@ bool AFLCoverage::runOnModule(Module &M) {
   int PrevCallerVecSize = PowerOf2Ceil(PrevCallerSize);
   if (ctx_k)
     PrevCallerTy = VectorType::get(IntLocTy, PrevCallerVecSize
-  #if LLVM_VERSION_MAJOR >= 12
                                    ,
                                    false
-  #endif
     );
 #endif
 
@@ -553,9 +448,7 @@ bool AFLCoverage::runOnModule(Module &M) {
         if (ctx_k) {
 
           PrevCaller = IRB.CreateLoad(
-  #if LLVM_VERSION_MAJOR >= 14
               PrevCallerTy,
-  #endif
               AFLPrevCaller);
           PrevCaller->setMetadata(M.getMDKindID("nosanitize"),
                                   MDNode::get(C, None));
@@ -570,9 +463,7 @@ bool AFLCoverage::runOnModule(Module &M) {
           // load the context ID of the previous function and write to a
           // local variable on the stack
           LoadInst *PrevCtxLoad = IRB.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
               IRB.getInt32Ty(),
-#endif
               AFLContext);
           PrevCtxLoad->setMetadata(M.getMDKindID("nosanitize"),
                                    MDNode::get(C, None));
@@ -651,7 +542,6 @@ bool AFLCoverage::runOnModule(Module &M) {
    The inline function successors() is not inlined and also not found at runtime
    :-( As I am unable to detect Ubuntu18.04 here, the next best thing is to
    disable this optional optimization for LLVM 6.0.0 and Linux */
-#if !(LLVM_VERSION_MAJOR == 6 && LLVM_VERSION_MINOR == 0) || !defined __linux__
       // only instrument if this basic block is the destination of a previous
       // basic block that has multiple successors
       // this gets rid of ~5-10% of instrumentations that are unnecessary
@@ -713,8 +603,6 @@ bool AFLCoverage::runOnModule(Module &M) {
 
       }
 
-#endif
-
       ConstantInt *CurLoc;
 
 #ifdef AFL_HAVE_VECTOR_INTRINSICS
@@ -731,17 +619,13 @@ bool AFLCoverage::runOnModule(Module &M) {
       if (ngram_size) {
 
         PrevLoc = IRB.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
             PrevLocTy,
-#endif
             AFLPrevLoc);
 
       } else {
 
         PrevLoc = IRB.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
             IRB.getInt32Ty(),
-#endif
             AFLPrevLoc);
 
       }
@@ -770,9 +654,7 @@ bool AFLCoverage::runOnModule(Module &M) {
       /* Load SHM pointer */
 
       LoadInst *MapPtr = IRB.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
           PointerType::get(Int8Ty, 0),
-#endif
           AFLMapPtr);
       MapPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
 
@@ -787,9 +669,7 @@ bool AFLCoverage::runOnModule(Module &M) {
       else
 #endif
         MapPtrIdx = IRB.CreateGEP(
-#if LLVM_VERSION_MAJOR >= 14
             Int8Ty,
-#endif
             MapPtr, IRB.CreateXor(PrevLocTrans, CurLoc));
 
       /* Update bitmap */
@@ -797,9 +677,7 @@ bool AFLCoverage::runOnModule(Module &M) {
       if (use_threadsafe_counters) {                              /* Atomic */
 
         IRB.CreateAtomicRMW(llvm::AtomicRMWInst::BinOp::Add, MapPtrIdx, One,
-#if LLVM_VERSION_MAJOR >= 13
                             llvm::MaybeAlign(1),
-#endif
                             llvm::AtomicOrdering::Monotonic);
         /*
 
@@ -810,21 +688,14 @@ bool AFLCoverage::runOnModule(Module &M) {
       } else {
 
         LoadInst *Counter = IRB.CreateLoad(
-#if LLVM_VERSION_MAJOR >= 14
             IRB.getInt8Ty(),
-#endif
             MapPtrIdx);
         Counter->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
 
         Value *Incr = IRB.CreateAdd(Counter, One);
 
-#if LLVM_VERSION_MAJOR >= 9
         if (!skip_nozero) {
 
-#else
-        if (neverZero_counters_str != NULL) {
-
-#endif
           /* hexcoder: Realize a counter that skips zero during overflow.
            * Once this counter reaches its maximum value, it next increments to
            * 1
@@ -902,125 +773,6 @@ bool AFLCoverage::runOnModule(Module &M) {
       inst_blocks++;
 
     }
-
-#if 0
-    if (use_threadsafe_counters) {                       /*Atomic NeverZero */
-      // handle the list of registered blocks to instrument
-      for (auto val : todo) {
-
-        /* hexcoder: Realize a thread-safe counter that skips zero during
-         * overflow. Once this counter reaches its maximum value, it next
-         * increments to 1
-         *
-         * Instead of
-         * Counter + 1 -> Counter
-         * we inject now this
-         * Counter + 1 -> {Counter, OverflowFlag}
-         * Counter + OverflowFlag -> Counter
-         */
-
-        /* equivalent c code looks like this
-         * Thanks to
-         https://preshing.com/20150402/you-can-do-any-kind-of-atomic-read-modify-write-operation/
-
-            int old = atomic_load_explicit(&Counter, memory_order_relaxed);
-            int new;
-            do {
-
-                 if (old == 255) {
-
-                   new = 1;
-
-                 } else {
-
-                   new = old + 1;
-
-                 }
-
-            } while (!atomic_compare_exchange_weak_explicit(&Counter, &old, new,
-
-         memory_order_relaxed, memory_order_relaxed));
-
-         */
-
-        Value *              MapPtrIdx = val;
-        Instruction *        MapPtrIdxInst = cast<Instruction>(val);
-        BasicBlock::iterator it0(&(*MapPtrIdxInst));
-        ++it0;
-        IRBuilder<> IRB(&(*it0));
-
-        // load the old counter value atomically
-        LoadInst *Counter = IRB.CreateLoad(
-  #if LLVM_VERSION_MAJOR >= 14
-        IRB.getInt8Ty(),
-  #endif
-        MapPtrIdx);
-        Counter->setAlignment(llvm::Align());
-        Counter->setAtomic(llvm::AtomicOrdering::Monotonic);
-        Counter->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
-
-        BasicBlock *BB = IRB.GetInsertBlock();
-        // insert a basic block with the corpus of a do while loop
-        // the calculation may need to repeat, if atomic compare_exchange is not
-        // successful
-
-        BasicBlock::iterator it(*Counter);
-        it++;  // split after load counter
-        BasicBlock *end_bb = BB->splitBasicBlock(it);
-        end_bb->setName("injected");
-
-        // insert the block before the second half of the split
-        BasicBlock *do_while_bb =
-            BasicBlock::Create(C, "injected", end_bb->getParent(), end_bb);
-
-        // set terminator of BB from target end_bb to target do_while_bb
-        auto term = BB->getTerminator();
-        BranchInst::Create(do_while_bb, BB);
-        term->eraseFromParent();
-
-        // continue to fill instructions into the do_while loop
-        IRB.SetInsertPoint(do_while_bb, do_while_bb->getFirstInsertionPt());
-
-        PHINode *PN = IRB.CreatePHI(Int8Ty, 2);
-
-        // compare with maximum value 0xff
-        auto *Cmp = IRB.CreateICmpEQ(Counter, ConstantInt::get(Int8Ty, -1));
-
-        // increment the counter
-        Value *Incr = IRB.CreateAdd(Counter, One);
-
-        // select the counter value or 1
-        auto *Select = IRB.CreateSelect(Cmp, One, Incr);
-
-        // try to save back the new counter value
-        auto *CmpXchg = IRB.CreateAtomicCmpXchg(
-            MapPtrIdx, PN, Select, llvm::AtomicOrdering::Monotonic,
-            llvm::AtomicOrdering::Monotonic);
-        CmpXchg->setAlignment(llvm::Align());
-        CmpXchg->setWeak(true);
-        CmpXchg->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
-
-        // get the result of trying to update the Counter
-        Value *Success =
-            IRB.CreateExtractValue(CmpXchg, ArrayRef<unsigned>({1}));
-        // get the (possibly updated) value of Counter
-        Value *OldVal =
-            IRB.CreateExtractValue(CmpXchg, ArrayRef<unsigned>({0}));
-
-        // initially we use Counter
-        PN->addIncoming(Counter, BB);
-        // on retry, we use the updated value
-        PN->addIncoming(OldVal, do_while_bb);
-
-        // if the cmpXchg was not successful, retry
-        IRB.CreateCondBr(Success, end_bb, do_while_bb);
-
-      }
-
-    }
-
-#endif
-
   }
 
   /*
@@ -1095,26 +847,5 @@ bool AFLCoverage::runOnModule(Module &M) {
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   return PreservedAnalyses();
-#else
-  return true;
-#endif
-
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerAFLPass(const PassManagerBuilder &,
-                            legacy::PassManagerBase &PM) {
-
-  PM.add(new AFLCoverage());
-
-}
-
-static RegisterStandardPasses RegisterAFLPass(
-    PassManagerBuilder::EP_OptimizerLast, registerAFLPass);
-
-static RegisterStandardPasses RegisterAFLPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerAFLPass);
-#endif
-

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -88,7 +88,6 @@ extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-  #if 1
     #if LLVM_VERSION_MAJOR >= 16
             PB.registerOptimizerEarlyEPCallback(
     #else


### PR DESCRIPTION
Same as the last one but for all the files with the name afl-llvm-*
