### PR TITLE
Fix: get map_size from env for AFL_NO_FORKSRV

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1593,8 +1593,8 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
       } else {
 
         // The binary is most likely instrumented using AFL's tool, and we will
-        // set map_size to MAP_SIZE.
-        fsrv->real_map_size = fsrv->map_size = MAP_SIZE;
+        // set map_size from ENV or default MAP_SIZE.
+        fsrv->real_map_size = fsrv->map_size = get_map_size();
 
       }
 


### PR DESCRIPTION
Hi!

I get problem while using `afl_showmap`.
env AFL_MAP_SIZE ignorred if i used env AFL_NO_FORKSRV. I think is incorrect behaivor.

### Log without AFL_NO_FORKSRV
```
AFL_MAP_SIZE=1858873 afl-showmap ...
[+] Hash of coverage map: 2949c56d6e7027aa
[+] Captured 4201 tuples (map size 1858873, highest value 8, total values 15535) in '/dev/stdout'.
```

### Log with AFL_NO_FORKSRV=1
```
AFL_NO_FORKSRV=1 AFL_MAP_SIZE=1858873 afl-showmap ...
[!] WARNING: Old fork server model is used by the target, this still works though.
[+] Hash of coverage map: d9713c4ec64d4c42
[+] Captured 7 tuples (map size 65536, highest value 5, total values 11) in '/dev/stdout'.
```

If we set env AFL_NO_FORKSRV=1, we get into condition where the variables `fsrv->real_map_size = fsrv->map_size ` is always set to MAP_SIZE. I replaced this with a function that also checks ENV `AFL_MAP_SIZE` (get_map_size)
