### PR TITLE
Ensure custom mutators are made aware when a sync'd testcase is added to the queue

### DIFF
--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -745,9 +745,13 @@ void add_to_queue(afl_state_t *afl, u8 *fname, u32 len, u8 passed_det) {
   if (afl->custom_mutators_count) {
 
     /* At the initialization stage, queue_cur is NULL */
-    if (afl->queue_cur && !afl->syncing_party) {
+    if (afl->queue_cur || afl->syncing_party) {
 
-      run_afl_custom_queue_new_entry(afl, q, fname, afl->queue_cur->fname);
+      u8 *fname_orig = NULL;
+
+      if (afl->queue_cur) { fname_orig = afl->queue_cur->fname; }
+
+      run_afl_custom_queue_new_entry(afl, q, fname, fname_orig);
 
     }
 


### PR DESCRIPTION
This change makes custom mutators aware of any sync'd new queue items by calling `run_afl_custom_queue_new_entry()`.
 `filename_orig_queue` is set to `NULL` so the custom mutator can appropriately handle there not being a parent testcase.

This effectively reverts some changes made in https://github.com/AFLplusplus/AFLplusplus/pull/1034/commits/d354ec2586a3a31c87a8b95433c2886f04c44a03#diff-6014111dd595b4fe80b8a3217b59af6cdb9f6bb24b22943433cade54d450f114

As discussed https://discord.com/channels/736989425770168422/980700642983182366/1388169999994322996

I have tested this works with my own custom mutator, which was previously crashing when asked to mutate a testcase it was unaware of.

I have also searched the codebase for included custom mutator `afl_custom_queue_new_entry()` implementations and have confirmed they all either ignore the parameter or already handle it being `NULL`. However, I haven't tested them.