### PR TITLE
forkserver: warn when target calls exec*()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ Here is some information to get you started:
   default configuration on Google's
   [fuzzbench](https://github.com/google/fuzzbench/tree/master/fuzzers/aflplusplus).
 
+
+## Instrumentation Modes (Beginner Overview)
+
+AFL++ relies on instrumentation to observe program execution and guide fuzzing
+toward new code paths.
+
+Depending on your setup and access to source code, AFL++ supports multiple
+instrumentation modes:
+
+### Compiler-based Instrumentation (Default)
+* Recommended for most users
+* Requires access to the target’s source code
+* Provides the fastest and most accurate coverage feedback
+
+### QEMU Mode
+* Designed for binary-only targets
+* Does not require recompilation
+* Slower than compiler-based instrumentation but highly flexible
+
+### Unicorn Mode
+* Intended for emulation and firmware-like targets
+* Useful for fuzzing isolated functions or embedded code
+* Requires additional configuration and advanced setup
+
+
+
 ## Building and installing AFL++
 
 To have AFL++ easily available with everything compiled, pull the image directly

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -2249,12 +2249,18 @@ fsrv_run_result_t __attribute__((hot)) afl_fsrv_run_target(
 
   /* Report outcome to caller. */
 
-  /* Was the run unsuccessful? */
-  if (unlikely(*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG)) {
+/* Was the run unsuccessful? */
+if (unlikely(*(u32 *)fsrv->trace_bits == EXEC_FAIL_SIG)) {
 
-    return FSRV_RUN_ERROR;
+  WARNF(
+      "Target called exec*() inside an instrumented binary. "
+      "This breaks AFL++ forkserver assumptions. "
+      "Please fuzz the final executable or disable the forkserver.");
 
-  }
+  return FSRV_RUN_ERROR;
+
+}
+
 
   /* Did we timeout? */
   if (unlikely(fsrv->last_run_timed_out)) {


### PR DESCRIPTION
### Problem
If an instrumented target calls exec*(), AFL++ forkserver assumptions break,
often leading to confusing failures without a clear diagnostic.

### Solution
Detect EXEC_FAIL_SIG in afl_fsrv_run_target() and emit a WARNF message
explaining the issue before returning an execution error.

### Impact
- Improves diagnostics for misconfigured targets
- No functional change for valid targets
- Negligible performance impact

### Testing
- Built AFL++
- Tested with a target that calls execv()
