### PR TITLE
add afl-cmin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ afl-clang-lto
 afl-clang-lto++
 afl-clang-lto++.8
 afl-clang-lto.8
+afl-cmin
 afl-cmin.8
 afl-cmin.bash.8
 afl-cmin.py.8


### PR DESCRIPTION
`afl-cmin` binary is created since e9177bb462b46e912e68e20f0bb63b90f76abcb2, add it to `.gitignore`