### PR TITLE
FIx isssue AFLplusplus#2503:Incorrect guard offset calculation for __afl_coverage_interesting calls and comparison instructions in FunctionGuardArray.

### DIFF
--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -1017,7 +1017,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
         Value *GuardPtr = IRB.CreateIntToPtr(
             IRB.CreateAdd(
                 IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
-                ConstantInt::get(IntptrTy, (++special + AllBlocks.size()) * 4)),
+                ConstantInt::get(IntptrTy, (special++ + AllBlocks.size() - skip_blocks ) * 4)),
             Int32PtrTy);
 
         LoadInst *Idx = IRB.CreateLoad(IRB.getInt32Ty(), GuardPtr);
@@ -1117,12 +1117,12 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
           auto GuardPtr1 = IRB.CreateInBoundsGEP(
               FunctionGuardArray->getValueType(), FunctionGuardArray,
               {IRB.getInt64(0),
-               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size()))});
+               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks))});
 
           auto GuardPtr2 = IRB.CreateInBoundsGEP(
               FunctionGuardArray->getValueType(), FunctionGuardArray,
               {IRB.getInt64(0),
-               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size()))});
+               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks))});
 
           result = IRB.CreateSelect(res, GuardPtr1, GuardPtr2);
           skip_select = 1;
@@ -1156,12 +1156,12 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
           auto GuardPtr1 = IRB.CreateInBoundsGEP(
               FunctionGuardArray->getValueType(), FunctionGuardArray,
               {IRB.getInt64(0),
-               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size()))});
+               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks))});
 
           auto GuardPtr2 = IRB.CreateInBoundsGEP(
               FunctionGuardArray->getValueType(), FunctionGuardArray,
               {IRB.getInt64(0),
-               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size()))});
+               IRB.getInt32((cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks))});
 
           result = IRB.CreateSelect(res, GuardPtr1, GuardPtr2);
           skip_select = 1;
@@ -1224,7 +1224,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                     IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                     ConstantInt::get(
                         IntptrTy,
-                        (cnt_cov + local_selects++ + AllBlocks.size()) * 4)),
+                        (cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks) * 4)),
                 Int32PtrTy);
 
             auto GuardPtr2 = IRB.CreateIntToPtr(
@@ -1232,7 +1232,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                     IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                     ConstantInt::get(
                         IntptrTy,
-                        (cnt_cov + local_selects++ + AllBlocks.size()) * 4)),
+                        (cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks) * 4)),
                 Int32PtrTy);
 
             result = IRB.CreateSelect(condition, GuardPtr1, GuardPtr2);
@@ -1260,7 +1260,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                     IRB.CreateAdd(
                         IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                         ConstantInt::get(IntptrTy, (cnt_cov + local_selects++ +
-                                                    AllBlocks.size()) *
+                                                    AllBlocks.size() - skip_blocks) *
                                                        4)),
                     Int32PtrTy);
                 x = IRB.CreateInsertElement(GuardPtr1, val1, (uint64_t)0);
@@ -1269,7 +1269,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                     IRB.CreateAdd(
                         IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                         ConstantInt::get(IntptrTy, (cnt_cov + local_selects++ +
-                                                    AllBlocks.size()) *
+                                                    AllBlocks.size() - skip_blocks) *
                                                        4)),
                     Int32PtrTy);
                 y = IRB.CreateInsertElement(GuardPtr2, val2, (uint64_t)0);
@@ -1281,7 +1281,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                           IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                           ConstantInt::get(
                               IntptrTy,
-                              (cnt_cov + local_selects++ + AllBlocks.size()) *
+                              (cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks) *
                                   4)),
                       Int32PtrTy);
                   x = IRB.CreateInsertElement(x, val1, i);
@@ -1291,7 +1291,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
                           IRB.CreatePointerCast(FunctionGuardArray, IntptrTy),
                           ConstantInt::get(
                               IntptrTy,
-                              (cnt_cov + local_selects++ + AllBlocks.size()) *
+                              (cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks) *
                                   4)),
                       Int32PtrTy);
                   y = IRB.CreateInsertElement(y, val2, i);


### PR DESCRIPTION
I have submitted the issue https://bgithub.xyz/AFLplusplus/AFLplusplus/issues/2503 using my partner's account 'bigchengz'.
FIx isssue https://bgithub.xyz/AFLplusplus/AFLplusplus/issues/2503:Incorrect guard offset calculation for __afl_coverage_interesting calls and comparison instructions in FunctionGuardArray.
Description:
I've identified a buffer layout issue in the PCGUARD instrumentation mode, The FunctionGuardArray size calculation is correct but the offset calculations for special instrumentation guards is incorrect, which mabe leads to a buffer overflow.
Problem Analysis:
In instrumentation/SanitizerCoveragePCGUARD.so.cc:969-976, Since cnt_hidden_sel_inc is always 0 now，the FunctionGuardArray size is correctly calculated as:

AllBlocks.size() + (first + cnt_cov + cnt_sel_inc - skip_blocks)
However, the offset calculations for special calls and comparison instructions don't account for skip_blocks .

Expected Layout:

[0 to AllBlocks.size() - skip_blocks - 1] -> Used basic blocks
[AllBlocks.size() - skip_blocks to AllBlocks.size() - skip_blocks + cnt_cov - 1] -> Special calls
[AllBlocks.size() - skip_blocks + cnt_cov to ...] -> Comparison instructions
Current Layout:

[0 to AllBlocks.size() - skip_blocks - 1] -> Used basic blocks
[AllBlocks.size() - skip_blocks to AllBlocks.size() - 1] -> Unused space (wasted)
[AllBlocks.size() + 1 to AllBlocks.size() + cnt_cov] -> Special calls
[AllBlocks.size() + cnt_cov to ...] -> Comparison instructions
Specific Issues:

Special call (_afl_coverage_interesting ) offset calculation in instrumentation/SanitizerCoveragePCGUARD.so.cc:1017-1021:
Current: (++special + AllBlocks.size()) * 4
Should be: (special++ + AllBlocks.size() - skip_blocks) * 4
Comparison instructions offset calculation in instrumentation/SanitizerCoveragePCGUARD.so.cc:1117-1120:
Current: (cnt_cov + local_selects++ + AllBlocks.size())
Should be: (cnt_cov + local_selects++ + AllBlocks.size() - skip_blocks)