### PR TITLE
Fix file descriptor leak in get_binary_hash

### DIFF
--- a/src/afl-performance.c
+++ b/src/afl-performance.c
@@ -105,7 +105,7 @@ u64 get_binary_hash(u8 *fn) {
   struct stat st;
   if (fstat(fd, &st) < 0) { PFATAL("Unable to fstat '%s'", fn); }
   u32 f_len = st.st_size;
-  if (!f_len) { return 0; }
+  if (!f_len) { close(fd); return 0;}
   u8 *f_data = mmap(0, f_len, PROT_READ, MAP_PRIVATE, fd, 0);
   if (f_data == MAP_FAILED) { PFATAL("Unable to mmap file '%s'", fn); }
   close(fd);


### PR DESCRIPTION
**Describe**

This patch fixes a file descriptor leak in the `get_binary_hash()` function.  
When the target file is empty (`st.st_size == 0`), the function previously returned early without closing the file descriptor, resulting in a potential resource leak.  
The fix adds a `close(fd)` call before returning in that case.

**Expected Behavior**

When the input file is empty, the function should close the file descriptor before returning.  
This ensures no file descriptor leak occurs regardless of file contents.

**Actual Behavior**

If the input file is empty, the function returns immediately without closing the file descriptor.  
When invoked repeatedly, this can lead to file descriptor exhaustion and undefined behavior.

Prevents a file descriptor leak by ensuring the descriptor is closed when handling empty files.  
Thanks for reviewing.