### PR TITLE
Remove macros for old compiler versions from split-* and injection passes

### DIFF
--- a/instrumentation/injection-pass.cc
+++ b/instrumentation/injection-pass.cc
@@ -27,14 +27,9 @@
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -46,15 +41,8 @@
 #include "llvm/Analysis/ValueTracking.h"
 
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
 
 #include <set>
 #include "afl-llvm-common.h"
@@ -63,42 +51,16 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class InjectionRoutines : public PassInfoMixin<InjectionRoutines> {
 
  public:
   InjectionRoutines() {
 
-#else
-class InjectionRoutines : public ModulePass {
-
- public:
-  static char ID;
-  InjectionRoutines() : ModulePass(ID) {
-
-#endif
-
     initInstrumentList();
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-
-  #if LLVM_VERSION_MAJOR >= 4
-  StringRef getPassName() const override {
-
-  #else
-  const char *getPassName() const override {
-
-  #endif
-    return "Injection routines";
-
-  }
-
-#endif
 
  private:
   bool hookRtns(Module &M);
@@ -111,7 +73,6 @@ class InjectionRoutines : public ModulePass {
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -119,9 +80,6 @@ llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-  #if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-  #endif
             PB.registerOptimizerLastEPCallback([](ModulePassManager &MPM,
                                                   OptimizationLevel  OL
   #if LLVM_VERSION_MAJOR >= 20
@@ -138,10 +96,6 @@ llvmGetPassPluginInfo() {
 
 }
 
-#else
-char InjectionRoutines::ID = 0;
-#endif
-
 bool InjectionRoutines::hookRtns(Module &M) {
 
   std::vector<CallInst *> calls, llvmStdStd, llvmStdC, gccStdStd, gccStdC,
@@ -152,62 +106,22 @@ bool InjectionRoutines::hookRtns(Module &M) {
   IntegerType *Int8Ty = IntegerType::getInt8Ty(C);
   PointerType *i8PtrTy = PointerType::get(Int8Ty, 0);
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c1 = M.getOrInsertFunction("__afl_injection_sql", VoidTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee sqlfunc = c1;
-#else
-  Function *sqlfunc = cast<Function>(c1);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c2 = M.getOrInsertFunction("__afl_injection_ldap", VoidTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee ldapfunc = c2;
-#else
-  Function *ldapfunc = cast<Function>(c2);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee
-#else
-  Constant *
-#endif
       c3 = M.getOrInsertFunction("__afl_injection_xss", VoidTy, i8PtrTy
-#if LLVM_VERSION_MAJOR < 5
-                                 ,
-                                 NULL
-#endif
       );
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee xssfunc = c3;
-#else
-  Function *xssfunc = cast<Function>(c3);
-#endif
 
-#if LLVM_VERSION_MAJOR >= 9
   FunctionCallee FuncPtr;
-#else
-  Function *FuncPtr;
-#endif
 
   bool ret = false;
 
@@ -311,14 +225,8 @@ bool InjectionRoutines::hookRtns(Module &M) {
 
 }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses InjectionRoutines::run(Module                &M,
                                          ModuleAnalysisManager &MAM) {
-
-#else
-bool InjectionRoutines::runOnModule(Module &M) {
-
-#endif
 
   if (getenv("AFL_QUIET") == NULL)
     printf("Running injection-pass by Marc Heuse (mh@mh-sec.de)\n");
@@ -339,36 +247,8 @@ bool InjectionRoutines::runOnModule(Module &M) {
   bool ret = hookRtns(M);
   verifyModule(M);
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   if (ret == false)
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
-
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerInjectionRoutinesPass(const PassManagerBuilder &,
-                                          legacy::PassManagerBase &PM) {
-
-  auto p = new InjectionRoutines();
-  PM.add(p);
-
-}
-
-static RegisterStandardPasses RegisterInjectionRoutinesPass(
-    PassManagerBuilder::EP_OptimizerLast, registerInjectionRoutinesPass);
-
-static RegisterStandardPasses RegisterInjectionRoutinesPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerInjectionRoutinesPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterInjectionRoutinesPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerInjectionRoutinesPass);
-  #endif
-#endif
-

--- a/instrumentation/split-compares-pass.so.cc
+++ b/instrumentation/split-compares-pass.so.cc
@@ -30,30 +30,16 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if LLVM_MAJOR >= 11
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/IR/Module.h"
-#if LLVM_VERSION_MAJOR >= 14                /* how about stable interfaces? */
-  #include "llvm/Passes/OptimizationLevel.h"
-#endif
+#include "llvm/Passes/OptimizationLevel.h"
 
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
 
 using namespace llvm;
 #include "afl-llvm-common.h"
@@ -64,31 +50,17 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_MAJOR >= 11
 class SplitComparesTransform : public PassInfoMixin<SplitComparesTransform> {
 
  public:
   //  static char ID;
   SplitComparesTransform() : enableFPSplit(0) {
 
-#else
-class SplitComparesTransform : public ModulePass {
-
- public:
-  static char ID;
-  SplitComparesTransform() : ModulePass(ID), enableFPSplit(0) {
-
-#endif
-
     initInstrumentList();
 
   }
 
-#if LLVM_MAJOR >= 11
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-#endif
 
  private:
   int enableFPSplit;
@@ -177,7 +149,6 @@ class SplitComparesTransform : public ModulePass {
 
 }  // namespace
 
-#if LLVM_MAJOR >= 11
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -185,10 +156,6 @@ llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-  #if 1
-    #if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-    #endif
     #if LLVM_VERSION_MAJOR >= 16
             PB.registerOptimizerEarlyEPCallback(
     #else
@@ -204,36 +171,10 @@ llvmGetPassPluginInfo() {
                   MPM.addPass(SplitComparesTransform());
 
                 });
-
-  /* TODO LTO registration */
-  #else
-            using PipelineElement = typename PassBuilder::PipelineElement;
-            PB.registerPipelineParsingCallback([](StringRef          Name,
-                                                  ModulePassManager &MPM,
-                                                  ArrayRef<PipelineElement>) {
-
-              if (Name == "splitcompares") {
-
-                MPM.addPass(SplitComparesTransform());
-                return true;
-
-              } else {
-
-                return false;
-
-              }
-
-            });
-
-  #endif
-
           }};
 
 }
 
-#else
-char SplitComparesTransform::ID = 0;
-#endif
 
 /// This function splits FCMP instructions with xGE or xLE predicates into two
 /// FCMP instructions with predicate xGT or xLT and EQ
@@ -951,8 +892,6 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
 
   LLVMContext &C = M.getContext();
 
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 7)
   const DataLayout &dl = M.getDataLayout();
 
   /* define unions with floating point and (sign, exponent, mantissa)  triples
@@ -966,8 +905,6 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
     return counts;
 
   }
-
-#endif
 
   std::vector<CmpInst *> fcomps;
 
@@ -1710,14 +1647,9 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
 
 }
 
-#if LLVM_MAJOR >= 11
 PreservedAnalyses SplitComparesTransform::run(Module                &M,
                                               ModuleAnalysisManager &MAM) {
 
-#else
-bool SplitComparesTransform::runOnModule(Module &M) {
-
-#endif
 
   if ((isatty(2) && getenv("AFL_QUIET") == NULL) ||
       getenv("AFL_DEBUG") != NULL) {
@@ -1824,11 +1756,8 @@ bool SplitComparesTransform::runOnModule(Module &M) {
 
   bool brokenDebug = false;
   if (verifyModule(M, &errs()
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
                           ,
                    &brokenDebug  // 9th May 2016
-#endif
                    )) {
 
     reportError(
@@ -1853,7 +1782,6 @@ bool SplitComparesTransform::runOnModule(Module &M) {
 
   }
 
-#if LLVM_MAJOR >= 11
   /*  if (modified) {
 
       PA.abandon<XX_Manager>();
@@ -1864,36 +1792,5 @@ bool SplitComparesTransform::runOnModule(Module &M) {
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
 
 }
-
-#if LLVM_MAJOR < 11                                 /* use old pass manager */
-
-static void registerSplitComparesPass(const PassManagerBuilder &,
-                                      legacy::PassManagerBase &PM) {
-
-  PM.add(new SplitComparesTransform());
-
-}
-
-static RegisterStandardPasses RegisterSplitComparesPass(
-    PassManagerBuilder::EP_OptimizerLast, registerSplitComparesPass);
-
-static RegisterStandardPasses RegisterSplitComparesTransPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerSplitComparesPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterSplitComparesTransPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerSplitComparesPass);
-  #endif
-
-static RegisterPass<SplitComparesTransform> X("splitcompares",
-                                              "AFL++ split compares",
-                                              true /* Only looks at CFG */,
-                                              true /* Analysis Pass */);
-#endif
-

--- a/instrumentation/split-switches-pass.so.cc
+++ b/instrumentation/split-switches-pass.so.cc
@@ -27,34 +27,20 @@
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
-  #include "llvm/Passes/PassPlugin.h"
-  #include "llvm/Passes/PassBuilder.h"
-  #include "llvm/IR/PassManager.h"
-#else
-  #include "llvm/IR/LegacyPassManager.h"
-  #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#endif
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Pass.h"
 #include "llvm/Analysis/ValueTracking.h"
-#if LLVM_VERSION_MAJOR >= 14                /* how about stable interfaces? */
-  #include "llvm/Passes/OptimizationLevel.h"
-#endif
+#include "llvm/Passes/OptimizationLevel.h"
 
 #include "llvm/IR/IRBuilder.h"
-#if LLVM_VERSION_MAJOR >= 4 || \
-    (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR > 4)
-  #include "llvm/IR/Verifier.h"
-  #include "llvm/IR/DebugInfo.h"
-#else
-  #include "llvm/Analysis/Verifier.h"
-  #include "llvm/DebugInfo.h"
-  #define nullptr 0
-#endif
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/DebugInfo.h"
 
 #include <set>
 #include "afl-llvm-common.h"
@@ -63,42 +49,16 @@ using namespace llvm;
 
 namespace {
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 class SplitSwitchesTransform : public PassInfoMixin<SplitSwitchesTransform> {
 
  public:
   SplitSwitchesTransform() {
 
-#else
-class SplitSwitchesTransform : public ModulePass {
-
- public:
-  static char ID;
-  SplitSwitchesTransform() : ModulePass(ID) {
-
-#endif
     initInstrumentList();
 
   }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-#else
-  bool runOnModule(Module &M) override;
-
-  #if LLVM_VERSION_MAJOR >= 4
-  StringRef getPassName() const override {
-
-  #else
-  const char *getPassName() const override {
-
-  #endif
-    return "splits switch constructs";
-
-  }
-
-#endif
-
   struct CaseExpr {
 
     ConstantInt *Val;
@@ -125,7 +85,6 @@ class SplitSwitchesTransform : public ModulePass {
 
 }  // namespace
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
 
@@ -133,10 +92,6 @@ llvmGetPassPluginInfo() {
           /* lambda to insert our pass into the pass pipeline. */
           [](PassBuilder &PB) {
 
-  #if 1
-    #if LLVM_VERSION_MAJOR <= 13
-            using OptimizationLevel = typename PassBuilder::OptimizationLevel;
-    #endif
     #if LLVM_VERSION_MAJOR >= 16
             PB.registerOptimizerEarlyEPCallback(
     #else
@@ -153,36 +108,9 @@ llvmGetPassPluginInfo() {
                   MPM.addPass(SplitSwitchesTransform());
 
                 });
-
-  /* TODO LTO registration */
-  #else
-            using PipelineElement = typename PassBuilder::PipelineElement;
-            PB.registerPipelineParsingCallback([](StringRef          Name,
-                                                  ModulePassManager &MPM,
-                                                  ArrayRef<PipelineElement>) {
-
-              if (Name == "splitswitches") {
-
-                MPM.addPass(SplitSwitchesTransform());
-                return true;
-
-              } else {
-
-                return false;
-
-              }
-
-            });
-
-  #endif
-
           }};
 
 }
-
-#else
-char SplitSwitchesTransform::ID = 0;
-#endif
 
 /* switchConvert - Transform simple list of Cases into list of CaseRange's */
 BasicBlock *SplitSwitchesTransform::switchConvert(
@@ -392,10 +320,7 @@ BasicBlock *SplitSwitchesTransform::switchConvert(
 
 bool SplitSwitchesTransform::splitSwitches(Module &M) {
 
-#if (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 7)
   LLVMContext &C = M.getContext();
-#endif
-
   std::vector<SwitchInst *> switches;
 
   /* iterate over all functions, bbs and instruction and add
@@ -462,11 +387,7 @@ bool SplitSwitchesTransform::splitSwitches(Module &M) {
     CaseVector Cases;
     for (SwitchInst::CaseIt i = SI->case_begin(), e = SI->case_end(); i != e;
          ++i)
-#if LLVM_VERSION_MAJOR >= 5
       Cases.push_back(CaseExpr(i->getCaseValue(), i->getCaseSuccessor()));
-#else
-      Cases.push_back(CaseExpr(i.getCaseValue(), i.getCaseSuccessor()));
-#endif
     /* bugfix thanks to pbst
      * round up bytesChecked (in case getBitWidth() % 8 != 0) */
     std::vector<bool> bytesChecked((7 + Cases[0].Val->getBitWidth()) / 8,
@@ -512,14 +433,8 @@ bool SplitSwitchesTransform::splitSwitches(Module &M) {
 
 }
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
 PreservedAnalyses SplitSwitchesTransform::run(Module                &M,
                                               ModuleAnalysisManager &MAM) {
-
-#else
-bool SplitSwitchesTransform::runOnModule(Module &M) {
-
-#endif
 
   if ((isatty(2) && getenv("AFL_QUIET") == NULL) || getenv("AFL_DEBUG") != NULL)
     printf("Running split-switches-pass by laf.intel@gmail.com\n");
@@ -529,7 +444,6 @@ bool SplitSwitchesTransform::runOnModule(Module &M) {
   bool ret = splitSwitches(M);
   verifyModule(M);
 
-#if LLVM_VERSION_MAJOR >= 11                        /* use new pass manager */
                              /*  if (modified) {
                            
                                  PA.abandon<XX_Manager>();
@@ -540,31 +454,5 @@ bool SplitSwitchesTransform::runOnModule(Module &M) {
     return PreservedAnalyses::all();
   else
     return PreservedAnalyses();
-#else
-  return ret;
-#endif
 
 }
-
-#if LLVM_VERSION_MAJOR < 11                         /* use old pass manager */
-static void registerSplitSwitchesTransPass(const PassManagerBuilder &,
-                                           legacy::PassManagerBase &PM) {
-
-  auto p = new SplitSwitchesTransform();
-  PM.add(p);
-
-}
-
-static RegisterStandardPasses RegisterSplitSwitchesTransPass(
-    PassManagerBuilder::EP_OptimizerLast, registerSplitSwitchesTransPass);
-
-static RegisterStandardPasses RegisterSplitSwitchesTransPass0(
-    PassManagerBuilder::EP_EnabledOnOptLevel0, registerSplitSwitchesTransPass);
-
-  #if LLVM_VERSION_MAJOR >= 11
-static RegisterStandardPasses RegisterSplitSwitchesTransPassLTO(
-    PassManagerBuilder::EP_FullLinkTimeOptimizationLast,
-    registerSplitSwitchesTransPass);
-  #endif
-#endif
-


### PR DESCRIPTION
Same as last one