### PR TITLE
calibration: use max observed execution time per seed for q->exec_us

### DIFF
--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -520,6 +520,7 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
   u8 fault = 0, new_bits = 0, var_detected = 0, hnb = 0,
      first_run = (q->exec_cksum == 0);
   u64 start_us, stop_us, diff_us;
+  u64 max_exec_us = 0;
   s32 old_sc = afl->stage_cur, old_sm = afl->stage_max;
   u32 use_tmout = afl->fsrv.exec_tmout;
   u8 *old_sn = afl->stage_name;
@@ -625,9 +626,22 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
     u64 cksum;
 
+    u64 run_start_us = get_cur_time_us();
+    
     (void)write_to_testcase(afl, (void **)&use_mem, q->len, 1);
 
     fault = fuzz_run_target(afl, &afl->fsrv, use_tmout);
+
+    u64 run_stop_us = get_cur_time_us();
+    u64 run_diff_us = run_stop_us - run_start_us;
+
+    if (unlikely(!run_diff_us)) { ++run_diff_us; }
+    
+    if (run_diff_us > max_exec_us) { 
+    
+      max_exec_us = run_diff_us; 
+    
+    }
 
     // update the time spend in calibration after each execution, as those may
     // be slow
@@ -709,6 +723,7 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
   if (unlikely(afl->fixed_seed)) {
 
     diff_us = (u64)(afl->fsrv.exec_tmout - 1) * (u64)afl->stage_max;
+    q->exec_us = (u64)(afl->fsrv.exec_tmout - 1);
 
   } else {
 
@@ -716,6 +731,10 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
     diff_us = stop_us - start_us;
     if (unlikely(!diff_us)) { ++diff_us; }
 
+    u64 avg_exec_us = diff_us / afl->stage_max;
+    q->exec_us = (max_exec_us > avg_exec_us) ? max_exec_us : avg_exec_us;
+    if (unlikely(!q->exec_us)) { q->exec_us = 1; }
+    
   }
 
   afl->total_cal_us += diff_us;
@@ -731,7 +750,6 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
   }
 
-  q->exec_us = diff_us / afl->stage_max;
   if (unlikely(!q->exec_us)) { q->exec_us = 1; }
 
   q->bitmap_size = count_bytes(afl, afl->fsrv.trace_bits);


### PR DESCRIPTION
During calibration some runs use a resumed persistent-loop (fast) while one run (the fork + initialization) can be significantly slower. The previous code used the average per-seed time to set q->exec_us. If the average is much smaller than the fork/init run, the first fork run may be killed by the timeout, causing a repeated fork->timeout loop and preventing persistent mode from ever being used.

This change tracks the maximum observed single-run time during calibration and sets q->exec_us to max(max_single_run, avg_run_time). That ensures timeouts are large enough to accommodate fork/init runs while remaining robust against transient small runs.

Files changed:
- afl-fuzz.c: calibrate_case()