### PR TITLE
Disable recording afl-cc commmand line into binary

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2698,6 +2698,15 @@ void add_misc_params(aflcc_state_t *aflcc) {
 
   }
 
+#if LLVM_MAJOR == 18
+  if (aflcc->compiler_mode != GCC && aflcc->compiler_mode != GCC_PLUGIN) {
+
+    insert_param(aflcc, "-fno-record-command-line");
+    insert_param(aflcc, "-gno-record-command-line");
+
+  }
+#endif
+
 }
 
 /*


### PR DESCRIPTION
For some reason, `afl-clang-fast` records compiler's command line in output binary (.debug_line section) when I use LLVM-18. It wasn't actually a problem until recent v4.33c update, where persistent mode signatures (`##SIG_AFL_PERSISTENT##` and `##SIG_AFL_DEFER_FORKSRV##`) began to match without NULL at the end. This way `afl-fuzz` recognizes debug-line as a valid persistent signature, and it leads to a failure during application forkserver handshake.

The solution could be is to pass `-fno-record-command-line -gno-record-command-line` options to a clang compiler. This problem I could reproduce only with LLVM-18 and on Ubuntu 20.04/22.04. Everything works fine with Ubuntu 24.04 and any other version of LLVM (I tried 14-20).