### PR TITLE
afl-showmap: add streaming mode (-S) for efficient coverage collection

### DIFF
--- a/examples/afl_showmap_streaming_mode.py
+++ b/examples/afl_showmap_streaming_mode.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Simple wrapper class for afl-showmap streaming mode.
+
+Usage:
+    with AflShowmapStreaming("./afl-showmap", "./target", ["arg1"]) as showmap:
+        status, crash_signal, edges = showmap.get_coverage(b"test input")
+        print(f"Status: {status.name}, hit {len(edges)} edges")
+        if crash_signal:
+            print(f"Crashed with signal: {crash_signal.name}")
+
+        # Batch processing
+        results = showmap.get_coverage_batch([b"input1", b"input2"])
+        for status, crash_signal, edges in results:
+            print(f"{status.name}: {len(edges)} edges")
+"""
+
+import os
+import signal
+import struct
+import subprocess
+import sys
+from enum import IntEnum
+from pathlib import Path
+
+
+class ExitStatus(IntEnum):
+    """Exit status from streaming protocol (bits 0-1 of status field)."""
+
+    EXITED = 0   # Normal exit
+    TIMEOUT = 1  # Execution timed out
+    CRASH = 2    # Target crashed
+
+
+# Status field layout (u16):
+#   bits 0-1:  exit status (0=exited, 1=timeout, 2=crash)
+#   bits 2-7:  reserved (must be 0)
+#   bits 8-15: signal number (only valid when status=crash)
+
+# Masks for status field parsing
+_STATUS_EXIT_MASK = 0x0003      # bits 0-1
+_STATUS_RESERVED_MASK = 0x00FC  # bits 2-7 (must be 0)
+_STATUS_SIGNAL_SHIFT = 8        # bits 8-15
+
+
+class AflShowmapStreaming:
+    """Minimal wrapper for afl-showmap -S streaming mode (sync)."""
+
+    def __init__(
+        self,
+        afl_showmap: "str | Path",
+        target: "str | Path",
+        target_args: "list[str] | None" = None,
+        timeout_ms: int = 1000,
+    ):
+        cmd = [str(afl_showmap), "-S", "-t", str(timeout_ms), "--", str(target)]
+        if target_args:
+            cmd.extend(target_args)
+        self._proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "AFL_QUIET": "1"},
+        )
+
+    def get_coverage(
+        self, data: bytes
+    ) -> "tuple[ExitStatus, signal.Signals | None, list[tuple[int, int]]]":
+        """Send input, get coverage result.
+
+        Returns:
+            (exit_status, crash_signal, edges) where edges is list of (edge_offset, hit_count).
+        """
+        self._send(data)
+        return self._recv()
+
+    def get_coverage_batch(
+        self, inputs: "list[bytes]"
+    ) -> "list[tuple[ExitStatus, signal.Signals | None, list[tuple[int, int]]]]":
+        """Process multiple inputs, return list of (exit_status, crash_signal, edges) tuples."""
+        return [self.get_coverage(data) for data in inputs]
+
+    def _send(self, data: bytes) -> None:
+        """Send a test case: [u32 length][data]."""
+        assert self._proc.stdin
+        self._proc.stdin.write(struct.pack("<I", len(data)) + data)
+        self._proc.stdin.flush()
+
+    def _recv(self) -> "tuple[ExitStatus, signal.Signals | None, list[tuple[int, int]]]":
+        """Receive: [u16 status][u32 count][{u32 edge_idx, u8 hit_ctr} * count].
+
+        Returns:
+            (exit_status, crash_signal, edges) where:
+            - exit_status: ExitStatus enum value
+            - crash_signal: signal.Signals if crash, None otherwise
+            - edges: list of (edge_offset, hit_count) tuples
+        """
+        status_raw = struct.unpack("<H", self._read_exactly(2))[0]
+
+        # Check reserved bits — if non-zero, protocol has changed
+        reserved = status_raw & _STATUS_RESERVED_MASK
+        if reserved != 0:
+            raise RuntimeError(
+                f"Protocol mismatch: reserved status bits are non-zero ({reserved:#x}). "
+                f"Update this client to match the new afl-showmap protocol."
+            )
+
+        exit_status = ExitStatus(status_raw & _STATUS_EXIT_MASK)
+        signal_num = status_raw >> _STATUS_SIGNAL_SHIFT
+        crash_signal = signal.Signals(signal_num) if signal_num else None
+
+        edge_count = struct.unpack("<I", self._read_exactly(4))[0]
+        edge_data = self._read_exactly(edge_count * 5)
+        edges = [
+            struct.unpack_from("<IB", edge_data, i * 5) for i in range(edge_count)
+        ]
+        return exit_status, crash_signal, edges
+
+    def _read_exactly(self, n: int) -> bytes:
+        """Read exactly n bytes from stdout."""
+        assert self._proc.stdout
+        data = b""
+        while len(data) < n:
+            chunk = self._proc.stdout.read(n - len(data))
+            if not chunk:
+                raise EOFError(f"Expected {n} bytes, got {len(data)}")
+            data += chunk
+        return data
+
+    def close(self) -> None:
+        """Close the streaming connection and verify afl-showmap exited cleanly."""
+        assert self._proc.stdin
+        # Send: [u32 length=0] — signals EOF
+        self._proc.stdin.write(struct.pack("<I", 0))
+        self._proc.stdin.flush()
+        self._proc.stdin.close()
+
+        exit_code = self._proc.wait()
+        if exit_code != 0:
+            stderr = self._proc.stderr.read().decode() if self._proc.stderr else ""
+            raise RuntimeError(f"afl-showmap failed (exit {exit_code}): {stderr}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+def _run_demo(afl_showmap: Path, target: Path, target_args: "list[str]") -> None:
+    """Run demo showing wrapper usage."""
+    with AflShowmapStreaming(afl_showmap, target, target_args) as showmap:
+        # Single input
+        print("Single:")
+        status, crash_signal, edges = showmap.get_coverage(b"AAAA")
+        sig_info = f", signal={crash_signal.name}" if crash_signal else ""
+        print(f"  b'AAAA': {status.name}{sig_info}, {len(edges)} edges")
+
+        # Batch
+        print("\nBatch:")
+        inputs = [b"BBBB", b"CCCC", b"test"]
+        results = showmap.get_coverage_batch(inputs)
+        for inp, (status, crash_signal, edges) in zip(inputs, results):
+            sig_info = f", signal={crash_signal.name}" if crash_signal else ""
+            print(f"  {inp!r}: {status.name}{sig_info}, {len(edges)} edges")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <afl-showmap> <target> [target_args...]")
+        sys.exit(1)
+
+    afl_showmap = Path(sys.argv[1])
+    target = Path(sys.argv[2])
+    target_args = sys.argv[3:]
+
+    _run_demo(afl_showmap, target, target_args)

--- a/include/debug.h
+++ b/include/debug.h
@@ -33,9 +33,9 @@
  * Terminal colors *
  *******************/
 
-#ifndef MESSAGES_TO_STDOUT
-  #define MESSAGES_TO_STDOUT
-#endif
+/* Define MESSAGES_TO_STDOUT to send diagnostic messages to stdout.
+   By default, messages go to stderr (correct Unix convention).
+   afl-fuzz defines this in afl-fuzz.h for its TUI. */
 
 #ifdef USE_COLOR
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -111,6 +111,9 @@ static bool quiet_mode,                /* Hide non-essential messages?      */
 static volatile u8 stop_soon,          /* Ctrl-C pressed?                   */
     child_crashed;                     /* Child crashed?                    */
 
+/* Streaming of inputs and coverage via stdin &stdout  */
+static bool streaming_mode;
+
 static sharedmem_t       shm;
 static afl_forkserver_t *fsrv;
 static sharedmem_t      *shm_fuzz;
@@ -481,6 +484,141 @@ static void showmap_run_target_forkserver(afl_forkserver_t *fsrv, u8 *mem,
 
     SAYF(cRST cLRD "\n+++ afl-showmap folder mode aborted by user +++\n" cRST);
     exit(1);
+
+  }
+
+}
+
+/* Helper to read exactly n bytes from fd */
+static ssize_t read_all(int fd, void *buf, size_t n) {
+
+  size_t  done = 0;
+  ssize_t r;
+
+  while (done < n) {
+
+    r = read(fd, (u8 *)buf + done, n - done);
+    if (r <= 0) { return done ? (ssize_t)done : r; }
+    done += r;
+
+  }
+
+  return (ssize_t)done;
+
+}
+
+/* Streaming mode exit status (lower 2 bits of status field) */
+#define STREAMING_STATUS_EXITED  0
+#define STREAMING_STATUS_TIMEOUT 1
+#define STREAMING_STATUS_CRASH   2
+
+/* Input streaming loop - reads test cases from stdin, writes coverage to stdout.
+   Protocol (LV = length-value format):
+   - Input:  [u32 length][u8 data[length]] (length=0 signals EOF)
+   - Output: [u16 status][u32 edge_count][{u32 edge_idx, u8 hit_ctr}*]
+             [u32 stdout_len][u8 stdout_data*][u32 stderr_len][u8 stderr_data*]
+   Status field:
+     bits 0-1:  exit status (0=exited, 1=timeout, 2=crash)
+     bits 2-7:  reserved (must be 0)
+     bits 8-15: signal number (only valid when status=crash)
+   Note: stdout_len and stderr_len are currently always 0 (not implemented).
+         These fields are reserved for future use to capture target output.
+*/
+static void streaming_loop(void) {
+
+  static u8 tc_buffer[MAX_FILE];
+  u32       tc_length;
+
+  while (read_all(STDIN_FILENO, &tc_length, 4) == 4 && tc_length > 0) {
+
+    if (tc_length > MAX_FILE) {
+
+      FATAL("Test case too large (%u > %lu)", tc_length, MAX_FILE);
+
+    }
+
+    /* Read test case */
+    if (read_all(STDIN_FILENO, tc_buffer, tc_length) != (ssize_t)tc_length) {
+
+      FATAL("Short read on input (expected %u bytes)", tc_length);
+
+    }
+
+    /* Execute via fork server */
+    showmap_run_target_forkserver(fsrv, tc_buffer, tc_length);
+
+    /* Determine exit status (bits 0-1) and signal number (bits 8-15) */
+    u16 status;
+    if (fsrv->last_run_timed_out) {
+
+      status = STREAMING_STATUS_TIMEOUT;
+
+    } else if (child_crashed) {
+
+      /* Encode signal number in bits 8-15 */
+      status = STREAMING_STATUS_CRASH | (WTERMSIG(fsrv->child_status) << 8);
+
+    } else {
+
+      status = STREAMING_STATUS_EXITED;
+
+    }
+
+    /* Write status */
+    if (write(STDOUT_FILENO, &status, 2) != 2) {
+
+      FATAL("Failed to write status");
+
+    }
+
+    /* Count hit edges */
+    u32 edge_count = 0;
+    for (u32 i = 0; i < map_size; i++) {
+
+      if (fsrv->trace_bits[i]) { edge_count++; }
+
+    }
+
+    /* Write edge count */
+    if (write(STDOUT_FILENO, &edge_count, 4) != 4) {
+
+      FATAL("Failed to write edge count");
+
+    }
+
+    /* Write edges: (edge_idx:u32, hit_ctr:u8) pairs */
+    for (u32 i = 0; i < map_size; i++) {
+
+      if (fsrv->trace_bits[i]) {
+
+        u32 offset = i;
+        u8  count = fsrv->trace_bits[i];
+        if (write(STDOUT_FILENO, &offset, 4) != 4 ||
+            write(STDOUT_FILENO, &count, 1) != 1) {
+
+          FATAL("Failed to write edge data");
+
+        }
+
+      }
+
+    }
+
+    /* Write stdout LV field (length=0, not implemented) */
+    u32 stdout_len = 0;
+    if (write(STDOUT_FILENO, &stdout_len, 4) != 4) {
+
+      FATAL("Failed to write stdout length");
+
+    }
+
+    /* Write stderr LV field (length=0, not implemented) */
+    u32 stderr_len = 0;
+    if (write(STDOUT_FILENO, &stderr_len, 4) != 4) {
+
+      FATAL("Failed to write stderr length");
+
+    }
 
   }
 
@@ -1023,7 +1161,7 @@ static void usage(u8 *argv0) {
       "\n%s [ options ] -- /path/to/target_app [ ... ]\n\n"
 
       "Required parameters:\n"
-      "  -o file    - file to write the trace data to\n\n"
+      "  -o file    - file to write the trace data to (not required with -S)\n\n"
 
       "Execution control settings:\n"
       "  -t msec    - timeout for each run (default: 1000ms)\n"
@@ -1042,6 +1180,18 @@ static void usage(u8 *argv0) {
 #endif
       "\n"
       "Other settings:\n"
+      "  -S         - streaming mode: read test cases from stdin, write coverage\n"
+      "               to stdout using a length-value protocol. Allows using\n"
+      "               afl-showmap as a coverage proxy to leverage the AFL++\n"
+      "               forkserver without implementing it.\n"
+      "               Protocol: Input  [u32 len][data]\n"
+      "                         Output [u16 status][u32 edges][(u32,u8)*]\n"
+      "                                [u32 stdout_len][stdout_data*]\n"
+      "                                [u32 stderr_len][stderr_data*]\n"
+      "               Status: bits 0-1 = exit (0=ok, 1=timeout, 2=crash),\n"
+      "                       bits 2-7 = reserved (0), bits 8-15 = signal\n"
+      "               Note: stdout_len/stderr_len are currently always 0\n"
+      "                     (output capture not yet implemented)\n"
       "  -i dir     - process all files below this directory, must be combined "
       "with -o.\n"
       "               With -C, -o is a file, without -C it must be a "
@@ -1122,7 +1272,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (getenv("AFL_QUIET") != NULL) { be_quiet = true; }
 
-  while ((opt = getopt(argc, argv, "+i:I:o:f:m:t:AeqCZOH:QUWbcrshXY")) > 0) {
+  while ((opt = getopt(argc, argv, "+i:I:o:f:m:t:AeqCZOH:QUWbcrshSXY")) > 0) {
 
     switch (opt) {
 
@@ -1352,6 +1502,13 @@ int main(int argc, char **argv_orig, char **envp) {
         raw_instr_output = true;
         break;
 
+      case 'S':
+
+        if (streaming_mode) { FATAL("Multiple -S options not supported"); }
+        streaming_mode = true;
+        quiet_mode = true;
+        break;
+
       case 'h':
         usage(argv[0]);
         return -1;
@@ -1366,9 +1523,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
   if (collect_coverage) { binary_mode = false; }  // ensure this
 
-  if (optind == argc || !out_file) { usage(argv[0]); }
+  if (optind == argc || (!out_file && !streaming_mode)) { usage(argv[0]); }
 
   if (in_dir && in_filelist) { FATAL("you can only specify either -i or -I"); }
+
+  if (streaming_mode && (in_dir || in_filelist)) {
+    FATAL("-S streaming mode is incompatible with -i/-I input options");
+  }
+
+  if (streaming_mode && out_file) {
+    FATAL("-S streaming mode is incompatible with -o output option");
+  }
 
   if (in_dir || in_filelist) {
 
@@ -1430,7 +1595,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
-  if (in_dir || in_filelist) {
+  if (in_dir || in_filelist || streaming_mode) {
 
     /* If we don't have a file name chosen yet, use a safe default. */
     u8 *use_dir = ".";
@@ -1660,6 +1825,15 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+  /* Input streaming mode - read inputs from stdin, write coverage to stdout */
+  if (streaming_mode) {
+
+    map_size = fsrv->map_size;
+    streaming_loop();
+    goto showmap_done;
+
+  }
+
   if (in_dir || in_filelist) {
 
     afl->fsrv.dev_urandom_fd = open("/dev/urandom", O_RDONLY);
@@ -1837,13 +2011,19 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+showmap_done:
+
   remove_shm = false;
   afl_shm_deinit(&shm);
   if (fsrv->use_shmem_fuzz) { shm_fuzz = deinit_shmem(fsrv, shm_fuzz); }
 
   u32 ret;
 
-  if (cmin_mode && !!getenv("AFL_CMIN_CRASHES_ONLY")) {
+  if (streaming_mode) {
+
+    ret = 0;  /* Streaming mode exits 0 on success, FATAL on error */
+
+  } else if (cmin_mode && !!getenv("AFL_CMIN_CRASHES_ONLY")) {
 
     ret = run_timed_out();
 
@@ -1866,4 +2046,3 @@ int main(int argc, char **argv_orig, char **envp) {
   exit(ret);
 
 }
-

--- a/test/test-afl-showmap-streaming.sh
+++ b/test/test-afl-showmap-streaming.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+
+# Test afl-showmap streaming mode (-S flag)
+# Verifies that streaming mode produces identical coverage to batch mode
+
+. ./test-pre.sh
+
+$ECHO "$BLUE[*] Testing: afl-showmap streaming mode (-S flag)"
+
+# Check if afl-showmap exists
+test -e ../afl-showmap || {
+  $ECHO "$YELLOW[-] afl-showmap not found, skipping streaming tests"
+  INCOMPLETE=1
+  . ./test-post.sh
+  exit 0
+}
+
+# Check if streaming mode is supported
+../afl-showmap -h 2>&1 | grep -q '\-S' || {
+  $ECHO "$YELLOW[-] afl-showmap does not support -S streaming mode, skipping"
+  INCOMPLETE=1
+  . ./test-post.sh
+  exit 0
+}
+
+$ECHO "$GREEN[+] afl-showmap supports streaming mode (-S flag)"
+
+# Check for Python (needed to parse binary streaming output)
+command -v python3 >/dev/null 2>&1 || {
+  $ECHO "$YELLOW[-] python3 not found, skipping streaming tests"
+  INCOMPLETE=1
+  . ./test-post.sh
+  exit 0
+}
+
+# Compile test binary if needed
+AFL_COMPILER=afl-clang-fast
+test -e ../afl-clang-fast || AFL_COMPILER=afl-cc
+test -e ../${AFL_COMPILER} || {
+  $ECHO "$RED[!] no AFL compiler found, cannot compile test binary"
+  CODE=1
+  . ./test-post.sh
+  exit 1
+}
+
+test -e test-instr.plain || {
+  $ECHO "$GREY[*] compiling test-instr.plain..."
+  ../${AFL_COMPILER} -o test-instr.plain -O0 ../test-instr.c > /dev/null 2>&1
+}
+
+test -e test-instr.plain || {
+  $ECHO "$RED[!] failed to compile test-instr.plain"
+  CODE=1
+  . ./test-post.sh
+  exit 1
+}
+
+# Python helper to create streaming input: [u32 len][data]... [u32 0]
+# Usage: create_streaming_input "input1" "input2" ... > output_file
+create_streaming_input() {
+  python3 -c "
+import sys
+import struct
+
+for arg in sys.argv[1:]:
+    data = (arg + '\n').encode()
+    sys.stdout.buffer.write(struct.pack('<I', len(data)))
+    sys.stdout.buffer.write(data)
+sys.stdout.buffer.write(struct.pack('<I', 0))
+" "$@"
+}
+
+# Python helper to parse streaming binary output to sorted edge list
+# Streaming output: [u16 status][u32 edge_count][{u32 edge_id, u8 hit_count}*]
+# Output format matches batch mode: 6-digit zero-padded edge IDs
+parse_streaming() {
+  python3 -c "
+import sys, struct
+read = sys.stdin.buffer.read
+while True:
+    hdr = read(6)
+    if len(hdr) < 6:
+        break
+    status, n_edges = struct.unpack('<HI', hdr)
+    edges = [struct.unpack('<IB', read(5))[0] for _ in range(n_edges)]
+    for e in sorted(edges):
+        print(f'{e:06d}')
+"
+}
+
+# Helper to extract edge IDs from text showmap output
+parse_text() {
+  cut -d: -f1 | sort -n
+}
+
+# ============================================================================
+# Test 1: Streaming vs batch mode produce same coverage (input "0")
+# ============================================================================
+$ECHO "$GREY[*] Test 1: streaming vs batch mode equivalence (input '0')"
+
+# Batch mode
+echo "0" | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -o .streaming-batch0 -- ./test-instr.plain > /dev/null 2>&1
+BATCH0=$(cat .streaming-batch0 | parse_text)
+
+# Streaming mode
+create_streaming_input "0" > .streaming-input0
+AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -S -t 1000 -- ./test-instr.plain < .streaming-input0 > .streaming-stream0 2>/dev/null
+STREAM0=$(cat .streaming-stream0 | parse_streaming)
+
+test "$BATCH0" = "$STREAM0" && {
+  $ECHO "$GREEN[+] streaming mode produces same coverage as batch mode for input '0'"
+} || {
+  $ECHO "$RED[!] streaming mode coverage differs from batch mode for input '0'"
+  CODE=1
+}
+
+rm -f .streaming-batch0 .streaming-stream0 .streaming-input0
+
+# ============================================================================
+# Test 2: Streaming vs batch mode produce same coverage (input "1")
+# ============================================================================
+$ECHO "$GREY[*] Test 2: streaming vs batch mode equivalence (input '1')"
+
+# Batch mode
+echo "1" | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -o .streaming-batch1 -- ./test-instr.plain > /dev/null 2>&1
+BATCH1=$(cat .streaming-batch1 | parse_text)
+
+# Streaming mode
+create_streaming_input "1" > .streaming-input1
+AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -S -t 1000 -- ./test-instr.plain < .streaming-input1 > .streaming-stream1 2>/dev/null
+STREAM1=$(cat .streaming-stream1 | parse_streaming)
+
+test "$BATCH1" = "$STREAM1" && {
+  $ECHO "$GREEN[+] streaming mode produces same coverage as batch mode for input '1'"
+} || {
+  $ECHO "$RED[!] streaming mode coverage differs from batch mode for input '1'"
+  CODE=1
+}
+
+rm -f .streaming-batch1 .streaming-stream1 .streaming-input1
+
+# ============================================================================
+# Test 3: Different inputs produce different coverage in streaming mode
+# ============================================================================
+$ECHO "$GREY[*] Test 3: streaming mode differentiates inputs"
+
+test "$STREAM0" != "$STREAM1" && {
+  $ECHO "$GREEN[+] streaming mode produces different coverage for different inputs"
+} || {
+  $ECHO "$RED[!] streaming mode should produce different coverage for '0' vs '1'"
+  CODE=1
+}
+
+# ============================================================================
+# Test 4: Streaming mode determinism
+# ============================================================================
+$ECHO "$GREY[*] Test 4: streaming mode determinism"
+
+create_streaming_input "0" > .streaming-det-input
+AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -S -t 1000 -- ./test-instr.plain < .streaming-det-input > .streaming-det1 2>/dev/null
+AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -S -t 1000 -- ./test-instr.plain < .streaming-det-input > .streaming-det2 2>/dev/null
+
+DET1=$(cat .streaming-det1 | parse_streaming)
+DET2=$(cat .streaming-det2 | parse_streaming)
+
+test "$DET1" = "$DET2" && {
+  $ECHO "$GREEN[+] streaming mode is deterministic"
+} || {
+  $ECHO "$RED[!] streaming mode is not deterministic"
+  CODE=1
+}
+
+rm -f .streaming-det1 .streaming-det2 .streaming-det-input
+
+# ============================================================================
+# Test 5: Multiple inputs in single streaming session
+# ============================================================================
+$ECHO "$GREY[*] Test 5: multiple inputs in single streaming session"
+
+create_streaming_input "0" "1" "test" > .streaming-multi-input
+AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -S -t 1000 -- ./test-instr.plain < .streaming-multi-input > .streaming-multi 2>/dev/null
+
+# Should have 3 coverage maps in output
+MULTI_SIZE=$(wc -c < .streaming-multi)
+test "$MULTI_SIZE" -gt 20 && {
+  $ECHO "$GREEN[+] streaming mode handled multiple inputs (${MULTI_SIZE} bytes)"
+} || {
+  $ECHO "$RED[!] streaming mode failed with multiple inputs"
+  CODE=1
+}
+
+rm -f .streaming-multi .streaming-multi-input
+
+# Cleanup
+rm -f test-instr.plain
+
+. ./test-post.sh


### PR DESCRIPTION
Add -S flag for continuous coverage collection via stdin/stdout. This allows processing inputs without writing them to disk and is faster when inputs arrive one by one, leveraging forkserver speed without needing to handle implementation details. This would be useful for computing coverage on the go for evaluation, or even for building a fuzzer prototype without the hassle of implementing the forkserver protocol and so on.

Currently, problems arise when `afl-showmap` prints an error message, since it apparently writes to stdout, which is also used for communication. I guess these are the options:

1. Write errors to stderr (expected behavior anyway, but probably will break stuff).
2. Ignore this situation and assume that the pipe will break anyway when an error is printed (I think all error messages are related to fatal errors).
3. Create an fd and send it as the first message to `afl-showmap`.

```
Protocol:
- Input:  [u32 length][u8 data[length]]... [u32 0] (zero length = EOF)
- Output: [u16 status][u32 edge_count][{u32 edge_idx, u8 hit_count}...] Status: bits 0-1 = exit status (0=exited, 1=timeout, 2=crash)
```