### PR TITLE
Fix splicing to copy from correct offset in target file

### DIFF
--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -3424,7 +3424,7 @@ retry_splicing:
     len = target->len;
     afl->in_scratch_buf = afl_realloc(AFL_BUF_PARAM(in_scratch), len);
     memcpy(afl->in_scratch_buf, in_buf, split_at);
-    memcpy(afl->in_scratch_buf + split_at, new_buf, len - split_at);
+    memcpy(afl->in_scratch_buf + split_at, new_buf + split_at, len - split_at);
     in_buf = afl->in_scratch_buf;
     afl_swap_bufs(AFL_BUF_PARAM(in), AFL_BUF_PARAM(in_scratch));
 
@@ -5908,7 +5908,7 @@ pacemaker_fuzzing:
         len = target->len;
         afl->in_scratch_buf = afl_realloc(AFL_BUF_PARAM(in_scratch), len);
         memcpy(afl->in_scratch_buf, in_buf, split_at);
-        memcpy(afl->in_scratch_buf + split_at, new_buf, len - split_at);
+        memcpy(afl->in_scratch_buf + split_at, new_buf + split_at, len - split_at);
         in_buf = afl->in_scratch_buf;
         afl_swap_bufs(AFL_BUF_PARAM(in), AFL_BUF_PARAM(in_scratch));
 


### PR DESCRIPTION
The splicing code was copying from the beginning of new_buf (offset 0) instead of from split_at. This meant the spliced result contained:
- Bytes 0 to split_at-1 from in_buf (correct)
- Bytes 0 to len-split_at-1 from new_buf (incorrect)

The correct behavior for splicing is to take:
- Head (0 to split_at-1) from the current input
- Tail (split_at to len-1) from the target input

Fixed in both fuzz_one_original() and mopt_common_fuzzing().