### PR TITLE
Fix __sanitizer_cov_trace_pc_guard implementation

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -67,7 +67,7 @@ __attribute__((weak)) void __sanitizer_symbolize_pc(void *, const char *fmt,
 #include <sys/wait.h>
 #include <sys/types.h>
 
-#if !__GNUC__
+#ifdef __llvm__
   #include "llvm/Config/llvm-config.h"
 #endif
 


### PR DESCRIPTION
`__GNUC__` is set for clang, which was causing `__sanitizer_cov_trace_pc_guard` to use the wrong implementation.

 `#if (LLVM_VERSION_MAJOR < 9)` was true because `llvm-config.h` was never included.