### PR TITLE
Fix stats calculation for custom trimming

### DIFF
--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -462,7 +462,6 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf,
   u8 val_buf[STRINGIFY_VAL_SIZE_MAX];
 
   afl->stage_name = afl->stage_name_buf;
-  afl->bytes_trim_in += q->len;
 
   /* Initialize trimming in the custom mutator */
   afl->stage_cur = 0;
@@ -655,7 +654,6 @@ u8 trim_case_custom(afl_state_t *afl, struct queue_entry *q, u8 *in_buf,
 abort_trimming:
 
   if (out_buf) afl_free(out_buf);
-  afl->bytes_trim_out += q->len;
   return fault;
 
 }

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -1126,6 +1126,8 @@ u8 trim_case(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
   u8  needs_write = 0, fault = 0;
   u32 orig_len = q->len;
   u64 trim_start_us = get_cur_time_us();
+  afl->bytes_trim_in += orig_len;
+
   /* Custom mutator trimmer */
   if (afl->custom_mutators_count) {
 
@@ -1176,7 +1178,6 @@ u8 trim_case(afl_state_t *afl, struct queue_entry *q, u8 *in_buf) {
   }
 
   afl->stage_name = afl->stage_name_buf;
-  afl->bytes_trim_in += q->len;
 
   /* Select initial chunk len, starting with large steps. */
 


### PR DESCRIPTION
Previously, during custom trimming the input size was added to `bytes_trim_in` only once in `trim_case_custom`, while `bytes_trim_out` was updated twice (first in `trim_case_custom`, then again in `trim_case`).
This patch ensures that only `trim_case` updates these fields (for both default and custom trimming cases), since it has all the necessary information, and avoids further inconsistencies.