### PR TITLE
Improving auto-generated dictionary of Cmplog

### DIFF
--- a/include/cmplog.h
+++ b/include/cmplog.h
@@ -75,6 +75,7 @@ struct cmpfn_operands {
 } __attribute__((packed));
 
 typedef struct cmp_operands cmp_map_list[CMP_MAP_H];
+// using cmp_map_list = struct cmp_operands[CMP_MAP_H=32]
 
 struct cmp_map {
 
@@ -87,6 +88,16 @@ struct cmp_map {
 
 struct afl_forkserver;
 void cmplog_exec_child(struct afl_forkserver *fsrv, char **argv);
+
+enum {
+
+  ADDR_ATTR_NOTFOUND = 0,
+  ADDR_ATTR_RO = 1,
+  ADDR_ATTR_RW = 2,
+
+};
+
+int get_prog_addr_attr(const void *addr);
 
 #endif
 

--- a/include/cmplog.h
+++ b/include/cmplog.h
@@ -41,6 +41,10 @@
 #define CMP_TYPE_INS 0
 #define CMP_TYPE_RTN 1
 
+#define ADDR_ATTR_COMBINE(v0attr, v1attr) ((v0attr & 3) + ((v1attr & 3) << 2))
+#define ADDR_ATTR_V0(x) (x & 3)
+#define ADDR_ATTR_V1(x) ((x >> 2) & 3)
+
 struct cmp_header {  // 16 bit = 2 bytes
 
   unsigned hits : 6;       // up to 63 entries, we have CMP_MAP_H = 32
@@ -70,12 +74,12 @@ struct cmpfn_operands {
   u8 v1[32];
   u8 v0_len;
   u8 v1_len;
-  u8 unused[6];  // 2 bits could be used for "is constant operand"
+  u8 addr_attr;
+  u8 unused[5];  // 2 bits could be used for "is constant operand"
 
 } __attribute__((packed));
 
 typedef struct cmp_operands cmp_map_list[CMP_MAP_H];
-// using cmp_map_list = struct cmp_operands[CMP_MAP_H=32]
 
 struct cmp_map {
 
@@ -89,6 +93,7 @@ struct cmp_map {
 struct afl_forkserver;
 void cmplog_exec_child(struct afl_forkserver *fsrv, char **argv);
 
+// Attribute of whether the Buffer points to the memory area mapped by ELF
 enum {
 
   ADDR_ATTR_NOTFOUND = 0,
@@ -96,8 +101,6 @@ enum {
   ADDR_ATTR_RW = 2,
 
 };
-
-int get_prog_addr_attr(const void *addr);
 
 #endif
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -13,6 +13,13 @@
 
 */
 
+#ifdef __linux__
+  #ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+  #endif
+  #include <link.h>
+#endif
+
 #ifdef __AFL_CODE_COVERAGE
   #ifndef _GNU_SOURCE
     #define _GNU_SOURCE
@@ -2448,9 +2455,11 @@ void __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len) {
 
   cmpfn[hits].v0_len = 0x80 + l;
   cmpfn[hits].v1_len = 0x80 + l;
-  __builtin_memcpy(cmpfn[hits].v0, ptr1, len1);
-  __builtin_memcpy(cmpfn[hits].v1, ptr2, len2);
+  __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
+  __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
   // fprintf(stderr, "RTN3\n");
+  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
+  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
 
 }
 
@@ -2502,9 +2511,11 @@ void __cmplog_rtn_hook_str(u8 *ptr1, u8 *ptr2) {
 
   cmpfn[hits].v0_len = 0x80 + len1;
   cmpfn[hits].v1_len = 0x80 + len2;
-  __builtin_memcpy(cmpfn[hits].v0, ptr1, len1);
-  __builtin_memcpy(cmpfn[hits].v1, ptr2, len2);
+  __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
+  __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
   // fprintf(stderr, "RTN3\n");
+  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
+  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
 
 }
 
@@ -2561,9 +2572,11 @@ void __cmplog_rtn_hook(u8 *ptr1, u8 *ptr2) {
 
   cmpfn[hits].v0_len = len;
   cmpfn[hits].v1_len = len;
-  __builtin_memcpy(cmpfn[hits].v0, ptr1, len);
-  __builtin_memcpy(cmpfn[hits].v1, ptr2, len);
+  __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
+  __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
   // fprintf(stderr, "RTN3\n");
+  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
+  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
 
 }
 
@@ -2629,9 +2642,12 @@ void __cmplog_rtn_hook_n(u8 *ptr1, u8 *ptr2, u64 len) {
 
   cmpfn[hits].v0_len = l;
   cmpfn[hits].v1_len = l;
-  __builtin_memcpy(cmpfn[hits].v0, ptr1, l);
-  __builtin_memcpy(cmpfn[hits].v1, ptr2, l);
+  __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
+  __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
   // fprintf(stderr, "RTN3\n");
+  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
+  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
+
 #endif
 
 }
@@ -2918,6 +2934,43 @@ void __afl_injection_xss(u8 *buf) {
   }
 
 }
+
+#ifdef __linux__
+static int addr_static_cb(struct dl_phdr_info *info, size_t size, void *data) {
+
+  for (size_t i = 0; i < info->dlpi_phnum; i++) {
+
+    if (info->dlpi_phdr[i].p_type != PT_LOAD) { continue; }
+    uintptr_t addr_start = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+    uintptr_t addr_end = addr_start + MIN(info->dlpi_phdr[i].p_memsz,
+                                          info->dlpi_phdr[i].p_filesz);
+    if (((uintptr_t)data >= addr_start) && ((uintptr_t)data < addr_end)) {
+
+      if ((info->dlpi_phdr[i].p_flags & PF_W) == 0) {
+
+        return ADDR_ATTR_RO;
+
+      } else {
+
+        return ADDR_ATTR_RW;
+
+      }
+
+    }
+
+  }
+
+  return ADDR_ATTR_NOTFOUND;
+
+}
+
+int get_prog_addr_attr(const void *addr) {
+
+  return dl_iterate_phdr(addr_static_cb, (void *)addr);
+
+}
+
+#endif
 
 #undef write_error
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -2399,6 +2399,48 @@ static int area_is_valid(void *ptr, size_t len) {
 
 }
 
+/* Attribute of whether the Buffer points to the memory area mapped by ELF */
+
+#ifdef __linux__
+
+// From
+// https://github.com/google/honggfuzz/blob/ded8c87bcf3cc32f64c1097746a3461d6da1c24a/libhfcommon/util.c#L963
+static int addr_static_cb(struct dl_phdr_info *info, size_t size, void *data) {
+
+  for (size_t i = 0; i < info->dlpi_phnum; i++) {
+
+    if (info->dlpi_phdr[i].p_type != PT_LOAD) { continue; }
+    uintptr_t addr_start = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+    uintptr_t addr_end = addr_start + MIN(info->dlpi_phdr[i].p_memsz,
+                                          info->dlpi_phdr[i].p_filesz);
+    if (((uintptr_t)data >= addr_start) && ((uintptr_t)data < addr_end)) {
+
+      if ((info->dlpi_phdr[i].p_flags & PF_W) == 0) {
+
+        return ADDR_ATTR_RO;
+
+      } else {
+
+        return ADDR_ATTR_RW;
+
+      }
+
+    }
+
+  }
+
+  return ADDR_ATTR_NOTFOUND;
+
+}
+
+static u8 get_prog_addr_attr(const void *addr) {
+
+  return dl_iterate_phdr(addr_static_cb, (void *)addr);
+
+}
+
+#endif
+
 /* hook for string with length functions, eg. strncmp, strncasecmp etc.
    Note that we ignore the len parameter and take longer strings if present. */
 void __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len) {
@@ -2457,9 +2499,12 @@ void __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len) {
   cmpfn[hits].v1_len = 0x80 + l;
   __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
   __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
-  // fprintf(stderr, "RTN3\n");
-  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
-  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
+// fprintf(stderr, "RTN3\n");
+#ifdef __linux__
+  u8 attr1 = get_prog_addr_attr(ptr1);
+  u8 attr2 = get_prog_addr_attr(ptr2);
+  cmpfn->addr_attr = ADDR_ATTR_COMBINE(attr1, attr2);
+#endif
 
 }
 
@@ -2513,9 +2558,12 @@ void __cmplog_rtn_hook_str(u8 *ptr1, u8 *ptr2) {
   cmpfn[hits].v1_len = 0x80 + len2;
   __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
   __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
-  // fprintf(stderr, "RTN3\n");
-  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
-  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
+// fprintf(stderr, "RTN3\n");
+#ifdef __linux__
+  u8 attr1 = get_prog_addr_attr(ptr1);
+  u8 attr2 = get_prog_addr_attr(ptr2);
+  cmpfn->addr_attr = ADDR_ATTR_COMBINE(attr1, attr2);
+#endif
 
 }
 
@@ -2574,9 +2622,12 @@ void __cmplog_rtn_hook(u8 *ptr1, u8 *ptr2) {
   cmpfn[hits].v1_len = len;
   __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
   __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
-  // fprintf(stderr, "RTN3\n");
-  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
-  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
+// fprintf(stderr, "RTN3\n");
+#ifdef __linux__
+  u8 attr1 = get_prog_addr_attr(ptr1);
+  u8 attr2 = get_prog_addr_attr(ptr2);
+  cmpfn->addr_attr = ADDR_ATTR_COMBINE(attr1, attr2);
+#endif
 
 }
 
@@ -2645,8 +2696,11 @@ void __cmplog_rtn_hook_n(u8 *ptr1, u8 *ptr2, u64 len) {
   __builtin_memcpy(cmpfn[hits].v0, ptr1, 32);
   __builtin_memcpy(cmpfn[hits].v1, ptr2, 32);
   // fprintf(stderr, "RTN3\n");
-  cmpfn->unused[0] = get_prog_addr_attr(ptr1);
-  cmpfn->unused[1] = get_prog_addr_attr(ptr2);
+  #ifdef __linux__
+  u8 attr1 = get_prog_addr_attr(ptr1);
+  u8 attr2 = get_prog_addr_attr(ptr2);
+  cmpfn->addr_attr = ADDR_ATTR_COMBINE(attr1, attr2);
+  #endif
 
 #endif
 
@@ -2934,43 +2988,6 @@ void __afl_injection_xss(u8 *buf) {
   }
 
 }
-
-#ifdef __linux__
-static int addr_static_cb(struct dl_phdr_info *info, size_t size, void *data) {
-
-  for (size_t i = 0; i < info->dlpi_phnum; i++) {
-
-    if (info->dlpi_phdr[i].p_type != PT_LOAD) { continue; }
-    uintptr_t addr_start = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
-    uintptr_t addr_end = addr_start + MIN(info->dlpi_phdr[i].p_memsz,
-                                          info->dlpi_phdr[i].p_filesz);
-    if (((uintptr_t)data >= addr_start) && ((uintptr_t)data < addr_end)) {
-
-      if ((info->dlpi_phdr[i].p_flags & PF_W) == 0) {
-
-        return ADDR_ATTR_RO;
-
-      } else {
-
-        return ADDR_ATTR_RW;
-
-      }
-
-    }
-
-  }
-
-  return ADDR_ATTR_NOTFOUND;
-
-}
-
-int get_prog_addr_attr(const void *addr) {
-
-  return dl_iterate_phdr(addr_static_cb, (void *)addr);
-
-}
-
-#endif
 
 #undef write_error
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2904,15 +2904,15 @@ static u8 rtn_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u8 *cbuf,
       // o->v0, v1_len, o->v1);
 
       if (!memcmp(o->v0, orig_o->v0, v0_len) &&
-          o->unused[0] != ADDR_ATTR_NOTFOUND &&
-          orig_o->unused[0] != ADDR_ATTR_NOTFOUND) {
+          ADDR_ATTR_V0(o->addr_attr) != ADDR_ATTR_NOTFOUND &&
+          ADDR_ATTR_V0(orig_o->addr_attr) != ADDR_ATTR_NOTFOUND) {
 
         maybe_add_auto(afl, o->v0, v0_len);
 
       } else if (!memcmp(o->v1, orig_o->v1, v1_len) &&
 
-                 o->unused[1] != ADDR_ATTR_NOTFOUND &&
-                 orig_o->unused[1] != ADDR_ATTR_NOTFOUND) {
+                 ADDR_ATTR_V1(o->addr_attr) != ADDR_ATTR_NOTFOUND &&
+                 ADDR_ATTR_V1(orig_o->addr_attr) != ADDR_ATTR_NOTFOUND) {
 
         maybe_add_auto(afl, o->v1, v1_len);
 

--- a/src/afl-fuzz-redqueen.c
+++ b/src/afl-fuzz-redqueen.c
@@ -2903,14 +2903,33 @@ static u8 rtn_fuzz(afl_state_t *afl, u32 key, u8 *orig_buf, u8 *buf, u8 *cbuf,
       // shape_len), check_if_text_buf((u8 *)&o->v1, shape_len), v0_len,
       // o->v0, v1_len, o->v1);
 
-      // Note that this check differs from the line 1901, for RTN we are more
-      // opportunistic for adding to the dictionary than cmps
-      if (!memcmp(o->v0, orig_o->v0, v0_len) ||
-          (!found_one || check_if_text_buf((u8 *)&o->v0, v0_len) == v0_len))
+      if (!memcmp(o->v0, orig_o->v0, v0_len) &&
+          o->unused[0] != ADDR_ATTR_NOTFOUND &&
+          orig_o->unused[0] != ADDR_ATTR_NOTFOUND) {
+
         maybe_add_auto(afl, o->v0, v0_len);
-      if (!memcmp(o->v1, orig_o->v1, v1_len) ||
-          (!found_one || check_if_text_buf((u8 *)&o->v1, v1_len) == v1_len))
+
+      } else if (!memcmp(o->v1, orig_o->v1, v1_len) &&
+
+                 o->unused[1] != ADDR_ATTR_NOTFOUND &&
+                 orig_o->unused[1] != ADDR_ATTR_NOTFOUND) {
+
         maybe_add_auto(afl, o->v1, v1_len);
+
+      } else {
+
+        // Note that this check differs from the line 1901, for RTN we are more
+        // opportunistic for adding to the dictionary than cmps
+        if (!memcmp(o->v0, orig_o->v0, v0_len) &&
+            (!found_one || check_if_text_buf((u8 *)&o->v0, v0_len) == v0_len) &&
+            v0_len != 32)
+          maybe_add_auto(afl, o->v0, v0_len);
+        if (!memcmp(o->v1, orig_o->v1, v1_len) &&
+            (!found_one || check_if_text_buf((u8 *)&o->v1, v1_len) == v1_len) &&
+            v1_len != 32)
+          maybe_add_auto(afl, o->v1, v1_len);
+
+      }
 
       //}
 


### PR DESCRIPTION
**Background:** We observed that on FuzzBench, Honggfuzz performs better than AFL++ on the proj4 benchmark ([for example, here](https://storage.googleapis.com/www.fuzzbench.com/reports/2024-05-13-new-cov/index.html#proj4_proj_crs_to_crs_fuzzer-summary)). Over the past month, we have been investigating the reasons and attempting to further improve AFL++.  

For proj4, we noticed that Honggfuzz’s auto-generated dictionary is of much higher quality than AFL++’s. Honggfuzz employs a simple strategy when collecting string constants for its dictionary: during `memcmp`/`strcmp` operations, it checks whether one of the pointers originates from the ELF file’s mapped memory (typically writable or non-writable data sections), excluding pointers from the heap. For example, in string constant comparisons, the data being compared usually points to the heap, while the string constant pointer points to the ELF’s read-only data section. When porting this to AFL++, we marked this information in an unused field of the cmplog’s `rtn` entry.  

We initially ported Honggfuzz’s strategy (Version 1, `aflplusplus_hfdictv1`), but the generated dictionary still contained many low-quality bytes. We modified AFL++ to log auto-dictionary additions per code location ([Here](https://github.com/am009/AFLplusplus-log/commit/490d766cf36695c76b5cfea8de3cc91f711ac157#diff-e19a2aa96f6d8b887db995462c38ab48d2ddb449a68b63df967137d4469454eeR2949-R2965)), revealing that `location3` and `location4` ([link](https://github.com/AFLplusplus/AFLplusplus/blob/11a5e3768483591bdf80a62ece6af7db1a72626e/src/afl-fuzz-redqueen.c#L2908-L2913)) added numerous suboptimal dictionary entries, typically 32 bytes in size. 

AFL++’s cmplog will even instruments functions with signatures similar to `memcmp`/`strcmp` (and also ignoring the size from 3rd arg, see this [code](https://github.com/AFLplusplus/AFLplusplus/blob/11a5e3768483591bdf80a62ece6af7db1a72626e/instrumentation/afl-compiler-rt.o.c#L2570-L2576)), it directly records the maximum 32 bytes from the memory pointed to by the first two arguments as a cmplog `rtn` entry when encountering such functions. The related condition checks ([link](https://github.com/AFLplusplus/AFLplusplus/blob/11a5e3768483591bdf80a62ece6af7db1a72626e/src/afl-fuzz-redqueen.c#L2908-L2913)) are quite loose, and over 90% of auto-dictionary entries originate there. After further filtering these entries, we achieved better results (Version 2, `aflplusplus_hfdictv2`).  

**Local FuzzBench Results**  
Fuzzers:  
- `aflplusplus_hfdictv1`: First version with Honggfuzz’s auto-dictionary logic.  
- `aflplusplus_hfdictv2`: Filtered out 32-byte dictionaries from cmplog `rtn` entries.  
- `aflplusplus_proj4dict`: Auto-dictionary entries extracted from a 23-hour Honggfuzz instance (converted and fed to AFL++).  
- `honggfuzz_orig`: Original Honggfuzz from FuzzBench.  
- `aflplusplus_recent`: Recent stable AFL++ version.  

On the `proj4_proj_crs_to_crs_fuzzer` benchmark, AFL++ now performs as good as Honggfuzz:  

![2025-07-09172510](https://github.com/user-attachments/assets/d7dd2fba-146e-4d40-a867-1175424c1bcc)

[hfdict-base-aflpphfdictv2-23h.zip](https://github.com/user-attachments/files/21139193/hfdict-base-aflpphfdictv2-23h.zip)

Testing across 4 other benchmarks also showed improvements on some other benchmarks:  

![2025-07-09164000](https://github.com/user-attachments/assets/42f73f4f-e167-4622-99d3-36db7ef19bdc)

[report-5-benchmarks.zip](https://github.com/user-attachments/files/21139199/report-5-benchmarks.zip)

We are also requesting public FuzzBench experiments to further validate the results across more benchmarks ([experiments request PR link](https://github.com/google/fuzzbench/pull/2090)). 

- [ ] Wait for the public Fuzzbench result
- [x] Probably find better names for new functions, and probably split a dedicated field from the `unused` field in `cmpfn_operands`
- [x] Rebase to latest dev branch