### PR TITLE
afl-showmap: set AFL_MAP_SIZE for targets with large coverage maps

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -140,6 +140,9 @@ u8 *u_stringify_mem_size(u8 *buf, u64 val);
 
 u8 *u_stringify_time_diff(u8 *buf, u64 cur_ms, u64 event_ms);
 
+/* Validate map size, returns validated size or FATALs if invalid */
+u32 validate_map_size(u32 map_size);
+
 /* Reads the map size from ENV */
 u32 get_map_size(void);
 

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -1367,6 +1367,20 @@ u8 *u_simplestring_time_diff(u8 *buf, u64 cur_ms, u64 event_ms) {
 
 }
 
+/* Validate map size, returns validated size or FATALs if invalid */
+u32 validate_map_size(u32 map_size) {
+
+  if (!map_size || map_size > (1U << 29)) {
+
+    FATAL("illegal AFL_MAP_SIZE %u, must be between %u and %u", map_size, 64U,
+          1U << 29);
+
+  }
+
+  return map_size;
+
+}
+
 /* Reads the map size from ENV */
 u32 get_map_size(void) {
 
@@ -1376,12 +1390,7 @@ u32 get_map_size(void) {
   if ((ptr = getenv("AFL_MAP_SIZE")) || (ptr = getenv("AFL_MAPSIZE"))) {
 
     map_size = atoi(ptr);
-    if (!map_size || map_size > (1 << 29)) {
-
-      FATAL("illegal AFL_MAP_SIZE %u, must be between %u and %u", map_size, 64U,
-            1U << 29);
-
-    }
+    validate_map_size(map_size);
 
     if (map_size % 64) { map_size = (((map_size >> 6) + 1) << 6); }
 

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1592,15 +1592,20 @@ int main(int argc, char **argv_orig, char **envp) {
 
     u32 save_be_quiet = be_quiet;
     be_quiet = !debug;
-    if (map_size > 4194304) {
+    if (map_size <= DEFAULT_SHMEM_SIZE) {
 
-      fsrv->map_size = map_size;
+      fsrv->map_size = DEFAULT_SHMEM_SIZE;  // dummy temporary value
 
     } else {
 
-      fsrv->map_size = 4194304;  // dummy temporary value
+      validate_map_size(map_size);
+      fsrv->map_size = map_size;
 
     }
+
+    char vbuf[16];
+    snprintf(vbuf, sizeof(vbuf), "%u", fsrv->map_size);
+    setenv("AFL_MAP_SIZE", vbuf, 1);
 
     u32 new_map_size =
         afl_fsrv_get_mapsize(fsrv, use_argv, &stop_soon,


### PR DESCRIPTION
The instrumentation runtime checks AFL_MAP_SIZE to verify the parent tool supports large maps before starting the forkserver. Without this env var set, targets requiring >64KB maps fail with FS_ERROR_MAP_SIZE.

afl-fuzz already sets this, but afl-showmap did not.