### PR TITLE
afl-cc: add check for using TSAN and ASAN/LSAN at the same time

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2089,6 +2089,9 @@ void add_sanitizers(aflcc_state_t *aflcc, char **envp) {
 
   if (getenv("AFL_USE_TSAN") || aflcc->have_tsan) {
 
+    if (getenv("AFL_USE_ASAN") || aflcc->have_asan)
+      FATAL("ASAN and TSAN are mutually exclusive");
+
     if (!aflcc->have_fp) {
 
       insert_param(aflcc, "-fno-omit-frame-pointer");
@@ -2103,6 +2106,9 @@ void add_sanitizers(aflcc_state_t *aflcc, char **envp) {
 
   if (getenv("AFL_USE_LSAN") && !aflcc->have_lsan) {
 
+    if (getenv("AFL_USE_TSAN") || aflcc->have_tsan)
+      FATAL("TSAN and LSAN are mutually exclusive");
+    
     insert_param(aflcc, "-fsanitize=leak");
     add_defs_lsan_ctrl(aflcc);
     aflcc->have_lsan = 1;


### PR DESCRIPTION
According to the [gcc's specifications on instrumentation options](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html), the `-fsanitize=thread` option cannot be combined with `-fsanitize=address`,  `-fsanitize=leak`. Therefore, this commit adds check for using TSAN and ASAN/LSAN and exits the compiling process when the incompatibility issue is detected.