### PR TITLE
Fix incorrect pointer arithmetic in afl_resize_map_buffers()

### DIFF
--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -165,8 +165,7 @@ void afl_resize_map_buffers(afl_state_t *afl, u32 old_size, u32 new_size) {
     u32 size_diff = new_size - old_size;
 
     memset(afl->var_bytes + old_size, 0, size_diff);
-    memset(afl->top_rated + old_size * sizeof(void *), 0,
-           size_diff * sizeof(void *));
+    memset(afl->top_rated + old_size, 0, size_diff * sizeof(void *));
     memset(afl->clean_trace + old_size, 0, size_diff);
     memset(afl->clean_trace_custom + old_size, 0, size_diff);
     memset(afl->first_trace + old_size, 0, size_diff);

--- a/src/afl-performance.c
+++ b/src/afl-performance.c
@@ -105,7 +105,13 @@ u64 get_binary_hash(u8 *fn) {
   struct stat st;
   if (fstat(fd, &st) < 0) { PFATAL("Unable to fstat '%s'", fn); }
   u32 f_len = st.st_size;
-  if (!f_len) { close(fd); return 0;}
+  if (!f_len) {
+
+    close(fd);
+    return 0;
+
+  }
+
   u8 *f_data = mmap(0, f_len, PROT_READ, MAP_PRIVATE, fd, 0);
   if (f_data == MAP_FAILED) { PFATAL("Unable to mmap file '%s'", fn); }
   close(fd);


### PR DESCRIPTION
### Description
When running the fuzzing on the PostgreSQL fork, AFL crashes with a segmentation fault. The log shows:
```
[*] Creating hard links for all input files...
[+] Loaded a total of 116 seeds.
[*] Spinning up the fork server...
Segmentation fault
Segmentation fault
Segmentation fault
[+] All right - new fork server model v1 is up.
[*] Target map size: 907729
[!] WARNING: More than 256 tokens - will use them probabilistically.
[*] Loaded 412 autodictionary entries
[+] Re-initializing maps to 907776 bytes
Segmentation fault
```
Bisect identified commit 8090c82c6399cb7ad98abb84eca822f885544fbb as the first bad commit. This code was later refactored in commit 2e7f191f3bfcdc36bd45eb5cacaa16f06e30401c.

### Root Cause  
Pointer arithmetic already includes `sizeof(void*)`, so `+ old_size * sizeof(void*)` overflows the buffer.

### Fix  
Remove the redundant `sizeof(void*)` in the offset:
```c
memset(afl->top_rated + old_size, 0, size_diff * sizeof(void *));
```
### Result
After applying the patch, everything launches and works correctly.