### PR TITLE
Fix `build_qemu_support.sh` fallback clone using wrong qemuafl revision

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -35,6 +35,7 @@ sudo apt-get install -y wget curl # for Frida mode
 sudo apt-get install -y python3-pip # for Unicorn mode
 git clone https://github.com/AFLplusplus/AFLplusplus
 cd AFLplusplus
+git submodule update --init
 make distrib
 sudo make install
 ```

--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -81,7 +81,7 @@ else
     CNT=1
     while [ '!' -d qemuafl/.git -a "$CNT" -lt 4 ]; do
       echo "Trying to clone qemuafl (attempt $CNT/3)"
-      git clone --depth 1 https://github.com/AFLplusplus/qemuafl
+      git clone https://github.com/AFLplusplus/qemuafl
       CNT=`expr "$CNT" + 1`
     done
   }
@@ -97,7 +97,10 @@ else
   echo "[*] Checking out $QEMUAFL_VERSION"
   sh -c 'git stash' 1>/dev/null 2>/dev/null
   git pull
-  git checkout "$QEMUAFL_VERSION" || echo Warning: could not check out to commit $QEMUAFL_VERSION
+  git checkout "$QEMUAFL_VERSION" || {
+    echo "[-] Failed to checkout to commit $QEMUAFL_VERSION"
+    exit 1
+  }
 fi
 
 echo "[*] Making sure imported headers matches"


### PR DESCRIPTION
## PR description
If a user clones AFL++ but does not run `git submodule update --init` (or when building via **Docker**, where `.dockerignore` excludes `.git` so the repo appears non-git), `build_qemu_support.sh` falls back to cloning `qemuafl` manually:
```bash
git clone --depth 1 https://github.com/AFLplusplus/qemuafl
git checkout "$QEMUAFL_VERSION" || echo Warning: could not check out to commit $QEMUAFL_VERSION
```

Because of the shallow `--depth 1` clone, the checkout to the correct submodule commit often fails silently.
**The script then continues using the latest `qemuafl:master` instead of the exact version AFL++ expects.**

For a long time this went unnoticed — building against the wrong `qemuafl` version **still succeeded by coincidence**, since `master` remained compatible with older AFL++ code.
However, a recent change in `qemuafl` (https://github.com/AFLplusplus/qemuafl/pull/74) removed the `meson` submodule, and now old AFL++ versions that relied on it fail to build, exposing this underlying issue.

## Problem summary
- When users skip `git submodule update --init`, the script’s fallback path clones the wrong qemuafl revision.
- `git checkout` failure is non-fatal, silently leaving the repo on `master`.
- `INSTALL.md` doesn’t mention submodule initialization, so users can easily hit this.
- Although this used to "work," those builds were **technically incorrect** (built against the wrong qemuafl).

## Fix summary
- Remove `--depth 1` of  git clone in `build_qemu_support.sh`.
- Make checkout failure fatal (`exit 1`).
- Update `INSTALL.md` to mention running `git submodule update --init` before `make distrib`.