### PR TITLE
fix(build_gramatron_mutator): Suppress `calloc-transposed-args`

### DIFF
--- a/custom_mutators/gramatron/build_gramatron_mutator.sh
+++ b/custom_mutators/gramatron/build_gramatron_mutator.sh
@@ -134,7 +134,7 @@ test -e json-c/.libs/libjson-c.a || {
   sh -c 'git stash && git stash drop' 1>/dev/null 2>/dev/null
   git checkout "$JSONC_VERSION" || exit 1
   sh autogen.sh || exit 1
-  export CFLAGS=-fPIC
+  export CFLAGS="-fPIC -Wno-error=calloc-transposed-args"
   ./configure --disable-shared || exit 1
   make || exit 1
   cd ..


### PR DESCRIPTION
I suggest suppressing the warning to avoid updating the old dependency and reduce the risk of breaking the API in `gramatron`.

Before (compilation error):
```
arraylist.c: In function 'array_list_new':
arraylist.c:49:43: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
   49 |   if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
      |                                           ^~~~
arraylist.c:49:43: note: earlier argument should specify number of elements, later size of each element
```

After (compiled with warning):
```
arraylist.c: In function 'array_list_new':
arraylist.c:49:43: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
   49 |   if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
      |                                           ^~~~
arraylist.c:49:43: note: earlier argument should specify number of elements, later size of each element
  CC       debug.lo
```

This enables us to build the required version of the `json-c` dependency with GCC 14+.

Fixes #2597