### PR TITLE
Fix handling of skipped custom mutations

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -1942,14 +1942,14 @@ custom_mutator_stage:
               el->afl_custom_fuzz(el->data, out_buf, len, &mutated_buf, new_buf,
                                   target_len, max_seed_size);
 
-          if (unlikely(!mutated_buf)) {
-
-            // FATAL("Error in custom_fuzz. Size returned: %zu", mutated_size);
-            break;
-
-          }
-
           if (mutated_size > 0) {
+
+            if (unlikely(!mutated_buf)) {
+
+              // FATAL("Error in custom_fuzz. Size returned: %zu", mutated_size);
+              break;
+
+            }
 
             if (common_fuzz_stuff(afl, mutated_buf, (u32)mutated_size)) {
 


### PR DESCRIPTION
According to the documentation, when `afl_custom_fuzz` returns 0, the corresponding mutation result should be skipped. The implementation correctly runs the mutant only if the return value is greater than 0. However, one step earlier it also checks whether `mutation_buffer` is null, and if so, aborts fuzzing of the entire current test case instead of skipping only the current mutant.

Since `mutation_buffer` can legitimately be null when the custom mutator signals that the mutation should be discarded, the buffer check should only be performed when the mutant is intended to be kept. The commit fixes this.