### PR TITLE
Update afl-fuzz-ijon.c. Use cur_state file to save the maximum value

### DIFF
--- a/docs/IJON.md
+++ b/docs/IJON.md
@@ -142,6 +142,21 @@ make clean
 make LLVM_CONFIG=llvm-config-18 source-only
 ```
 
+### IJON mode debug build for afl-fuzz
+
+Note that this does not affect any ijon functionality, it just creates an extra file.
+
+```bash
+make clean
+CFLAGS="-DDUMP_IJON_STATE" make afl-fuzz
+```
+
+This will output non-zero values to the default/ijon_max/cur_state file whenever 
+the ijon max bitmap is updated. By looking at this file, you can see the maximum values
+of your max/min annotations so far, which can help you understand the current fuzzing progress. 
+
+For example, you can check Mario's current maximum y-axis position.
+
 ### Compiling Target Programs
 
 When using IJON instrumentation in AFL++, it is required to invoke `__AFL_INIT()` at the beginning of your target program’s `main()` function:

--- a/src/afl-fuzz-ijon.c
+++ b/src/afl-fuzz-ijon.c
@@ -446,6 +446,39 @@ void ijon_update_max_dynamic(ijon_min_state          *self,
     }
 
   }
+#ifdef DUMP_IJON_STATE
 
+  static size_t last_num = 0;
+  if (last_num == self->num_updates)
+    return;
+  last_num = self->num_updates;
+
+  u64 tmp_buf64[MAP_SIZE_IJON_ENTRIES];
+  char *file_path = (char*)tmp_buf64;
+
+  int n = snprintf(file_path, sizeof(tmp_buf64), "%s/cur_state", self->max_dir);
+  if (n < 0 || (size_t)n >= sizeof(tmp_buf64)) {
+
+    WARNF("state path too long or snprintf error");
+    return;
+
+  }
+
+  int fd = open(file_path, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  if (fd < 0) {
+
+    WARNF("Failed to open IJON max state file %s: %s", file_path, strerror(errno));
+    return;
+
+  }
+
+  int cnt = 0;
+  for (int i = 0; i < MAP_SIZE_IJON_ENTRIES; i++)
+    if (self->max_map[i])
+      tmp_buf64[cnt++] = self->max_map[i];
+
+  write(fd, tmp_buf64, cnt * sizeof(u64));
+  close(fd);
+
+#endif
 }
-


### PR DESCRIPTION
When using the ijon-max method, a file cur_state containing historical maximum values ​​is also saved in max_dir, which helps humans understand the fuzz progress by viewing the file.