### PR TITLE
Fix afl-showmap for AFL_NO_FORKSRV

### DIFF
--- a/include/forkserver.h
+++ b/include/forkserver.h
@@ -275,6 +275,9 @@ fsrv_run_result_t afl_fsrv_run_target(afl_forkserver_t *fsrv, u32 timeout,
 void              afl_fsrv_killall(void);
 void              afl_fsrv_deinit(afl_forkserver_t *fsrv);
 void              afl_fsrv_kill(afl_forkserver_t *fsrv);
+void afl_fsrv_resize_mapsize(afl_forkserver_t *fsrv, void *shm_p,
+                        char **use_argv, u32 map_size, volatile u8 *stop_soon,
+                        bool unicorn_mode);
 
 #ifdef __linux__
 void nyx_load_target_hash(afl_forkserver_t *fsrv);

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -969,14 +969,22 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     /* TODO: Come up with some nice way to initialize this all */
 
-    if (fsrv->init_child_func != fsrv_exec_child) {
+    if (fsrv->init_child_func == afl_fauxsrv_execv) {
+
+      if (!be_quiet) { ACTF("Faux forkserver already initialized"); }
+
+    }
+    else if (fsrv->init_child_func != fsrv_exec_child) {
 
       FATAL("Different forkserver not compatible with fauxserver");
 
+    } else {
+
+      fsrv->init_child_func = afl_fauxsrv_execv;
+      
     }
 
     if (!be_quiet) { ACTF("Using AFL++ faux forkserver..."); }
-    fsrv->init_child_func = afl_fauxsrv_execv;
 
   }
 

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -35,6 +35,7 @@
 #include "common.h"
 #include "list.h"
 #include "forkserver.h"
+#include "sharedmem.h"
 #include "hash.h"
 
 #include <stdio.h>
@@ -1887,6 +1888,83 @@ u32 afl_fsrv_get_mapsize(afl_forkserver_t *fsrv, char **argv,
   afl_fsrv_start(fsrv, argv, stop_soon_p, debug_child_output);
   return fsrv->map_size;
 
+}
+
+/* Get mapsize from fsrv and resize if larger than DEFAULT_SHMEM_SIZE */
+
+void afl_fsrv_resize_mapsize(afl_forkserver_t *fsrv, void *shm_p, char **use_argv,
+                        u32 map_size, volatile u8 *stop_soon, bool unicorn_mode) {
+  if (!fsrv->cs_mode && !fsrv->qemu_mode && !unicorn_mode) {
+
+      if (map_size <= DEFAULT_SHMEM_SIZE) {
+
+        fsrv->map_size = DEFAULT_SHMEM_SIZE;  // dummy temporary value
+
+      } else {
+
+        validate_map_size(map_size);
+        fsrv->map_size = map_size;
+
+      }
+
+      char vbuf[16];
+      snprintf(vbuf, sizeof(vbuf), "%u", fsrv->map_size);
+      setenv("AFL_MAP_SIZE", vbuf, 1);
+
+      u32 new_map_size =
+          afl_fsrv_get_mapsize(fsrv, use_argv, stop_soon,
+                              (get_afl_env("AFL_DEBUG_CHILD") ||
+                                get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
+                                  ? 1
+                                  : 0);
+
+      if (new_map_size) {
+
+        // only reinitialize when it makes sense
+        if (map_size < new_map_size) {
+
+          if (!be_quiet)
+            ACTF("Acquired new map size for target: %u bytes\n", new_map_size);
+
+  #ifdef __linux__
+          /* no need to terminate the nyx runner */
+          if (!fsrv->nyx_mode) {
+
+  #endif
+            sharedmem_t *shm = (sharedmem_t*)shm_p;
+            afl_shm_deinit(shm);
+            afl_fsrv_kill(fsrv);
+            fsrv->map_size = new_map_size;
+            fsrv->trace_bits =
+                afl_shm_init(shm, new_map_size, 0, DEFAULT_PERMISSION, -1);
+            afl_fsrv_start(fsrv, use_argv, stop_soon,
+                          (get_afl_env("AFL_DEBUG_CHILD") ||
+                            get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
+                              ? 1
+                              : 0);
+  #ifdef __linux__
+
+          }
+
+  #endif
+
+        }
+
+        map_size = new_map_size;
+
+      }
+
+      fsrv->map_size = map_size;
+
+    } else {
+
+      afl_fsrv_start(fsrv, use_argv, stop_soon,
+                    (get_afl_env("AFL_DEBUG_CHILD") ||
+                      get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
+                        ? 1
+                        : 0);
+
+    }
 }
 
 /* Delete the current testcase and write the buf to the testcase file */

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1766,10 +1766,10 @@ int main(int argc, char **argv_orig, char **envp) {
                                  ? SIGKILL
                                  : SIGTERM);
 
+  u32 save_be_quiet = be_quiet;
+  be_quiet = !debug;
   if (!fsrv->cs_mode && !fsrv->qemu_mode && !unicorn_mode) {
 
-    u32 save_be_quiet = be_quiet;
-    be_quiet = !debug;
     if (map_size <= DEFAULT_SHMEM_SIZE) {
 
       fsrv->map_size = DEFAULT_SHMEM_SIZE;  // dummy temporary value
@@ -1791,13 +1791,11 @@ int main(int argc, char **argv_orig, char **envp) {
                               get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
                                  ? 1
                                  : 0);
-    be_quiet = save_be_quiet;
 
     if (new_map_size) {
 
       // only reinitialize when it makes sense
-      if (map_size < new_map_size ||
-          (new_map_size > map_size && new_map_size - map_size >= MAP_SIZE)) {
+      if (map_size < new_map_size) {
 
         if (!be_quiet)
           ACTF("Acquired new map size for target: %u bytes\n", new_map_size);
@@ -1812,6 +1810,11 @@ int main(int argc, char **argv_orig, char **envp) {
           fsrv->map_size = new_map_size;
           fsrv->trace_bits =
               afl_shm_init(&shm, new_map_size, 0, DEFAULT_PERMISSION, -1);
+           afl_fsrv_start(fsrv, use_argv, &stop_soon,
+                         (get_afl_env("AFL_DEBUG_CHILD") ||
+                          get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
+                            ? 1
+                            : 0);
 #ifdef __linux__
 
         }
@@ -1835,6 +1838,7 @@ int main(int argc, char **argv_orig, char **envp) {
                        : 0);
 
   }
+  be_quiet = save_be_quiet;
 
   /* Input streaming mode - read inputs from stdin, write coverage to stdout */
   if (streaming_mode) {

--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -1768,76 +1768,9 @@ int main(int argc, char **argv_orig, char **envp) {
 
   u32 save_be_quiet = be_quiet;
   be_quiet = !debug;
-  if (!fsrv->cs_mode && !fsrv->qemu_mode && !unicorn_mode) {
 
-    if (map_size <= DEFAULT_SHMEM_SIZE) {
+  afl_fsrv_resize_mapsize(fsrv, &shm, use_argv, map_size, &stop_soon, unicorn_mode);
 
-      fsrv->map_size = DEFAULT_SHMEM_SIZE;  // dummy temporary value
-
-    } else {
-
-      validate_map_size(map_size);
-      fsrv->map_size = map_size;
-
-    }
-
-    char vbuf[16];
-    snprintf(vbuf, sizeof(vbuf), "%u", fsrv->map_size);
-    setenv("AFL_MAP_SIZE", vbuf, 1);
-
-    u32 new_map_size =
-        afl_fsrv_get_mapsize(fsrv, use_argv, &stop_soon,
-                             (get_afl_env("AFL_DEBUG_CHILD") ||
-                              get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                                 ? 1
-                                 : 0);
-
-    if (new_map_size) {
-
-      // only reinitialize when it makes sense
-      if (map_size < new_map_size) {
-
-        if (!be_quiet)
-          ACTF("Acquired new map size for target: %u bytes\n", new_map_size);
-
-#ifdef __linux__
-        /* no need to terminate the nyx runner */
-        if (!fsrv->nyx_mode) {
-
-#endif
-          afl_shm_deinit(&shm);
-          afl_fsrv_kill(fsrv);
-          fsrv->map_size = new_map_size;
-          fsrv->trace_bits =
-              afl_shm_init(&shm, new_map_size, 0, DEFAULT_PERMISSION, -1);
-           afl_fsrv_start(fsrv, use_argv, &stop_soon,
-                         (get_afl_env("AFL_DEBUG_CHILD") ||
-                          get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                            ? 1
-                            : 0);
-#ifdef __linux__
-
-        }
-
-#endif
-
-      }
-
-      map_size = new_map_size;
-
-    }
-
-    fsrv->map_size = map_size;
-
-  } else {
-
-    afl_fsrv_start(fsrv, use_argv, &stop_soon,
-                   (get_afl_env("AFL_DEBUG_CHILD") ||
-                    get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                       ? 1
-                       : 0);
-
-  }
   be_quiet = save_be_quiet;
 
   /* Input streaming mode - read inputs from stdin, write coverage to stdout */
@@ -2061,4 +1994,3 @@ showmap_done:
   exit(ret);
 
 }
-

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -1535,52 +1535,12 @@ int main(int argc, char **argv_orig, char **envp) {
   (void)check_binary_signatures(fsrv->target_path);
 #endif
 
-  if (!fsrv->qemu_mode && !unicorn_mode) {
+  u32 save_be_quiet = be_quiet;
+  be_quiet = !debug;
 
-    fsrv->map_size = 4194304;  // dummy temporary value
-    u32 new_map_size =
-        afl_fsrv_get_mapsize(fsrv, use_argv, &stop_soon,
-                             (get_afl_env("AFL_DEBUG_CHILD") ||
-                              get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                                 ? 1
-                                 : 0);
+  afl_fsrv_resize_mapsize(fsrv, &shm, use_argv, map_size, &stop_soon, unicorn_mode);
 
-    if (new_map_size) {
-
-      if (map_size < new_map_size ||
-          (new_map_size > map_size && new_map_size - map_size > MAP_SIZE)) {
-
-        if (!be_quiet)
-          ACTF("Acquired new map size for target: %u bytes\n", new_map_size);
-
-        afl_shm_deinit(&shm);
-        afl_fsrv_kill(fsrv);
-        fsrv->map_size = new_map_size;
-        fsrv->trace_bits =
-            afl_shm_init(&shm, new_map_size, 0, DEFAULT_PERMISSION, -1);
-        afl_fsrv_start(fsrv, use_argv, &stop_soon,
-                       (get_afl_env("AFL_DEBUG_CHILD") ||
-                        get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                           ? 1
-                           : 0);
-
-      }
-
-      map_size = new_map_size;
-
-    }
-
-    fsrv->map_size = map_size;
-
-  } else {
-
-    afl_fsrv_start(fsrv, use_argv, &stop_soon,
-                   (get_afl_env("AFL_DEBUG_CHILD") ||
-                    get_afl_env("AFL_DEBUG_CHILD_OUTPUT"))
-                       ? 1
-                       : 0);
-
-  }
+  be_quiet = save_be_quiet;
 
   if (fsrv->support_shmem_fuzz && !fsrv->use_shmem_fuzz)
     shm_fuzz = deinit_shmem(fsrv, shm_fuzz);


### PR DESCRIPTION
Hi!

When using afl-showmap, I realized it doesn't work for `AFL_NO_FORK` mode. 
The problem is that `map_size` is redefined and `afl_fsrv_kill` is called, but after that we don't start fork server again.

In file `afl-tmin.c` the [same code](https://github.com/AFLplusplus/AFLplusplus/blob/dev/src/afl-tmin.c#L1538) that does the same thing, maybe it’s worth combining them into common function, but I’m not sure which file is best to add it to.