### PR TITLE
Install Meson in CI for QEMU mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: debug
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
-        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools meson python3-pip gcc-12-plugin-dev
       - name: install llvm-tools
         run: sudo apt install -y clang-${{ matrix.version }} llvm-${{ matrix.version }} llvm-${{ matrix.version }}-dev lld-${{ matrix.version }}
       - name: install clang-rt (for llvm 15)
@@ -59,7 +59,7 @@ jobs:
       - name: debug
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
-        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+        run: sudo apt-get install -y -m -f build-essential git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev findutils libcmocka-dev python3-dev python3-setuptools meson python3-pip gcc-12-plugin-dev
       - name: install llvm-tools (20)
         if: matrix.version >= '20'
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: debug
         run: apt-cache search plugin-dev | grep gcc-; echo; apt-cache search clang-format- | grep clang-format-
       - name: install packages
-        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0 libglib2.0-dev  clang-15 llvm-15-dev libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build python3-pip gcc-12-plugin-dev
+        run: sudo apt-get install -y -m -f build-essential gcc-12 g++-12 git libtool libtool-bin automake flex bison libglib2.0 libglib2.0-dev  clang-15 llvm-15-dev libc++-dev findutils libcmocka-dev python3-dev python3-setuptools meson python3-pip gcc-12-plugin-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
       - name: install gcc plugin


### PR DESCRIPTION
Follow up on https://github.com/AFLplusplus/AFLplusplus/pull/2571, but instead of keeping `ninja-build` as a documentation hint, relying on the fact that Debian-based distributions have Meson depend on Ninja.