### PR TITLE
Fix null pointer dereference in check_sync_fuzzers

### DIFF
--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -813,9 +813,9 @@ void check_sync_fuzzers(afl_state_t *afl) {
 
       }
 
-    }
+      closedir(dir);
 
-    closedir(dir);
+    }
 
     if (!have_main) {
 


### PR DESCRIPTION
**Describe**

This patch fixes a potential null pointer dereference in the `check_sync_fuzzers()` function by moving the `closedir(dir)` call inside the `if (dir)` block.

**Expected Behavior**

`closedir(dir)` should only be called when `dir` is a valid directory pointer returned by `opendir()`.  
This ensures the program avoids undefined behavior when `opendir()` fails.

**Actual Behavior**

Previously, `closedir(dir)` was called unconditionally, even when `dir` might be `NULL` due to `opendir()` failure.  
Calling `closedir(NULL)` results in undefined behavior and may cause a segmentation fault.

This change prevents undefined behavior and improves stability in edge cases.

Thanks for reviewing.