### PR TITLE
Add warning when -f flag is used without -i or -I in afl-showmap

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1376,6 +1376,12 @@ int main(int argc, char **argv_orig, char **envp) {
 
   }
 
+  if (at_file && !in_dir && !in_filelist) {
+
+    WARNF("Using -f without -i or -I has no effect");
+
+  }
+
   if (fsrv->qemu_mode && !mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_QEMU; }
   if (unicorn_mode && !mem_limit_given) { fsrv->mem_limit = MEM_LIMIT_UNICORN; }
 


### PR DESCRIPTION
https://github.com/AFLplusplus/AFLplusplus/pull/2661#issuecomment-3760275664