### PR TITLE
GNUmakefile.llvm: Turn the test_build target into a NOP if AFL_NO_TEST_BUILD is set

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -554,6 +554,9 @@ document:
 
 .PHONY: test_build
 test_build: $(PROGS)
+ifdef AFL_NO_TEST_BUILD
+	@echo "[*] Not testing the CC wrapper and instrumentation output (AFL_NO_TEST_BUILD set)."
+else
 	@echo "[*] Testing the CC wrapper and instrumentation output..."
 	unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_PATH=. AFL_LLVM_LAF_ALL=1 ./afl-cc $(CFLAGS) $(CPPFLAGS) ./test-instr.c -o test-instr $(LDFLAGS)
 ifdef IS_IOS
@@ -564,6 +567,7 @@ endif
 	@rm -f test-instr
 	@cmp -s .test-instr0 .test-instr1; DR="$$?"; rm -f .test-instr0 .test-instr1; if [ "$$DR" = "0" ]; then echo; echo "Oops, the instrumentation does not seem to be behaving correctly!"; echo; echo "Please post to https://github.com/AFLplusplus/AFLplusplus/issues to troubleshoot the issue."; echo; exit 1; fi
 	@echo "[+] All right, the instrumentation seems to be working!"
+endif
 
 .PHONY: all_done
 all_done: test_build


### PR DESCRIPTION
The testing fails in FreeBSD jails if allow.sysvipc isn't set to 1 (default):

    [*] Testing the CC wrapper and instrumentation output...
    unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_PATH=. AFL_LLVM_LAF_ALL=1 ./afl-cc -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -g -Wno-pointer-sign -Wno-variadic-macros -Wall -Wextra -Wno-pointer-arith -fPIC -I include/ -DAFL_PATH=\"/usr/local/afl++-llvm/lib/afl\" -DBIN_PATH=\"/usr/local/afl++-llvm/bin\" -DDOC_PATH=\"/usr/local/afl++-llvm/share/doc/afl\" -I /usr/local/include/ -pthread -Wall -g -Wno-cast-qual -Wno-variadic-macros -Wno-pointer-sign -I ./include/ -I ./instrumentation/ -DAFL_PATH=\"/usr/local/afl++-llvm/lib/afl\" -DBIN_PATH=\"/usr/local/afl++-llvm/bin\" -DLLVM_BINDIR=\"/usr/local/llvm19/bin\" -DVERSION=\"++4.33c\" -DLLVM_LIBDIR=\"/usr/local/llvm19/lib\" -DLLVM_VERSION=\"19.1.7\" -DAFL_CLANG_FLTO=\"-flto=full\" -DAFL_REAL_LD=\"/usr/local/llvm19/bin/ld.lld\" -DAFL_CLANG_LDPATH=\"1\" -DAFL_CLANG_FUSELD=\"1\" -DCLANG_BIN=\"clang19\" -DCLANGPP_BIN=\"clang++19\" -DUSE_BINDIR=0 -Wno-unused-function -Wno-deprecated  ./test-instr.c -o test-instr  -fstack-protector-strong  -L /usr/local/lib/ -lpthread -lm -lz
    ASAN_OPTIONS=detect_leaks=0 ./afl-showmap -m none -q -o .test-instr0 ./test-instr < /dev/null

    [-]  SYSTEM ERROR : shmget() failed, try running afl-system-config
        Stop location : afl_shm_init(), src/afl-sharedmem.c:303
           OS message : Function not implemented
    gmake[1]: *** [GNUmakefile.llvm:559: test_build] Error 1

Setting AFL_NO_TEST_BUILD=1 allows to build afl++ packages in poudriere without having to change the jail settings.

Without setting AFL_NO_TEST_BUILD the generated packages are incomplete:

    fk@test-vm ~/git/privoxy $/usr/local/afl++-llvm/bin/afl-cc --version

    [-] PROGRAM ABORT : Unable to find 'afl-compiler-rt.o'. Please set the AFL_PATH environment variable.
             Location : find_built_deps(), src/afl-cc.c:594