### PR TITLE
llvm-common: skip null entries in global_ctors instead of breaking

### DIFF
--- a/instrumentation/afl-llvm-common.cc
+++ b/instrumentation/afl-llvm-common.cc
@@ -366,8 +366,11 @@ void scanForDangerousFunctions(llvm::Module *M) {
 
           if (CS->getNumOperands() >= 2) {
 
-            if (CS->getOperand(1)->isNullValue())
-              break;  // Found a null terminator, stop here.
+            // Skip null entries - these can appear when constructor functions
+            // are removed by optimization passes (e.g., GlobalDCE) or during
+            // LTO linking without the array being compacted.
+            // See LLVM's CtorUtils.cpp which also uses continue for null entries.
+            if (CS->getOperand(1)->isNullValue()) continue;
 
             ConstantInt *CI = dyn_cast<ConstantInt>(CS->getOperand(0));
             int          Priority = CI ? CI->getSExtValue() : 0;


### PR DESCRIPTION
Null entries can appear in the middle of llvm.global_ctors when optimization passes remove constructor functions. Using 'break' caused constructors after null entries to be missed.

Changed to 'continue' to match LLVM's CtorUtils.cpp behavior, cf. https://github.com/llvm/llvm-project/blob/c386d6d3bfa400e94ac9cadb85a0b1a72ed54b2b/llvm/lib/Transforms/Utils/CtorUtils.cpp#L97