### PR TITLE
Add support for symbolizing unstable edges

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -509,6 +509,10 @@ typedef struct afl_state {
   sharedmem_t      shm;
   sharedmem_t     *shm_fuzz;
   afl_env_vars_t   afl_env;
+#ifdef __AFL_CODE_COVERAGE
+  sharedmem_t shm_pcmap;                         /* Shared memory for pcmap */
+  sharedmem_t shm_modmap;                       /* Shared memory for modmap */
+#endif
 
   char **argv;                                            /* argv if needed */
 
@@ -1244,6 +1248,14 @@ u8 save_if_interesting(afl_state_t *, void *, u32, u8);
 u8 has_new_bits(afl_state_t *, u8 *);
 #ifndef AFL_SHOWMAP
 void classify_counts(afl_forkserver_t *);
+#endif
+
+#ifdef __AFL_CODE_COVERAGE
+void afl_pcmap_init(afl_state_t *, u32);
+void afl_pcmap_resize(afl_state_t *, u32);
+void afl_modmap_init(afl_state_t *);
+void afl_dump_pc_map(afl_state_t *);
+void afl_dump_module_map(afl_state_t *);
 #endif
 
 /* Extras */

--- a/include/envs.h
+++ b/include/envs.h
@@ -123,7 +123,13 @@ static char *afl_environment_variables[] = {
     "AFL_NO_FASTRESUME", "AFL_SAN_ABSTRACTION", "AFL_LLVM_ONLY_FSRV",
     "AFL_GCC_ONLY_FRSV", "AFL_SAN_RECOVER",
     "AFL_PRELOAD_DISCRIMINATE_FORKSERVER_PARENT", "AFL_FORKSRV_UID",
-    "AFL_FORKSRV_GID", "AFL_COMPILER_LAUNCHER", NULL};
+    "AFL_FORKSRV_GID", "AFL_COMPILER_LAUNCHER",
+#ifdef __AFL_CODE_COVERAGE
+    "AFL_DUMP_PC_MAP",
+#endif
+    NULL
+
+};
 
 extern char *afl_environment_variables[];
 

--- a/include/types.h
+++ b/include/types.h
@@ -249,5 +249,20 @@ typedef int128_t s128;
   #endif
 #endif
 
+/* Module map entry for tracking loaded modules and their edge ranges */
+#ifdef __AFL_CODE_COVERAGE
+  #define MAX_AFL_MODULES 256
+
+typedef struct module_entry {
+
+  char name[4096];                                    /* Module name (path) */
+  u32  start_id;                                           /* First edge ID */
+  u32  stop_id;                                             /* Last edge ID */
+  u8   loaded;                                          /* Module is loaded */
+
+} module_entry_t;
+
+#endif                                               /* __AFL_CODE_COVERAGE */
+
 #endif                                                   /* ! _HAVE_TYPES_H */
 

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -237,6 +237,9 @@ afl_module_info_t *__afl_module_info = NULL;
 u32        __afl_pcmap_size = 0;
 uintptr_t *__afl_pcmap_ptr = NULL;
 
+u32             __afl_modmap_size = 0;
+module_entry_t *__afl_modmap_ptr = NULL;
+
 typedef struct {
 
   uintptr_t start;
@@ -906,6 +909,25 @@ static void __afl_map_shm(void) {
 
   }
 
+  char *modmap_id_str = getenv("__AFL_MODMAP_SHM_ID");
+
+  if (modmap_id_str) {
+
+    // Allocate space for module_entry_t array
+    __afl_modmap_size = MAX_AFL_MODULES;
+    u32 shm_id = atoi(modmap_id_str);
+
+    __afl_modmap_ptr = (module_entry_t *)shmat(shm_id, NULL, 0);
+
+    if (__afl_debug) {
+
+      fprintf(stderr, "DEBUG: Received %p via shmat for modmap (%u entries)\n",
+              __afl_modmap_ptr, __afl_modmap_size);
+
+    }
+
+  }
+
 #endif  // __AFL_CODE_COVERAGE
 
   if (!__afl_cmp_map && getenv("AFL_CMPLOG_DEBUG")) {
@@ -935,6 +957,14 @@ static void __afl_unmap_shm(void) {
     shmdt((void *)__afl_pcmap_ptr);
     __afl_pcmap_ptr = NULL;
     __afl_pcmap_size = 0;
+
+  }
+
+  if (__afl_modmap_size) {
+
+    shmdt((void *)__afl_modmap_ptr);
+    __afl_modmap_ptr = NULL;
+    __afl_modmap_size = 0;
 
   }
 
@@ -1737,6 +1767,70 @@ u32 locate_in_pcs(uintptr_t needle, u32 *index) {
 
 }
 
+/* Write a single module's info to the modmap shared memory */
+
+static void afl_write_mod_map(const char *name, u32 start_id, u32 stop_id) {
+
+  if (!__afl_modmap_ptr || !__afl_modmap_size) { return; }
+
+  // First, check if module already exists
+  for (u32 i = 0; i < __afl_modmap_size; i++) {
+
+    if (__afl_modmap_ptr[i].loaded &&
+        strcmp(__afl_modmap_ptr[i].name, name) == 0) {
+
+      // Module already exists, skip adding
+      if (__afl_debug) {
+
+        fprintf(
+            stderr,
+            "DEBUG: Module already in modmap, skipping: %s (existing: %u-%u, "
+            "new: %u-%u)\n",
+            name, __afl_modmap_ptr[i].start_id, __afl_modmap_ptr[i].stop_id,
+            start_id, stop_id);
+
+      }
+
+      return;
+
+    }
+
+  }
+
+  // Find first empty slot
+  for (u32 i = 0; i < __afl_modmap_size; i++) {
+
+    if (!__afl_modmap_ptr[i].loaded) {
+
+      // Copy module info to this slot
+      strncpy(__afl_modmap_ptr[i].name, name,
+              sizeof(__afl_modmap_ptr[i].name) - 1);
+      __afl_modmap_ptr[i].name[sizeof(__afl_modmap_ptr[i].name) - 1] = '\0';
+      __afl_modmap_ptr[i].start_id = start_id;
+      __afl_modmap_ptr[i].stop_id = stop_id;
+      __afl_modmap_ptr[i].loaded = 1;
+
+      if (__afl_debug) {
+
+        fprintf(stderr, "DEBUG: Added module to modmap[%u]: %s %u %u\n", i,
+                name, start_id, stop_id);
+
+      }
+
+      return;
+
+    }
+
+  }
+
+  // No empty slots available
+  fprintf(stderr,
+          "ERROR: Module map is full (%u entries). Cannot add module: %s\n",
+          __afl_modmap_size, name);
+  abort();
+
+}
+
 void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
                               const uintptr_t *pcs_end) {
 
@@ -1832,6 +1926,10 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
     if (!*mod_info->stop) { continue; }
 
+    // Save the module edge IDs in case they are nulled out by filtering
+    u32 mod_start_id = *mod_info->start;
+    u32 mod_stop_id = *mod_info->stop;
+
     u32 in_module_index = 0;
 
     while (start < end) {
@@ -1917,7 +2015,17 @@ void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
 
     }
 
+    // Mark as mapped when pcmap buffer is ready
     if (__afl_pcmap_ptr) { mod_info->mapped = 1; }
+
+    // Write modmap only if module is marked as mapped (i.e., fully processed)
+    // Use original edge IDs before filtering modified them
+    if (mod_info->mapped && __afl_modmap_ptr && __afl_modmap_size &&
+        mod_info->stop) {
+
+      afl_write_mod_map(mod_info->name, mod_start_id, mod_stop_id);
+
+    }
 
     if (__afl_debug) {
 

--- a/src/afl-fuzz-coverage.c
+++ b/src/afl-fuzz-coverage.c
@@ -1,0 +1,171 @@
+/*
+   american fuzzy lop++ - code coverage related utilities.
+   ----------------------------------------------
+
+   Originally written by Michal Zalewski
+
+   Now maintained by Marc Heuse <mh@mh-sec.de>,
+                        Heiko Eissfeldt <heiko.eissfeldt@hexco.de> and
+                        Andrea Fioraldi <andreafioraldi@gmail.com>
+
+   Copyright 2016, 2017 Google Inc. All rights reserved.
+   Copyright 2019-2024 AFLplusplus Project. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+   Edge to PC and module tracking.
+
+ */
+
+#include "afl-fuzz.h"
+
+#ifdef __AFL_CODE_COVERAGE
+
+/* Initialize the pc map shared memory for tracking edge ID to PC */
+
+void afl_pcmap_init(afl_state_t *afl, u32 map_size) {
+
+  size_t pcmap_size = map_size * sizeof(uintptr_t);
+
+  OKF("Creating PCMAP shared memory (%u entries, %zu bytes)", map_size,
+      pcmap_size);
+
+  u8 *pcmap = afl_shm_init(&afl->shm_pcmap, pcmap_size, 1, afl->perm,
+                           afl->chown_needed ? afl->fsrv.gid : -1);
+
+  if (!pcmap) { FATAL("BUG: Zero return from afl_shm_init."); }
+
+  memset(afl->shm_pcmap.map, 0, pcmap_size);
+
+  #ifdef USEMMAP
+  setenv("__AFL_PCMAP_SHM_ID", afl->shm_pcmap.g_shm_file_path, 1);
+  OKF("PCMAP ready at %s", afl->shm_pcmap.g_shm_file_path);
+  #else
+  u8 *shm_str = alloc_printf("%d", afl->shm_pcmap.shm_id);
+  setenv("__AFL_PCMAP_SHM_ID", shm_str, 1);
+  ck_free(shm_str);
+  OKF("PCMAP ready with ID %d", afl->shm_pcmap.shm_id);
+  #endif
+
+}
+
+/* Resize the edge map when the map size changes */
+
+void afl_pcmap_resize(afl_state_t *afl, u32 new_map_size) {
+
+  if (afl->shm_pcmap.map) { afl_shm_deinit(&afl->shm_pcmap); }
+
+  afl_pcmap_init(afl, new_map_size);
+
+}
+
+/* Initialize the module map shared memory for exporting module info */
+
+void afl_modmap_init(afl_state_t *afl) {
+
+  size_t modmap_size = sizeof(module_entry_t) * MAX_AFL_MODULES;
+
+  OKF("Creating MODMAP shared memory (%zu bytes, %d entries)", modmap_size,
+      MAX_AFL_MODULES);
+
+  u8 *modmap = afl_shm_init(&afl->shm_modmap, modmap_size, 1, afl->perm,
+                            afl->chown_needed ? afl->fsrv.gid : -1);
+
+  if (!modmap) { FATAL("BUG: Zero return from afl_shm_init."); }
+
+  memset(afl->shm_modmap.map, 0, modmap_size);
+
+  #ifdef USEMMAP
+  setenv("__AFL_MODMAP_SHM_ID", afl->shm_modmap.g_shm_file_path, 1);
+  OKF("MODMAP ready at %s", afl->shm_modmap.g_shm_file_path);
+  #else
+  u8 *shm_str = alloc_printf("%d", afl->shm_modmap.shm_id);
+  setenv("__AFL_MODMAP_SHM_ID", shm_str, 1);
+  ck_free(shm_str);
+  OKF("MODMAP ready with ID %d", afl->shm_modmap.shm_id);
+  #endif
+
+}
+
+/* Write PC map to disk with edge ID to PC mappings */
+
+void afl_dump_pc_map(afl_state_t *afl) {
+
+  if (!afl->shm_pcmap.map) { return; }
+
+  char pcmap_fn[4096];
+  snprintf(pcmap_fn, sizeof(pcmap_fn), "%s/pcmap.dump", afl->out_dir);
+
+  FILE *pcmap_fd;
+  if ((pcmap_fd = fopen(pcmap_fn, "w")) == NULL) {
+
+    PFATAL("could not create '%s'", pcmap_fn);
+
+  }
+
+  uintptr_t *pcmap = (uintptr_t *)afl->shm_pcmap.map;
+  u32        entry_count = 0;
+
+  for (u32 i = 0; i < afl->fsrv.real_map_size; i++) {
+
+    if (pcmap[i] != 0) {
+
+      fprintf(pcmap_fd, "%u 0x%lx\n", i, (unsigned long)pcmap[i]);
+      entry_count++;
+
+    }
+
+  }
+
+  fclose(pcmap_fd);
+  OKF("Wrote %u PC map entries to %s", entry_count, pcmap_fn);
+
+}
+
+/* Write module map to disk from shared memory */
+
+void afl_dump_module_map(afl_state_t *afl) {
+
+  if (!afl->shm_modmap.map) { return; }
+
+  char mfn[4096];
+  snprintf(mfn, sizeof(mfn), "%s/modinfo.txt", afl->out_dir);
+
+  FILE *modmap_fd;
+  if ((modmap_fd = fopen(mfn, "w")) == NULL) {
+
+    PFATAL("could not create '%s'", mfn);
+
+  }
+
+  module_entry_t *modmap = (module_entry_t *)afl->shm_modmap.map;
+  u32             entry_count = 0;
+
+  for (u32 i = 0; i < MAX_AFL_MODULES; i++) {
+
+    if (modmap[i].loaded) {
+
+      fprintf(modmap_fd, "%s %u %u\n", modmap[i].name, modmap[i].start_id,
+              modmap[i].stop_id);
+      entry_count++;
+
+    }
+
+  }
+
+  fclose(modmap_fd);
+
+  if (entry_count > 0) {
+
+    OKF("Wrote %u module entries to %s", entry_count, mfn);
+
+  }
+
+}
+
+#endif  // __AFL_CODE_COVERAGE
+

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -2610,6 +2610,17 @@ int main(int argc, char **argv_orig, char **envp) {
       afl_shm_init(&afl->shm, afl->fsrv.map_size, afl->non_instrumented_mode,
                    afl->perm, afl->chown_needed ? afl->fsrv.gid : -1);
 
+  #ifdef __AFL_CODE_COVERAGE
+  // Initialize pcmap and modmap before any forkserver starts
+  if (getenv("AFL_DUMP_PC_MAP")) {
+
+    afl_pcmap_init(afl, afl->fsrv.map_size);
+    afl_modmap_init(afl);
+
+  }
+
+  #endif
+
   if (!afl->non_instrumented_mode && !afl->unicorn_mode &&
       !afl->fsrv.frida_mode && !afl->fsrv.cs_mode &&
       !afl->afl_env.afl_skip_bin_check) {
@@ -2640,6 +2651,11 @@ int main(int argc, char **argv_orig, char **envp) {
           afl_shm_init(&afl->shm, new_map_size, afl->non_instrumented_mode,
                        afl->perm, afl->chown_needed ? afl->fsrv.gid : -1);
       setenv("AFL_NO_AUTODICT", "1", 1);  // loaded already
+
+  #ifdef __AFL_CODE_COVERAGE
+      if (getenv("AFL_DUMP_PC_MAP")) { afl_pcmap_resize(afl, new_map_size); }
+  #endif
+
       afl_fsrv_start(&afl->fsrv, afl->argv, &afl->stop_soon,
                      afl->afl_env.afl_debug_child);
 
@@ -2855,6 +2871,11 @@ int main(int argc, char **argv_orig, char **envp) {
           afl_shm_init(&afl->shm, new_map_size, afl->non_instrumented_mode,
                        afl->perm, afl->chown_needed ? afl->fsrv.gid : -1);
       afl->cmplog_fsrv.trace_bits = afl->fsrv.trace_bits;
+
+  #ifdef __AFL_CODE_COVERAGE
+      if (getenv("AFL_DUMP_PC_MAP")) { afl_pcmap_resize(afl, new_map_size); }
+  #endif
+
       afl_fsrv_start(&afl->fsrv, afl->argv, &afl->stop_soon,
                      afl->afl_env.afl_debug_child);
       afl_fsrv_start(&afl->cmplog_fsrv, afl->argv, &afl->stop_soon,
@@ -3659,6 +3680,13 @@ stop_fuzzing:
     // map in length.
     fwrite(afl->fsrv.persistent_trace_bits, 1, afl->fsrv.real_map_size, cov_fd);
     fclose(cov_fd);
+
+  }
+
+  if (getenv("AFL_DUMP_PC_MAP")) {
+
+    afl_dump_pc_map(afl);
+    afl_dump_module_map(afl);
 
   }
 

--- a/utils/unstable_edges/README.md
+++ b/utils/unstable_edges/README.md
@@ -1,0 +1,71 @@
+# Unstable Edge Symbolization
+
+This utility helps identify and symbolize unstable edges discovered during fuzzing.
+
+## Prerequisites
+
+This utility requires AFL++ to be built with code coverage support enabled. Build AFL++ by invoking:
+
+```
+CODE_COVERAGE=1 make
+```
+
+This enables a buffer for tracking both edges to PC addresses as well as loaded modules and the edge ID ranges for each module.
+
+## Running AFL++
+
+- To capture unstable edge information, you must run `afl-fuzz` with `AFL_DEBUG=1`.
+- To dump both the PC map and module map, you must run `afl-fuzz` with `AFL_DUMP_PC_MAP=1`.
+
+```
+AFL_DEBUG=1 AFL_DUMP_PC_MAP=1 afl-fuzz -i input -o output -- /path/to/target
+```
+
+## Using symbolize_unstable.py
+
+Once you have completed a fuzzing run with the above configuration, the output directory will contain three files needed for symbolization:
+
+- `fuzzer_stats` - Contains the list of unstable edge IDs in the `var_bytes` field
+- `pcmap.dump` - Maps edge IDs to program counter addresses
+- `modinfo.txt` - Maps edge ID ranges to binary modules
+
+Run the symbolization script by providing the path to the AFL++ output directory:
+
+```
+python3 symbolize_unstable.py /path/to/output/default/
+```
+
+## Example Input Files
+
+### fuzzer_stats (partial)
+```
+...
+var_bytes         : 42 191 232
+```
+
+### pcmap.dump
+```
+42 0x1a3f20
+191 0x3c5d00
+232 0x6f89d0
+```
+
+### modinfo.txt
+```
+/usr/lib/a.so 5   100
+/usr/lib/b.so 101 200
+/usr/lib/c.so 201 300
+```
+
+## Example Output
+
+```
+42  0x1a3f20 /src/a/a.c:245
+191 0x3c5d00 /src/b/b.c:67
+232 0x6f89d0 /usr/c/c.c:412
+```
+
+Each line shows:
+- Edge ID
+- Program counter address (hex)
+- Source location (file:line)

--- a/utils/unstable_edges/symbolize_unstable.py
+++ b/utils/unstable_edges/symbolize_unstable.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Symbolize unstable edges using pcmap and module info.
+
+Reads var_bytes from fuzzer_stats, looks up edge IDs in pcmap.dump,
+and symbolizes each unstable edge using modinfo.txt.
+"""
+
+import sys
+import subprocess
+import argparse
+import logging
+from pathlib import Path
+from multiprocessing import Pool, cpu_count
+from functools import partial
+
+LOG = logging.getLogger(__name__)
+
+
+def parse_modinfo(modinfo_path: Path):
+    """Extract list of modules names as well as start and stop edge IDs"""
+    modules = []
+    with open(modinfo_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            # Format: /path/to/module.so 7150 7648
+            if len(parts) != 3:
+                continue
+            module_path = parts[0]
+            start_id = int(parts[1])
+            stop_id = int(parts[2])
+            modules.append((module_path, start_id, stop_id))
+    return modules
+
+
+def parse_var_bytes(fuzzer_stats_path: Path):
+    """Extract unstable edges from fuzzer_stats."""
+    with open(fuzzer_stats_path, "r") as f:
+        for line in f:
+            if line.startswith("var_bytes"):
+                # Format: var_bytes        : 0 732045 732046 2016001 ...
+                parts = line.split(":", 1)
+                if len(parts) == 2:
+                    edge_ids_str = parts[1].strip()
+                    if edge_ids_str:
+                        return set(int(e) for e in edge_ids_str.split())
+    return set()
+
+
+def parse_pcmap(pcmap_path: Path):
+    """Parse pcmap.dump and return dict of edge_id => pc_offset."""
+    pcmap = {}
+    with open(pcmap_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            # Format: 5 0x15df17
+            if len(parts) != 2:
+                continue
+            edge_id = int(parts[0])
+            pc_offset = int(parts[1], 16)
+            pcmap[edge_id] = pc_offset
+    return pcmap
+
+
+def find_module_for_edge(edge_id: int, modules: list[tuple[str, int, int]]):
+    """Find module for the given edge_id."""
+    for module_path, start_id, stop_id in modules:
+        if start_id <= edge_id <= stop_id:
+            return module_path
+    return None
+
+
+def symbolize_address(module_path: str, pc_offset: int):
+    """Call llvm-symbolizer to symbolize a PC offset in a module."""
+    try:
+        result = subprocess.run(
+            ["llvm-symbolizer", f"--obj={module_path}", f"0x{pc_offset:x}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            lines = result.stdout.strip().split("\n")
+            # llvm-symbolizer outputs function name on first line, location on second
+            # For inlined functions, it outputs multiple pairs
+            # Just take the last location (innermost)
+            if len(lines) >= 2:
+                location = lines[-1]
+                return (
+                    location
+                    if location and location != "??:0" and location != "??:?"
+                    else None
+                )
+        return None
+    except Exception:
+        return None
+
+
+def process_edge(edge_data: tuple, pcmap: dict, modules: list):
+    """Process a single edge for symbolization."""
+    edge_id = edge_data
+
+    if edge_id not in pcmap:
+        return (edge_id, None, "not_in_pcmap")
+
+    pc_offset = pcmap[edge_id]
+    module_name = find_module_for_edge(edge_id, modules)
+
+    if not module_name:
+        return (edge_id, pc_offset, "no_module")
+
+    location = symbolize_address(module_name, pc_offset)
+
+    if location:
+        return (edge_id, pc_offset, location)
+    else:
+        return (edge_id, pc_offset, f"failed:{module_name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Symbolize unstable edges from AFL++ fuzzer output"
+    )
+    parser.add_argument(
+        "dump_path",
+        type=Path,
+        help="Path to AFL output directory (i.e. ./output/default/)",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=cpu_count(),
+        help=f"Number of parallel jobs for symbolization (default: {cpu_count()})",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+    if not args.dump_path.is_dir():
+        parser.error("AFL output directory does not exist")
+
+    for filename in ["pcmap.dump", "modinfo.txt", "fuzzer_stats"]:
+        if not (args.dump_path / filename).is_file():
+            parser.error(f"Unable to locate {filename} in output directory")
+
+    unstable_edges = parse_var_bytes(args.dump_path / "fuzzer_stats")
+    if not unstable_edges:
+        LOG.warning("No unstable edges found in fuzzer_stats")
+        sys.exit(0)
+
+    pcmap = parse_pcmap(args.dump_path / "pcmap.dump")
+    modules = parse_modinfo(args.dump_path / "modinfo.txt")
+
+    LOG.info(f"Symbolizing {len(unstable_edges)} unstable edges using {args.jobs} workers...")
+
+    worker_func = partial(process_edge, pcmap=pcmap, modules=modules)
+
+    with Pool(processes=args.jobs) as pool:
+        results = pool.map(worker_func, sorted(unstable_edges))
+
+    # Process results in order
+    for edge_id, pc_offset, result in sorted(results, key=lambda x: x[0]):
+        if result == "not_in_pcmap":
+            LOG.warning(f"Could not find edge {edge_id} in pcmap")
+        elif result == "no_module":
+            LOG.warning(
+                f"Could not find module for edge {edge_id} - PC: 0x{pc_offset:x}"
+            )
+        elif result.startswith("failed:"):
+            module_name = result.split(":", 1)[1]
+            LOG.warning(
+                f"Could not symbolize edge {edge_id} - PC: 0x{pc_offset:x}, Module: {module_name})"
+            )
+        else:
+            print(f"{edge_id} 0x{pc_offset:x} {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds support for symbolizing unstable edges.

By setting the `AFL_DUMP_PC_MAP` environment variable, AFL++ will now write two files on exit:
- `pcmap.dump`: Maps edge IDs to relative PC addresses
- `modinfo.txt`: Maps module names to their edge ID ranges (start/stop)

A Python utility script (`utils/unstable_edges/symbolize_unstable.py`) uses these files in combination with the `var_bytes` field in `fuzzer_stats` to convert edge IDs to symbols.
