### PR TITLE
Fixes `error: unknown type name 'vrange'` in `tree-ssanames.h`

### DIFF
--- a/instrumentation/afl-gcc-cmplog-pass.so.cc
+++ b/instrumentation/afl-gcc-cmplog-pass.so.cc
@@ -243,8 +243,8 @@ struct afl_cmplog_pass : afl_base_pass {
 
       tree t = build_nonstandard_integer_type(sz, 1);
 
-      tree   s = make_ssa_name(t);
-      gimple g = gimple_build_assign(s, VIEW_CONVERT_EXPR,
+      tree s = make_ssa_name(t);
+      auto g = gimple_build_assign(s, VIEW_CONVERT_EXPR,
                                      build1(VIEW_CONVERT_EXPR, t, lhs));
       lhs = s;
       gsi_insert_before(&gsi, g, GSI_SAME_STMT);
@@ -263,8 +263,8 @@ struct afl_cmplog_pass : afl_base_pass {
     lhs = fold_convert_loc(UNKNOWN_LOCATION, t, lhs);
     if (!is_gimple_val(lhs)) {
 
-      tree   s = make_ssa_name(t);
-      gimple g = gimple_build_assign(s, lhs);
+      tree s = make_ssa_name(t);
+      auto g = gimple_build_assign(s, lhs);
       lhs = s;
       gsi_insert_before(&gsi, g, GSI_SAME_STMT);
 
@@ -273,8 +273,8 @@ struct afl_cmplog_pass : afl_base_pass {
     rhs = fold_convert_loc(UNKNOWN_LOCATION, t, rhs);
     if (!is_gimple_val(rhs)) {
 
-      tree   s = make_ssa_name(t);
-      gimple g = gimple_build_assign(s, rhs);
+      tree s = make_ssa_name(t);
+      auto g = gimple_build_assign(s, rhs);
       rhs = s;
       gsi_insert_before(&gsi, g, GSI_SAME_STMT);
 
@@ -282,7 +282,7 @@ struct afl_cmplog_pass : afl_base_pass {
 
     /* Insert the call.  */
     tree   att = build_int_cst(t8u, attr);
-    gimple call;
+    gcall* call;
     if (pass_n)
       call = gimple_build_call(fn, 4, lhs, rhs, att,
                                build_int_cst(t8u, sz / 8 - 1));
@@ -305,7 +305,7 @@ struct afl_cmplog_pass : afl_base_pass {
       gimple_stmt_iterator gsi = gsi_last_bb(bb);
       if (gsi_end_p(gsi)) continue;
 
-      gimple stmt = gsi_stmt(gsi);
+      auto stmt = gsi_stmt(gsi);
 
       if (gimple_code(stmt) == GIMPLE_COND) {
 

--- a/instrumentation/afl-gcc-cmptrs-pass.so.cc
+++ b/instrumentation/afl-gcc-cmptrs-pass.so.cc
@@ -247,7 +247,7 @@ struct afl_cmptrs_pass : afl_base_pass {
       for (gimple_stmt_iterator gsi = gsi_after_labels(bb); !gsi_end_p(gsi);
            gsi_next(&gsi)) {
 
-        gimple stmt = gsi_stmt(gsi);
+        auto stmt = gsi_stmt(gsi);
 
         /* We're only interested in GIMPLE_CALLs.  */
         if (gimple_code(stmt) != GIMPLE_CALL) continue;
@@ -297,8 +297,8 @@ struct afl_cmptrs_pass : afl_base_pass {
           tree c = fold_convert_loc(UNKNOWN_LOCATION, tp8u, arg[i]);
           if (!is_gimple_val(c)) {
 
-            tree   s = make_ssa_name(tp8u);
-            gimple g = gimple_build_assign(s, c);
+            tree s = make_ssa_name(tp8u);
+            auto g = gimple_build_assign(s, c);
             c = s;
             gsi_insert_before(&gsi, g, GSI_SAME_STMT);
 
@@ -308,7 +308,7 @@ struct afl_cmptrs_pass : afl_base_pass {
 
         }
 
-        gimple call = gimple_build_call(fn, 2, arg[0], arg[1]);
+        auto call = gimple_build_call(fn, 2, arg[0], arg[1]);
         gsi_insert_before(&gsi, call, GSI_SAME_STMT);
 
       }

--- a/instrumentation/afl-gcc-common.h
+++ b/instrumentation/afl-gcc-common.h
@@ -43,6 +43,11 @@
 #include <algorithm>
 #include <fnmatch.h>
 
+#if defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+
 #include <gcc-plugin.h>
 #include <plugin-version.h>
 #include <toplev.h>
@@ -57,15 +62,21 @@
 #include <gimple-iterator.h>
 #include <stringpool.h>
 #include <gimple-ssa.h>
-#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= \
-    60200                                               /* >= version 6.2.0 */
+#if defined(__has_include) && __has_include(<tree-vrp.h>)
   #include <tree-vrp.h>
+#endif
+#if defined(__has_include) && __has_include(<value-range.h>)
+  #include <value-range.h>
 #endif
 #include <tree-ssanames.h>
 #include <tree-phinodes.h>
 #include <ssa-iterators.h>
 
 #include <intl.h>
+
+#if defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
 
 namespace {
 


### PR DESCRIPTION
* `instrumentation/afl-gcc-common.h` includes `tree-ssanames.h` but
  wasn't including `value-range-storage.h` which with Clang 18..21 yields
  an `error: unknown type name 'vrange'` in `tree-ssanames.h`
* In addition I adjusted the conditional `#include <tree-vrp.h>` to use
  `__has_include` similar to #2591
* Furthermore I adjusted a few variable declarations to use `auto` to
  make both Clang and GCC happy
  - What doesn't work (kind of expected) is for the resulting plugins to
    be loaded into Clang, so probably an additional `GNUmakefile`
    adjustment will be needed as well
* I suppress the `-Wmismatched-tags` warning locally for the GCC plugin
  headers; the warning is about declaration and definition using
  `struct` vs. `class` which is an issue with the MS ABI (Clang only)

-----

# Rationale

When building with Clang there were always errors resulting from the GCC plugin headers.

## Clang 18

```
clang++-18 -O3 -g -funroll-loops  -Wall -std=c++11 -fPIC -fno-rtti -fno-exceptions -I"/usr/bin/../lib/gcc/x86_64-linux-gnu/13/plugin"/include -I"/usr/bin/../lib/gcc/x86_64-linux-gnu/13/plugin" -shared instrumentation/afl-gcc-pass
.so.cc -o afl-gcc-pass.so -lrt
In file included from instrumentation/afl-gcc-pass.so.cc:126:
In file included from instrumentation/afl-gcc-common.h:64:
/usr/bin/../lib/gcc/x86_64-linux-gnu/13/plugin/include/tree-ssanames.h:60:41: error: unknown type name 'vrange'
   60 | extern bool set_range_info (tree, const vrange &);
      |                                         ^
1 error generated.
make[1]: *** [GNUmakefile.gcc_plugin:151: afl-gcc-pass.so] Error 1
```

## Clang 19

```
clang++-19 -O3 -g -funroll-loops  -Wall -std=c++11 -fPIC -fno-rtti -fno-exceptions -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin"/include -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin" -shared instrumentation/afl-gcc-pass.so.cc -o afl-
gcc-pass.so -lrt
In file included from instrumentation/afl-gcc-pass.so.cc:126:
In file included from instrumentation/afl-gcc-common.h:64:
/usr/lib/gcc/x86_64-linux-gnu/13/plugin/include/tree-ssanames.h:60:41: error: unknown type name 'vrange'
   60 | extern bool set_range_info (tree, const vrange &);
      |                                         ^
1 error generated.
make[1]: *** [GNUmakefile.gcc_plugin:151: afl-gcc-pass.so] Error 1
```

## Clang 20

```
clang++-20 -O3 -g -funroll-loops  -Wall -std=c++11 -fPIC -fno-rtti -fno-exceptions -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin"/include -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin" -shared instrumentation/afl-gcc-pass.so.cc -o afl-
gcc-pass.so -lrt
In file included from instrumentation/afl-gcc-pass.so.cc:126:
In file included from instrumentation/afl-gcc-common.h:64:
/usr/lib/gcc/x86_64-linux-gnu/13/plugin/include/tree-ssanames.h:60:41: error: unknown type name 'vrange'
   60 | extern bool set_range_info (tree, const vrange &);
      |                                         ^
1 error generated.
make[1]: *** [GNUmakefile.gcc_plugin:151: afl-gcc-pass.so] Error 1
```

## Clang 21

```
clang++-21 -O3 -g -funroll-loops  -Wall -std=c++11 -fPIC -fno-rtti -fno-exceptions -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin"/include -I"/usr/lib/gcc/x86_64-linux-gnu/13/plugin" -shared instrumentation/afl-gcc-pass.so.cc -o afl-
gcc-pass.so -lrt
In file included from instrumentation/afl-gcc-pass.so.cc:126:
In file included from instrumentation/afl-gcc-common.h:64:
/usr/lib/gcc/x86_64-linux-gnu/13/plugin/include/tree-ssanames.h:60:41: error: unknown type name 'vrange'
   60 | extern bool set_range_info (tree, const vrange &);
      |                                         ^
1 error generated.
make[1]: *** [GNUmakefile.gcc_plugin:151: afl-gcc-pass.so] Error 1
```

To reproduce my tests one would have to install the Clang versions 18 through 21 from apt.llvm.org on Ubuntu 24.04. The Default-GCC (13) on Ubuntu is also used to check against.

-----

Furthermore I am seeing this error _after_ applying the patch from this PR.

```
[*] Testing the CC wrapper and instrumentation output...
unset AFL_USE_ASAN AFL_USE_MSAN AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_INST_RATIO=100 AFL_PATH=. AFL_CC=clang-19 ./afl-gcc-fast -O3 -g -funroll-loops -Wall -Iinclude -Wno-pointer-sign -D
AFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DGCC_VERSION=\"\" -DGCC_BINDIR=\"\" -Wno-unused-function  ./test-instr.c -o test-instr -lrt
clang-19: error: unknown argument: '-fno-if-conversion'
clang-19: error: unknown argument: '-fno-if-conversion2'
make[1]: *** [GNUmakefile.gcc_plugin:166: test_build] Error 1
```

```
[*] Testing the CC wrapper and instrumentation output...
unset AFL_USE_ASAN AFL_USE_MSAN AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_INST_RATIO=100 AFL_PATH=. AFL_CC=clang-19 ./afl-gcc-fast -O3 -g -funroll-loops -Wall -Iinclude -Wno-pointer-sign -D
AFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DGCC_VERSION=\"\" -DGCC_BINDIR=\"\" -Wno-unused-function  ./test-instr.c -o test-instr -lrt
clang-19: error: unknown argument: '-fno-if-conversion'
clang-19: error: unknown argument: '-fno-if-conversion2'
make[1]: *** [GNUmakefile.gcc_plugin:166: test_build] Error 1
```

```
[*] Testing the CC wrapper and instrumentation output...                                                                                                                                                                             unset AFL_USE_ASAN AFL_USE_MSAN AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_INST_RATIO=100 AFL_PATH=. AFL_CC=clang-20 ./afl-gcc-fast -O3 -g -funroll-loops -Wall -Iinclude -Wno-pointer-sign -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DGCC_VERSION=\"\" -DGCC_BINDIR=\"\" -Wno-unused-function  ./test-instr.c -o test-instr -lrt
clang-20: error: unknown argument: '-fno-if-conversion'
clang-20: error: unknown argument: '-fno-if-conversion2'
make[1]: *** [GNUmakefile.gcc_plugin:166: test_build] Error 1
```

```
[*] Testing the CC wrapper and instrumentation output...                                                                                                                                                                             unset AFL_USE_ASAN AFL_USE_MSAN AFL_LLVM_ALLOWLIST AFL_LLVM_DENYLIST; ASAN_OPTIONS=detect_leaks=0 AFL_QUIET=1 AFL_INST_RATIO=100 AFL_PATH=. AFL_CC=clang-21 ./afl-gcc-fast -O3 -g -funroll-loops -Wall -Iinclude -Wno-pointer-sign -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DGCC_VERSION=\"\" -DGCC_BINDIR=\"\" -Wno-unused-function  ./test-instr.c -o test-instr -lrt
clang-21: error: unknown argument: '-fno-if-conversion'
clang-21: error: unknown argument: '-fno-if-conversion2'
make[1]: *** [GNUmakefile.gcc_plugin:166: test_build] Error 1
```

But that makes sense, given Clang won't load GCC plugins ...