### PR TITLE
Fix K-CTX context restoration in return blocks

### DIFF
--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -593,7 +593,7 @@ PreservedAnalyses AFLCoverage::run(Module &M, ModuleAnalysisManager &MAM) {
             StoreInst *RestoreCtx;
 #ifdef AFL_HAVE_VECTOR_INTRINSICS
             if (ctx_k)
-              RestoreCtx = IRB.CreateStore(PrevCaller, AFLPrevCaller);
+              RestoreCtx = Post_IRB.CreateStore(PrevCaller, AFLPrevCaller);
             else
 #endif
               RestoreCtx = Post_IRB.CreateStore(PrevCtx, AFLContext);
@@ -789,7 +789,7 @@ PreservedAnalyses AFLCoverage::run(Module &M, ModuleAnalysisManager &MAM) {
           StoreInst *RestoreCtx;
 #ifdef AFL_HAVE_VECTOR_INTRINSICS
           if (ctx_k)
-            RestoreCtx = IRB.CreateStore(PrevCaller, AFLPrevCaller);
+            RestoreCtx = Post_IRB.CreateStore(PrevCaller, AFLPrevCaller);
           else
 #endif
             RestoreCtx = Post_IRB.CreateStore(PrevCtx, AFLContext);


### PR DESCRIPTION
When AFL_LLVM_CTX_K is enabled, the context restoration in return blocks was incorrectly using IRB (which inserts at block start) instead of Post_IRB (which inserts before the return instruction).