### PR TITLE
Don't clear the screen when printing stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ utils/plot_ui/afl-plot-ui
 vuln_prog
 argv_fuzz_demo
 argv_fuzz_persistent_demo
+.cache

--- a/include/debug.h
+++ b/include/debug.h
@@ -184,6 +184,8 @@
 #define cEOL "\x1b[0K"
 #define CURSOR_HIDE "\x1b[?25l"
 #define CURSOR_SHOW "\x1b[?25h"
+#define TERM_ALT_SCREEN "\x1b[?1049h"
+#define TERM_HOME_SCREEN "\x1b[?1049l"
 
 /************************
  * Debug & error macros *
@@ -424,4 +426,3 @@ static inline const char *colorfilter(const char *x) {
   } while (0)
 
 #endif                                                   /* ! _HAVE_DEBUG_H */
-

--- a/include/debug.h
+++ b/include/debug.h
@@ -316,7 +316,7 @@ static inline const char *colorfilter(const char *x) {
 #define FATAL(x...)                                                      \
   do {                                                                   \
                                                                          \
-    SAYF(bSTOP RESET_G1 CURSOR_SHOW    cRST cLRD                         \
+    SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD           \
          "\n[-] PROGRAM ABORT : " cRST x);                               \
     SAYF(cLRD "\n         Location : " cRST "%s(), %s:%u\n\n", __func__, \
          __FILE__, (u32)__LINE__);                                       \
@@ -329,7 +329,7 @@ static inline const char *colorfilter(const char *x) {
 #define ABORT(x...)                                                      \
   do {                                                                   \
                                                                          \
-    SAYF(bSTOP RESET_G1 CURSOR_SHOW    cRST cLRD                         \
+    SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD           \
          "\n[-] PROGRAM ABORT : " cRST x);                               \
     SAYF(cLRD "\n    Stop location : " cRST "%s(), %s:%u\n\n", __func__, \
          __FILE__, (u32)__LINE__);                                       \
@@ -344,7 +344,7 @@ static inline const char *colorfilter(const char *x) {
   do {                                                                 \
                                                                        \
     fflush(stdout);                                                    \
-    SAYF(bSTOP RESET_G1 CURSOR_SHOW    cRST cLRD                       \
+    SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD         \
          "\n[-]  SYSTEM ERROR : " cRST x);                             \
     SAYF(cLRD "\n    Stop location : " cRST "%s(), %s:%u\n", __func__, \
          __FILE__, (u32)__LINE__);                                     \

--- a/include/debug.h
+++ b/include/debug.h
@@ -317,7 +317,7 @@ static inline const char *colorfilter(const char *x) {
   do {                                                                   \
                                                                          \
     SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD           \
-         "\n[-] PROGRAM ABORT : " cRST x);                               \
+         "\n[-] PROGRAM ABORT : " cRST               x);                               \
     SAYF(cLRD "\n         Location : " cRST "%s(), %s:%u\n\n", __func__, \
          __FILE__, (u32)__LINE__);                                       \
     exit(1);                                                             \
@@ -330,7 +330,7 @@ static inline const char *colorfilter(const char *x) {
   do {                                                                   \
                                                                          \
     SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD           \
-         "\n[-] PROGRAM ABORT : " cRST x);                               \
+         "\n[-] PROGRAM ABORT : " cRST               x);                               \
     SAYF(cLRD "\n    Stop location : " cRST "%s(), %s:%u\n\n", __func__, \
          __FILE__, (u32)__LINE__);                                       \
     fflush(stdout);                                                      \
@@ -345,7 +345,7 @@ static inline const char *colorfilter(const char *x) {
                                                                        \
     fflush(stdout);                                                    \
     SAYF(bSTOP RESET_G1 CURSOR_SHOW TERM_HOME_SCREEN cRST cLRD         \
-         "\n[-]  SYSTEM ERROR : " cRST x);                             \
+         "\n[-]  SYSTEM ERROR : " cRST               x);                             \
     SAYF(cLRD "\n    Stop location : " cRST "%s(), %s:%u\n", __func__, \
          __FILE__, (u32)__LINE__);                                     \
     SAYF(cLRD "       OS message : " cRST "%s\n", strerror(errno));    \
@@ -426,3 +426,4 @@ static inline const char *colorfilter(const char *x) {
   } while (0)
 
 #endif                                                   /* ! _HAVE_DEBUG_H */
+

--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -1694,3 +1694,4 @@ std::string ModuleSanitizerCoverageAFL::getSectionEnd(
   return "__stop___" + Section;
 
 }
+

--- a/instrumentation/afl-llvm-dict2file.so.cc
+++ b/instrumentation/afl-llvm-dict2file.so.cc
@@ -717,3 +717,4 @@ PreservedAnalyses AFLdict2filePass::run(Module &M, ModuleAnalysisManager &MAM) {
   return PA;
 
 }
+

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -831,3 +831,4 @@ PreservedAnalyses AFLCoverage::run(Module &M, ModuleAnalysisManager &MAM) {
   return PreservedAnalyses();
 
 }
+

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -579,3 +579,4 @@ PreservedAnalyses CmpLogInstructions::run(Module                &M,
     return PreservedAnalyses();
 
 }
+

--- a/instrumentation/injection-pass.cc
+++ b/instrumentation/injection-pass.cc
@@ -250,3 +250,4 @@ PreservedAnalyses InjectionRoutines::run(Module                &M,
     return PreservedAnalyses();
 
 }
+

--- a/instrumentation/split-compares-pass.so.cc
+++ b/instrumentation/split-compares-pass.so.cc
@@ -1792,3 +1792,4 @@ PreservedAnalyses SplitComparesTransform::run(Module                &M,
     return PreservedAnalyses();
 
 }
+

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -682,6 +682,7 @@ static void check_term_size(afl_state_t *afl) {
    execve() calls, plus in several other circumstances. */
 
 void show_stats(afl_state_t *afl) {
+
   SAYF(TERM_ALT_SCREEN);
 
   if (afl->pizza_is_served) {
@@ -695,6 +696,7 @@ void show_stats(afl_state_t *afl) {
   }
 
   SAYF(TERM_HOME_SCREEN);
+
 }
 
 void show_stats_normal(afl_state_t *afl) {
@@ -2583,3 +2585,4 @@ inline void update_cmplog_time(afl_state_t *afl, u64 *time) {
   *time = cur;
 
 }
+

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -682,6 +682,7 @@ static void check_term_size(afl_state_t *afl) {
    execve() calls, plus in several other circumstances. */
 
 void show_stats(afl_state_t *afl) {
+  SAYF(TERM_ALT_SCREEN);
 
   if (afl->pizza_is_served) {
 
@@ -693,6 +694,7 @@ void show_stats(afl_state_t *afl) {
 
   }
 
+  SAYF(TERM_HOME_SCREEN);
 }
 
 void show_stats_normal(afl_state_t *afl) {
@@ -2581,4 +2583,3 @@ inline void update_cmplog_time(afl_state_t *afl, u64 *time) {
   *time = cur;
 
 }
-

--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -65,9 +65,10 @@ extern "C" {
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)
-  #define SECTION_RODATA                                               \
-    __attribute__((used, retain)) __attribute__((section("__RODATA,__" \
-                                                         "rodata")))
+  #define SECTION_RODATA                          \
+    __attribute__((used, retain)) __attribute__(( \
+        section("__RODATA,__"                     \
+                "rodata")))
 #else
   #define SECTION_RODATA \
     __attribute__((used, retain)) __attribute__((section(".rodata")))


### PR DESCRIPTION
Closes: https://github.com/AFLplusplus/AFLplusplus/issues/2498

The way most applications (btop/htop etc) do this stats-type screen is switch to an alternate screen buffer on entry, and switch back on exit. Doing the same seems to work pretty well.

That being said it might be smarter to do this switch right after "[+] All set and ready to roll!" and return back on exit, instead of swapping buffers on each display. If theres a nice "entrypoint" and "exitpoint"-type place to put these swaps, let me know.