### PR TITLE
[Enhancement] Removed print warning "Old fork server..." for fauxserver

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1376,7 +1376,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
     } else {
 
-      if (!fsrv->qemu_mode && !fsrv->cs_mode
+      if (!fsrv->qemu_mode && !fsrv->cs_mode && !fsrv->use_fauxsrv
 #ifdef __linux__
           && !fsrv->nyx_mode
 #endif


### PR DESCRIPTION
Hi!

**Type of PR**: Enhancement
**Purpose of this PR**: Removed print warning "Old fork server model is used by the target, this still works though 1" for fauxserver
**I have tested the changes**: yes


When running afl-shomap with `AFL_NO_FORKSRV` environment variable, we receive a warning message:
`[!] WARNING: Old fork server model is used by the target, this still works though 1`

This affects when we run corpus minimization with several cores.

Example of running without modification code:
```
AFL_NO_FORKSRV=1 afl-cmin.py -i ./input -o ./cmin -m 10240 -t 100000 -T 10 -- /target @@
2026-01-27 14:51:14,819 - INFO - use 10 workers (-T)
search: 78 files [00:00, 311.65 files/s]
2026-01-27 14:51:15,073 - INFO - Found 78 input files in 1 directories
2026-01-27 14:51:15,219 - INFO - Remain 78 files after dedup
2026-01-27 14:51:15,219 - INFO - Sorting files.
2026-01-27 14:51:15,839 - INFO - Setting AFL_MAP_SIZE=1828017
2026-01-27 14:51:15,839 - INFO - Testing the target binary
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
2026-01-27 14:51:21,277 - INFO - ok, 2758 tuples recorded
2026-01-27 14:51:21,288 - INFO - Processing traces
  0% 0/78 [00:00<?, ?it/s][!] WARNING: Old fork server model is used by the target, this still works though 1[!] WARNING: Old fork server model is used by the target, this still works though 1

[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1[!] WARNING: Old fork server model is used by the target, this still works though 1

[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
  1% 1/78 [01:04<1:22:41, 64.44s/it][!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
 10% 8/78 [01:05<09:26,  8.09s/it]  [!] WARNING: Old fork server model is used by the target, this still works though 1
[!] WARNING: Old fork server model is used by the target, this still works though 1
100% 78/78 [01:49<00:00,  1.40s/it]
2026-01-27 14:53:10,582 - INFO - Obtaining trace results
100% 10/10 [00:00<00:00, 28.59it/s]
2026-01-27 14:53:13,560 - INFO - Found 6683 unique tuples across 78 files (78 effective)
2026-01-27 14:53:13,609 - INFO - Processing candidates and writing output
100% 6683/6683 [00:00<00:00, 495834.81it/s]
2026-01-27 14:53:14,479 - INFO - narrowed down to 63 files, saved in "./cmin"
2026-01-27 14:53:14,480 - INFO - Deleting trace files
```

Example of running with modification code:
```
 AFL_NO_FORKSRV=1 afl-cmin.py -i ./input -o ./cmin -m 10240 -t 100000 -T 10 -- /target @@
2026-01-27 14:44:31,764 - INFO - use 10 workers (-T)
search: 78 files [00:00, 464.95 files/s]
2026-01-27 14:44:31,935 - INFO - Found 78 input files in 1 directories
2026-01-27 14:44:32,083 - INFO - Remain 78 files after dedup
2026-01-27 14:44:32,083 - INFO - Sorting files.
2026-01-27 14:44:33,544 - INFO - Setting AFL_MAP_SIZE=1828017
2026-01-27 14:44:33,544 - INFO - Testing the target binary
2026-01-27 14:44:38,823 - INFO - ok, 2758 tuples recorded
2026-01-27 14:44:38,831 - INFO - Processing traces
100% 78/78 [01:54<00:00,  1.47s/it]
2026-01-27 14:46:33,760 - INFO - Obtaining trace results
100% 10/10 [00:00<00:00, 16.47it/s]
2026-01-27 14:46:37,038 - INFO - Found 6686 unique tuples across 78 files (78 effective)
2026-01-27 14:46:37,090 - INFO - Processing candidates and writing output
100% 6686/6686 [00:00<00:00, 565203.09it/s]
2026-01-27 14:46:37,668 - INFO - narrowed down to 63 files, saved in "./cmin"
2026-01-27 14:46:37,668 - INFO - Deleting trace files
```
  
