### PR TITLE
Chagne switch case for cast_size

### DIFF
--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -392,13 +392,9 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
       }
 
       // do we need to cast?
-#if INTPTR_MAX == INT32_MAX
-      /* 32-bit code */
       switch (max_size) {
-
-        case 8:
-          break;
-        case 9 ... 16:
+         
+        case 16:
           cast_size = 16;
           break;
         case 17 ... 32:
@@ -406,39 +402,10 @@ bool CmpLogInstructions::hookInstrs(Module &M, DomTreeCallback DTCallback) {
           break;
         case 33 ... 64:
           cast_size = 64;
-          break;
-        case 80:
-          break;
-        case 128:
-          cast_size = max_size;
           break;
         default:
           cast_size = 128;
-          break;
-
-      }
-
-#else
-      /* original code */
-      switch (max_size) {
-
-        case 8:
-          break;
-        case 9 ... 16:
-          cast_size = 16;
-          break;
-        case 17 ... 32:
-          cast_size = 32;
-          break;
-        case 33 ... 64:
-          cast_size = 64;
-          break;
-        case 80:
-          break;
-        case 128:
-          cast_size = max_size;
-          break;
-
+         
       }
 
 #endif


### PR DESCRIPTION
Hi,
In issues https://github.com/AFLplusplus/AFLplusplus/issues/2536,  [koltiradw](https://github.com/koltiradw) proposed changes that fixed problems with cmplog-instructions. This is a good change and really fixes what needs to be fixed.

But commit https://github.com/AFLplusplus/AFLplusplus/commit/95eade8f9a50e6bace43bfcd6280e07ab41ed67c is incorrect and breaks everything (After this, our project stopped building) because:
In this code https://github.com/AFLplusplus/AFLplusplus/blob/dev/instrumentation/cmplog-instructions-pass.cc#L423
```c
      switch (max_size) {

        case 8:
          break;
        case 9 ... 16:
          cast_size = 16;
          break;
        case 17 ... 32:
          cast_size = 32;
          break;
        case 33 ... 64:
          cast_size = 64;
          break;
        case 80:
          break;
        case 128:
          cast_size = max_size;
          break;

      }
```
* For `case 80`, `break;` appeared after which `cast_size ` variable will remain with the value "0";
* The switch statement "default" is missing.


For this reason, if I received a variable `max_size` that had a value in the range of 65-128, the variable `cast_size` had a value of 0.
I got a warning then an error when building: `warning: Failed to read symbol table from LLVM bitcode: LLVM error: Bitwidth for integer type out of range`: (https://github.com/llvm/llvm-project/blob/8aa7d823b0cba96e54d4d73539df4b82c3b401b9/llvm/lib/Bitcode/Reader/BitcodeReader.cpp#L2616)

when i run `llvm-bcanalyzer -dump` on my bitcode file (.bc), i get type table with an integer type that is zero bits long
```
8:  <TYPE_BLOCK_ID NumWords=2752 BlockCodeSize=4>
11:    <INTEGER op0=8/>
93:    <INTEGER op0=32/>
103:    <INTEGER op0=64/>
218:    <INTEGER op0=16/>
327:    <INTEGER op0=1/>
354:    <INTEGER op0=40/>
419:    <INTEGER op0=48/>
546:    <INTEGER op0=56/>
652:    <INTEGER op0=128/>
860:    <INTEGER op0=24/>
1049:    <INTEGER op0=6/>
1357:    <INTEGER op0=80/>
1358:    <INTEGER op0=0/>  <<<<---------------------------
1531:    <INTEGER op0=96/>
1532:  </TYPE_BLOCK_ID>
```

without this plugin i get this table:
```
8:  <TYPE_BLOCK_ID NumWords=2743 BlockCodeSize=4>
11:    <INTEGER op0=8/>
93:    <INTEGER op0=32/>
103:    <INTEGER op0=64/>
218:    <INTEGER op0=16/>
327:    <INTEGER op0=1/>
354:    <INTEGER op0=40/>
419:    <INTEGER op0=48/>
546:    <INTEGER op0=56/>
652:    <INTEGER op0=128/>
860:    <INTEGER op0=24/>
1049:    <INTEGER op0=6/>
1352:    <INTEGER op0=80/>
1525:    <INTEGER op0=96/>
1526:  </TYPE_BLOCK_ID>
```

And I don't understand why it's necessary to add preprocessor directive `#if INTPTR_MAX == INT32_MAX`