### PR TITLE
Fix the build on FreeBSD 13.5

### DIFF
--- a/include/sharedmem.h
+++ b/include/sharedmem.h
@@ -28,6 +28,8 @@
 #ifndef __AFL_SHAREDMEM_H
 #define __AFL_SHAREDMEM_H
 
+#include <unistd.h>
+
 #include "types.h"
 
 typedef struct sharedmem {


### PR DESCRIPTION
As it turns out b1e46370927a wasn't sufficient to fix the build on FreeBSD 13.5 which still failed with:

    [*] Compiling AFL++ for OS FreeBSD on ARCH amd64
    [+] ZLIB detected
    [!] Note: skipping x86 compilation checks (AFL_NO_X86 set).
    [+] shmat seems to be working.
    [+] Python 3.11.13 support seems to be working.
    [+] Everything seems to be working, ready to compile. (clang version 19.1.7)
    clang19 -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -g -Wno-pointer-sign -Wno-variadic-macros -Wall -Wextra -Wno-pointer-arith -fPIC -I include/ -DAFL_PATH=\"/usr/local/afl++-llvm/lib/afl\" -DBIN_PATH=\"/usr/local/afl++-llvm/bin\" -DDOC_PATH=\"/usr/local/afl++-llvm/share/doc/afl\" -I /usr/local/include/ -pthread -flto=full -DHAVE_ZLIB -c src/afl-common.c -o src/afl-common.o
    clang19 -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -g -Wno-pointer-sign -Wno-variadic-macros -Wall -Wextra -Wno-pointer-arith -fPIC -I include/ -DAFL_PATH=\"/usr/local/afl++-llvm/lib/afl\" -DBIN_PATH=\"/usr/local/afl++-llvm/bin\" -DDOC_PATH=\"/usr/local/afl++-llvm/share/doc/afl\" -I /usr/local/include/ -pthread -flto=full -DHAVE_ZLIB -c src/afl-sharedmem.c -o src/afl-sharedmem.o
    In file included from src/afl-sharedmem.c:37:
    include/sharedmem.h:61:19: error: unknown type name 'mode_t'; did you mean '__mode_t'?
       61 |                   mode_t mode, int gid);
          |                   ^~~~~~
          |                   __mode_t
    /usr/include/sys/_types.h:49:20: note: '__mode_t' declared here
       49 | typedef __uint16_t      __mode_t;       /* permissions */
          |                         ^
    1 error generated.
    gmake: *** [GNUmakefile:481: src/afl-sharedmem.o] Error 1
    gmake: *** Waiting for unfinished jobs....