### PR TITLE
Fix/Improve Cmplog routines LLVM pass

### DIFF
--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -102,7 +102,7 @@ llvmGetPassPluginInfo() {
 bool CmpLogRoutines::hookRtns(Module &M) {
 
   std::vector<CallInst *> calls, llvmStdStd, llvmStdC, gccStdStd, gccStdC,
-      Memcmp, Strcmp, Strncmp, GStrstrLen;
+      Memcmp, Strcmp, Strncmp, GStrstrLen, Memmem;
   LLVMContext &C = M.getContext();
 
   Type *VoidTy = Type::getVoidTy(C);
@@ -258,10 +258,11 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
           // Functions like strstr that return a pointer to the found substring
           // Signature: ptr strstr(ptr haystack, ptr needle)
-          bool isStrstr = (!FuncName.compare("strstr") ||
-                           !FuncName.compare("ap_strcasestr") ||
-                           !FuncName.compare("xmlStrstr") ||
-                           !FuncName.compare("xmlStrcasestr"));
+          bool isStrstr =
+              (!FuncName.compare("strstr") || !FuncName.compare("strcasestr") ||
+               !FuncName.compare("ap_strcasestr") ||
+               !FuncName.compare("xmlStrstr") ||
+               !FuncName.compare("xmlStrcasestr"));
           isStrstr &= FT->getNumParams() == 2 &&
                       FT->getReturnType()->isPointerTy() &&
                       FT->getParamType(0)->isPointerTy() &&
@@ -275,6 +276,25 @@ bool CmpLogRoutines::hookRtns(Module &M) {
                           FT->getParamType(0)->isPointerTy() &&
                           FT->getParamType(1)->isIntegerTy() &&
                           FT->getParamType(2)->isPointerTy();
+
+          // memmem: void* (const void *haystack, size_t haystacklen,
+          //                const void *needle, size_t needlelen)
+          bool isMemmem = (!FuncName.compare("memmem"));
+          isMemmem &= FT->getNumParams() == 4 &&
+                      FT->getReturnType()->isPointerTy() &&
+                      FT->getParamType(0)->isPointerTy() &&
+                      FT->getParamType(1)->isIntegerTy() &&
+                      FT->getParamType(2)->isPointerTy() &&
+                      FT->getParamType(3)->isIntegerTy();
+
+          // strnstr: char* (const char *big, const char *little, size_t len)
+          // BSD-specific function
+          bool isStrnstr = (!FuncName.compare("strnstr"));
+          isStrnstr &= FT->getNumParams() == 3 &&
+                       FT->getReturnType()->isPointerTy() &&
+                       FT->getParamType(0)->isPointerTy() &&
+                       FT->getParamType(1)->isPointerTy() &&
+                       FT->getParamType(2)->isIntegerTy();
 
           bool isGccStdStringStdString =
               Callee->getName().find("__is_charIT_EE7__value") !=
@@ -324,7 +344,8 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
           if (isGccStdStringCString || isGccStdStringStdString ||
               isLlvmStdStringStdString || isLlvmStdStringCString || isMemcmp ||
-              isStrcmp || isStrncmp || isStrstr || isGStrstrLen) {
+              isStrcmp || isStrncmp || isStrstr || isGStrstrLen || isMemmem ||
+              isStrnstr) {
 
             isPtrRtnN = isPtrRtn = false;
 
@@ -335,8 +356,9 @@ bool CmpLogRoutines::hookRtns(Module &M) {
           if (isPtrRtn) { calls.push_back(callInst); }
           if (isMemcmp || isPtrRtnN) { Memcmp.push_back(callInst); }
           if (isStrcmp || isStrstr) { Strcmp.push_back(callInst); }
-          if (isStrncmp) { Strncmp.push_back(callInst); }
+          if (isStrncmp || isStrnstr) { Strncmp.push_back(callInst); }
           if (isGStrstrLen) { GStrstrLen.push_back(callInst); }
+          if (isMemmem) { Memmem.push_back(callInst); }
           if (isGccStdStringStdString) { gccStdStd.push_back(callInst); }
           if (isGccStdStringCString) { gccStdC.push_back(callInst); }
           if (isLlvmStdStringStdString) { llvmStdStd.push_back(callInst); }
@@ -352,7 +374,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
   if (!calls.size() && !gccStdStd.size() && !gccStdC.size() &&
       !llvmStdStd.size() && !llvmStdC.size() && !Memcmp.size() &&
-      !Strcmp.size() && !Strncmp.size() && !GStrstrLen.size())
+      !Strcmp.size() && !Strncmp.size() && !GStrstrLen.size() && !Memmem.size())
     return false;
 
   /*
@@ -660,6 +682,48 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     args.push_back(v2Pcasted);
 
     IRB.CreateCall(cmplogHookFnStr, args);
+
+    // errs() << callInst->getCalledFunction()->getName() << "\n";
+
+  }
+
+  // memmem: void* (const void *haystack, size_t haystacklen,
+  //                const void *needle, size_t needlelen)
+  // Extract arg0 (haystack), arg2 (needle), arg3 (needlelen)
+  for (auto &callInst : Memmem) {
+
+    Value *v1P = callInst->getArgOperand(0),    // haystack
+        *v2P = callInst->getArgOperand(2),      // needle
+            *v3P = callInst->getArgOperand(3);  // needlelen
+
+    IRBuilder<> IRB2(callInst->getParent());
+    IRB2.SetInsertPoint(callInst);
+
+    LoadInst *CmpPtr =
+        IRB2.CreateLoad(PointerType::get(Int8Ty, 0), AFLCmplogPtr);
+    CmpPtr->setMetadata(M.getMDKindID("nosanitize"),
+#if LLVM_MAJOR >= 20
+                        MDNode::get(C, {}));
+#else
+                        MDNode::get(C, None));
+#endif
+    auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
+    auto ThenTerm = SplitBlockAndInsertIfThen(is_not_null, callInst, false);
+
+    IRBuilder<> IRB(ThenTerm);
+
+    std::vector<Value *> args;
+    Value               *v1Pcasted = IRB.CreatePointerCast(v1P, i8PtrTy);
+    Value               *v2Pcasted = IRB.CreatePointerCast(v2P, i8PtrTy);
+    Value               *v3Pbitcast = IRB.CreateBitCast(
+        v3P, IntegerType::get(C, v3P->getType()->getPrimitiveSizeInBits()));
+    Value *v3Pcasted =
+        IRB.CreateIntCast(v3Pbitcast, IntegerType::get(C, 64), false);
+    args.push_back(v1Pcasted);
+    args.push_back(v2Pcasted);
+    args.push_back(v3Pcasted);
+
+    IRB.CreateCall(cmplogHookFnN, args);
 
     // errs() << callInst->getCalledFunction()->getName() << "\n";
 

--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -102,7 +102,7 @@ llvmGetPassPluginInfo() {
 bool CmpLogRoutines::hookRtns(Module &M) {
 
   std::vector<CallInst *> calls, llvmStdStd, llvmStdC, gccStdStd, gccStdC,
-      Memcmp, Strcmp, Strncmp;
+      Memcmp, Strcmp, Strncmp, GStrstrLen;
   LLVMContext &C = M.getContext();
 
   Type *VoidTy = Type::getVoidTy(C);
@@ -230,11 +230,6 @@ bool CmpLogRoutines::hookRtns(Module &M) {
                !FuncName.compare("Curl_strcasecompare") ||
                !FuncName.compare("Curl_safe_strcasecompare") ||
                !FuncName.compare("cmsstrcasecmp") ||
-               !FuncName.compare("strstr") ||
-               !FuncName.compare("g_strstr_len") ||
-               !FuncName.compare("ap_strcasestr") ||
-               !FuncName.compare("xmlStrstr") ||
-               !FuncName.compare("xmlStrcasestr") ||
                !FuncName.compare("g_str_has_prefix") ||
                !FuncName.compare("g_str_has_suffix"));
           isStrcmp &=
@@ -260,6 +255,26 @@ bool CmpLogRoutines::hookRtns(Module &M) {
               FT->getParamType(0) ==
                   IntegerType::getInt8Ty(M.getContext())->getPointerTo(0) &&
               FT->getParamType(2)->isIntegerTy();
+
+          // Functions like strstr that return a pointer to the found substring
+          // Signature: ptr strstr(ptr haystack, ptr needle)
+          bool isStrstr = (!FuncName.compare("strstr") ||
+                           !FuncName.compare("ap_strcasestr") ||
+                           !FuncName.compare("xmlStrstr") ||
+                           !FuncName.compare("xmlStrcasestr"));
+          isStrstr &= FT->getNumParams() == 2 &&
+                      FT->getReturnType()->isPointerTy() &&
+                      FT->getParamType(0)->isPointerTy() &&
+                      FT->getParamType(1)->isPointerTy();
+
+          // g_strstr_len: gchar* (const gchar *haystack, gssize haystack_len,
+          //                       const gchar *needle)
+          bool isGStrstrLen = (!FuncName.compare("g_strstr_len"));
+          isGStrstrLen &= FT->getNumParams() == 3 &&
+                          FT->getReturnType()->isPointerTy() &&
+                          FT->getParamType(0)->isPointerTy() &&
+                          FT->getParamType(1)->isIntegerTy() &&
+                          FT->getParamType(2)->isPointerTy();
 
           bool isGccStdStringStdString =
               Callee->getName().find("__is_charIT_EE7__value") !=
@@ -309,7 +324,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
           if (isGccStdStringCString || isGccStdStringStdString ||
               isLlvmStdStringStdString || isLlvmStdStringCString || isMemcmp ||
-              isStrcmp || isStrncmp) {
+              isStrcmp || isStrncmp || isStrstr || isGStrstrLen) {
 
             isPtrRtnN = isPtrRtn = false;
 
@@ -319,8 +334,9 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
           if (isPtrRtn) { calls.push_back(callInst); }
           if (isMemcmp || isPtrRtnN) { Memcmp.push_back(callInst); }
-          if (isStrcmp) { Strcmp.push_back(callInst); }
+          if (isStrcmp || isStrstr) { Strcmp.push_back(callInst); }
           if (isStrncmp) { Strncmp.push_back(callInst); }
+          if (isGStrstrLen) { GStrstrLen.push_back(callInst); }
           if (isGccStdStringStdString) { gccStdStd.push_back(callInst); }
           if (isGccStdStringCString) { gccStdC.push_back(callInst); }
           if (isLlvmStdStringStdString) { llvmStdStd.push_back(callInst); }
@@ -336,7 +352,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
   if (!calls.size() && !gccStdStd.size() && !gccStdC.size() &&
       !llvmStdStd.size() && !llvmStdC.size() && !Memcmp.size() &&
-      !Strcmp.size() && !Strncmp.size())
+      !Strcmp.size() && !Strncmp.size() && !GStrstrLen.size())
     return false;
 
   /*
@@ -608,6 +624,42 @@ bool CmpLogRoutines::hookRtns(Module &M) {
     args.push_back(v2Pcasted);
 
     IRB.CreateCall(cmplogLlvmStdC, args);
+
+    // errs() << callInst->getCalledFunction()->getName() << "\n";
+
+  }
+
+  // g_strstr_len: gchar* (const gchar *haystack, gssize haystack_len,
+  //                       const gchar *needle)
+  // Extract arg0 (haystack) and arg2 (needle)
+  for (auto &callInst : GStrstrLen) {
+
+    Value *v1P = callInst->getArgOperand(0),  // haystack
+        *v2P = callInst->getArgOperand(2);    // needle
+
+    IRBuilder<> IRB2(callInst->getParent());
+    IRB2.SetInsertPoint(callInst);
+
+    LoadInst *CmpPtr =
+        IRB2.CreateLoad(PointerType::get(Int8Ty, 0), AFLCmplogPtr);
+    CmpPtr->setMetadata(M.getMDKindID("nosanitize"),
+#if LLVM_MAJOR >= 20
+                        MDNode::get(C, {}));
+#else
+                        MDNode::get(C, None));
+#endif
+    auto is_not_null = IRB2.CreateICmpNE(CmpPtr, Null);
+    auto ThenTerm = SplitBlockAndInsertIfThen(is_not_null, callInst, false);
+
+    IRBuilder<> IRB(ThenTerm);
+
+    std::vector<Value *> args;
+    Value               *v1Pcasted = IRB.CreatePointerCast(v1P, i8PtrTy);
+    Value               *v2Pcasted = IRB.CreatePointerCast(v2P, i8PtrTy);
+    args.push_back(v1Pcasted);
+    args.push_back(v2Pcasted);
+
+    IRB.CreateCall(cmplogHookFnStr, args);
 
     // errs() << callInst->getCalledFunction()->getName() << "\n";
 

--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -223,6 +223,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
                !FuncName.compare("strcasecmp") ||
                !FuncName.compare("stricmp") ||
                !FuncName.compare("ap_cstr_casecmp") ||
+               !FuncName.compare("apr_cstr_casecmp") ||
                !FuncName.compare("OPENSSL_strcasecmp") ||
                !FuncName.compare("xmlStrcasecmp") ||
                !FuncName.compare("g_strcasecmp") ||
@@ -230,6 +231,8 @@ bool CmpLogRoutines::hookRtns(Module &M) {
                !FuncName.compare("Curl_strcasecompare") ||
                !FuncName.compare("Curl_safe_strcasecompare") ||
                !FuncName.compare("cmsstrcasecmp") ||
+               !FuncName.compare("sqlite3_stricmp") ||
+               !FuncName.compare("sqlite3StrICmp") ||
                !FuncName.compare("g_str_has_prefix") ||
                !FuncName.compare("g_str_has_suffix"));
           isStrcmp &=
@@ -244,11 +247,13 @@ bool CmpLogRoutines::hookRtns(Module &M) {
                             !FuncName.compare("strncasecmp") ||
                             !FuncName.compare("strnicmp") ||
                             !FuncName.compare("ap_cstr_casecmpn") ||
+                            !FuncName.compare("apr_cstr_casecmpn") ||
                             !FuncName.compare("OPENSSL_strncasecmp") ||
                             !FuncName.compare("xmlStrncasecmp") ||
                             !FuncName.compare("g_ascii_strncasecmp") ||
                             !FuncName.compare("Curl_strncasecompare") ||
-                            !FuncName.compare("g_strncasecmp"));
+                            !FuncName.compare("g_strncasecmp") ||
+                            !FuncName.compare("sqlite3_strnicmp"));
           isStrncmp &=
               FT->getNumParams() == 3 && FT->getReturnType()->isIntegerTy(32) &&
               FT->getParamType(0) == FT->getParamType(1) &&

--- a/test/test-cmplog-routines-pass.sh
+++ b/test/test-cmplog-routines-pass.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+# Test script to verify CmpLog routines pass correctly instruments various functions
+# This tests the LLVM pass by compiling to IR and checking for expected hooks
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AFL_DIR="$SCRIPT_DIR/.."
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+PASS=0
+FAIL=0
+
+check_hook() {
+    local test_name="$1"
+    local source_file="$2"
+    local expected_hook="$3"
+    local function_call="$4"
+
+    # Compile to LLVM IR with CmpLog enabled
+    AFL_LLVM_CMPLOG=1 AFL_QUIET=1 "$AFL_DIR/afl-clang-fast" \
+        -S -emit-llvm -o "$TEMP_DIR/test.ll" "$source_file" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}[FAIL]${NC} $test_name - compilation failed"
+        ((FAIL++))
+        return 1
+    fi
+
+    # Check if the hook is present before the function call
+    if grep -q "$expected_hook" "$TEMP_DIR/test.ll" && \
+       grep -q "$function_call" "$TEMP_DIR/test.ll"; then
+        echo -e "${GREEN}[PASS]${NC} $test_name"
+        ((PASS++))
+        return 0
+    else
+        echo -e "${RED}[FAIL]${NC} $test_name - hook not found"
+        echo "  Expected hook: $expected_hook"
+        echo "  Expected call: $function_call"
+        ((FAIL++))
+        return 1
+    fi
+}
+
+# Check if afl-clang-fast exists
+if [ ! -x "$AFL_DIR/afl-clang-fast" ]; then
+    echo "Error: afl-clang-fast not found. Build AFL++ first."
+    exit 1
+fi
+
+echo "Testing CmpLog routines pass instrumentation..."
+echo
+
+# Test 1: memmem - should use __cmplog_rtn_hook_n
+cat > "$TEMP_DIR/test_memmem.c" << 'EOF'
+#define _GNU_SOURCE
+#include <string.h>
+#include <stddef.h>
+int main() {
+    char buf[100] = {0};
+    return memmem(buf, 100, "needle", 6) != NULL;
+}
+EOF
+check_hook "memmem -> __cmplog_rtn_hook_n" \
+    "$TEMP_DIR/test_memmem.c" \
+    "__cmplog_rtn_hook_n" \
+    "@memmem"
+
+# Test 2: strstr - should use __cmplog_rtn_hook_str
+cat > "$TEMP_DIR/test_strstr.c" << 'EOF'
+#include <string.h>
+int main() {
+    char buf[100] = {0};
+    return strstr(buf, "needle") != NULL;
+}
+EOF
+check_hook "strstr -> __cmplog_rtn_hook_str" \
+    "$TEMP_DIR/test_strstr.c" \
+    "__cmplog_rtn_hook_str" \
+    "@strstr"
+
+# Test 3: strcasestr - should use __cmplog_rtn_hook_str
+cat > "$TEMP_DIR/test_strcasestr.c" << 'EOF'
+#define _GNU_SOURCE
+#include <string.h>
+int main() {
+    char buf[100] = {0};
+    return strcasestr(buf, "needle") != NULL;
+}
+EOF
+check_hook "strcasestr -> __cmplog_rtn_hook_str" \
+    "$TEMP_DIR/test_strcasestr.c" \
+    "__cmplog_rtn_hook_str" \
+    "@strcasestr"
+
+# Test 4: strcmp - should use __cmplog_rtn_hook_str
+cat > "$TEMP_DIR/test_strcmp.c" << 'EOF'
+#include <string.h>
+int main() {
+    char buf[100] = {0};
+    return strcmp(buf, "needle");
+}
+EOF
+check_hook "strcmp -> __cmplog_rtn_hook_str" \
+    "$TEMP_DIR/test_strcmp.c" \
+    "__cmplog_rtn_hook_str" \
+    "@strcmp"
+
+# Test 5: strncmp - should use __cmplog_rtn_hook_strn
+cat > "$TEMP_DIR/test_strncmp.c" << 'EOF'
+#include <string.h>
+int main() {
+    char buf[100] = {0};
+    return strncmp(buf, "needle", 6);
+}
+EOF
+check_hook "strncmp -> __cmplog_rtn_hook_strn" \
+    "$TEMP_DIR/test_strncmp.c" \
+    "__cmplog_rtn_hook_strn" \
+    "@strncmp"
+
+# Test 6: memcmp - should use __cmplog_rtn_hook_n
+cat > "$TEMP_DIR/test_memcmp.c" << 'EOF'
+#include <string.h>
+int main() {
+    char buf[100] = {0};
+    return memcmp(buf, "needle", 6);
+}
+EOF
+check_hook "memcmp -> __cmplog_rtn_hook_n" \
+    "$TEMP_DIR/test_memcmp.c" \
+    "__cmplog_rtn_hook_n" \
+    "@memcmp"
+
+# Test 7: strcasecmp - should use __cmplog_rtn_hook_str
+cat > "$TEMP_DIR/test_strcasecmp.c" << 'EOF'
+#include <strings.h>
+int main() {
+    char buf[100] = {0};
+    return strcasecmp(buf, "needle");
+}
+EOF
+check_hook "strcasecmp -> __cmplog_rtn_hook_str" \
+    "$TEMP_DIR/test_strcasecmp.c" \
+    "__cmplog_rtn_hook_str" \
+    "@strcasecmp"
+
+# Test 8: g_strstr_len (simulated) - should use __cmplog_rtn_hook_str with arg0 and arg2
+cat > "$TEMP_DIR/test_g_strstr_len.c" << 'EOF'
+#include <string.h>
+#include <stddef.h>
+typedef char gchar;
+typedef long gssize;
+// Simulate glib function signature
+__attribute__((noinline))
+gchar* g_strstr_len(const gchar *haystack, gssize haystack_len, const gchar *needle) {
+    (void)haystack_len;
+    return strstr(haystack, needle);
+}
+int main() {
+    char buf[100] = {0};
+    return g_strstr_len(buf, 100, "needle") != NULL;
+}
+EOF
+check_hook "g_strstr_len -> __cmplog_rtn_hook_str" \
+    "$TEMP_DIR/test_g_strstr_len.c" \
+    "__cmplog_rtn_hook_str" \
+    "@g_strstr_len"
+
+echo
+echo "====================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "====================================="
+
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/test/test-cmplog-routines-pass.sh
+++ b/test/test-cmplog-routines-pass.sh
@@ -14,6 +14,7 @@ trap cleanup EXIT
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 PASS=0
@@ -59,121 +60,390 @@ fi
 echo "Testing CmpLog routines pass instrumentation..."
 echo
 
-# Test 1: memmem - should use __cmplog_rtn_hook_n
-cat > "$TEMP_DIR/test_memmem.c" << 'EOF'
-#define _GNU_SOURCE
-#include <string.h>
-#include <stddef.h>
-int main() {
-    char buf[100] = {0};
-    return memmem(buf, 100, "needle", 6) != NULL;
-}
-EOF
-check_hook "memmem -> __cmplog_rtn_hook_n" \
-    "$TEMP_DIR/test_memmem.c" \
-    "__cmplog_rtn_hook_n" \
-    "@memmem"
+#############################################################################
+# isMemcmp: int func(ptr, ptr, size_t) -> __cmplog_rtn_hook_n
+#############################################################################
+echo -e "${YELLOW}=== memcmp-like functions (3 params, returns int) ===${NC}"
 
-# Test 2: strstr - should use __cmplog_rtn_hook_str
-cat > "$TEMP_DIR/test_strstr.c" << 'EOF'
+# memcmp - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
 #include <string.h>
-int main() {
-    char buf[100] = {0};
-    return strstr(buf, "needle") != NULL;
-}
+int main() { char buf[100] = {0}; return memcmp(buf, "needle", 6); }
 EOF
-check_hook "strstr -> __cmplog_rtn_hook_str" \
-    "$TEMP_DIR/test_strstr.c" \
-    "__cmplog_rtn_hook_str" \
-    "@strstr"
+check_hook "memcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@memcmp"
 
-# Test 3: strcasestr - should use __cmplog_rtn_hook_str
-cat > "$TEMP_DIR/test_strcasestr.c" << 'EOF'
-#define _GNU_SOURCE
-#include <string.h>
-int main() {
-    char buf[100] = {0};
-    return strcasestr(buf, "needle") != NULL;
-}
-EOF
-check_hook "strcasestr -> __cmplog_rtn_hook_str" \
-    "$TEMP_DIR/test_strcasestr.c" \
-    "__cmplog_rtn_hook_str" \
-    "@strcasestr"
-
-# Test 4: strcmp - should use __cmplog_rtn_hook_str
-cat > "$TEMP_DIR/test_strcmp.c" << 'EOF'
-#include <string.h>
-int main() {
-    char buf[100] = {0};
-    return strcmp(buf, "needle");
-}
-EOF
-check_hook "strcmp -> __cmplog_rtn_hook_str" \
-    "$TEMP_DIR/test_strcmp.c" \
-    "__cmplog_rtn_hook_str" \
-    "@strcmp"
-
-# Test 5: strncmp - should use __cmplog_rtn_hook_strn
-cat > "$TEMP_DIR/test_strncmp.c" << 'EOF'
-#include <string.h>
-int main() {
-    char buf[100] = {0};
-    return strncmp(buf, "needle", 6);
-}
-EOF
-check_hook "strncmp -> __cmplog_rtn_hook_strn" \
-    "$TEMP_DIR/test_strncmp.c" \
-    "__cmplog_rtn_hook_strn" \
-    "@strncmp"
-
-# Test 6: memcmp - should use __cmplog_rtn_hook_n
-cat > "$TEMP_DIR/test_memcmp.c" << 'EOF'
-#include <string.h>
-int main() {
-    char buf[100] = {0};
-    return memcmp(buf, "needle", 6);
-}
-EOF
-check_hook "memcmp -> __cmplog_rtn_hook_n" \
-    "$TEMP_DIR/test_memcmp.c" \
-    "__cmplog_rtn_hook_n" \
-    "@memcmp"
-
-# Test 7: strcasecmp - should use __cmplog_rtn_hook_str
-cat > "$TEMP_DIR/test_strcasecmp.c" << 'EOF'
+# bcmp - BSD
+cat > "$TEMP_DIR/test.c" << 'EOF'
 #include <strings.h>
-int main() {
-    char buf[100] = {0};
-    return strcasecmp(buf, "needle");
-}
+int main() { char buf[100] = {0}; return bcmp(buf, "needle", 6); }
 EOF
-check_hook "strcasecmp -> __cmplog_rtn_hook_str" \
-    "$TEMP_DIR/test_strcasecmp.c" \
-    "__cmplog_rtn_hook_str" \
-    "@strcasecmp"
+check_hook "bcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@bcmp"
 
-# Test 8: g_strstr_len (simulated) - should use __cmplog_rtn_hook_str with arg0 and arg2
-cat > "$TEMP_DIR/test_g_strstr_len.c" << 'EOF'
-#include <string.h>
-#include <stddef.h>
-typedef char gchar;
-typedef long gssize;
-// Simulate glib function signature
-__attribute__((noinline))
-gchar* g_strstr_len(const gchar *haystack, gssize haystack_len, const gchar *needle) {
-    (void)haystack_len;
-    return strstr(haystack, needle);
-}
-int main() {
-    char buf[100] = {0};
-    return g_strstr_len(buf, 100, "needle") != NULL;
-}
+# CRYPTO_memcmp - OpenSSL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int CRYPTO_memcmp(const void *a, const void *b, unsigned long len);
+int main() { char buf[100] = {0}; return CRYPTO_memcmp(buf, "needle", 6); }
 EOF
-check_hook "g_strstr_len -> __cmplog_rtn_hook_str" \
-    "$TEMP_DIR/test_g_strstr_len.c" \
-    "__cmplog_rtn_hook_str" \
-    "@g_strstr_len"
+check_hook "CRYPTO_memcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@CRYPTO_memcmp"
+
+# OPENSSL_memcmp - OpenSSL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int OPENSSL_memcmp(const void *a, const void *b, unsigned long len);
+int main() { char buf[100] = {0}; return OPENSSL_memcmp(buf, "needle", 6); }
+EOF
+check_hook "OPENSSL_memcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@OPENSSL_memcmp"
+
+# memcmp_const_time - Samba
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int memcmp_const_time(const void *a, const void *b, unsigned long len);
+int main() { char buf[100] = {0}; return memcmp_const_time(buf, "needle", 6); }
+EOF
+check_hook "memcmp_const_time" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@memcmp_const_time"
+
+# memcmpct - constant time memcmp
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int memcmpct(const void *a, const void *b, unsigned long len);
+int main() { char buf[100] = {0}; return memcmpct(buf, "needle", 6); }
+EOF
+check_hook "memcmpct" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@memcmpct"
+
+echo
+
+#############################################################################
+# isStrcmp: int func(ptr, ptr) -> __cmplog_rtn_hook_str
+#############################################################################
+echo -e "${YELLOW}=== strcmp-like functions (2 params, returns int) ===${NC}"
+
+# strcmp - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#include <string.h>
+int main() { char buf[100] = {0}; return strcmp(buf, "needle"); }
+EOF
+check_hook "strcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@strcmp"
+
+# strcasecmp - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#include <strings.h>
+int main() { char buf[100] = {0}; return strcasecmp(buf, "needle"); }
+EOF
+check_hook "strcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@strcasecmp"
+
+# xmlStrcmp - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int xmlStrcmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return xmlStrcmp(buf, "needle"); }
+EOF
+check_hook "xmlStrcmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@xmlStrcmp"
+
+# xmlStrEqual - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int xmlStrEqual(const char *a, const char *b);
+int main() { char buf[100] = {0}; return xmlStrEqual(buf, "needle"); }
+EOF
+check_hook "xmlStrEqual" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@xmlStrEqual"
+
+# xmlStrcasecmp - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int xmlStrcasecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return xmlStrcasecmp(buf, "needle"); }
+EOF
+check_hook "xmlStrcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@xmlStrcasecmp"
+
+# g_strcmp0 - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_strcmp0(const char *a, const char *b);
+int main() { char buf[100] = {0}; return g_strcmp0(buf, "needle"); }
+EOF
+check_hook "g_strcmp0" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_strcmp0"
+
+# g_strcasecmp - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_strcasecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return g_strcasecmp(buf, "needle"); }
+EOF
+check_hook "g_strcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_strcasecmp"
+
+# g_ascii_strcasecmp - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_ascii_strcasecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return g_ascii_strcasecmp(buf, "needle"); }
+EOF
+check_hook "g_ascii_strcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_ascii_strcasecmp"
+
+# g_str_has_prefix - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_str_has_prefix(const char *a, const char *b);
+int main() { char buf[100] = {0}; return g_str_has_prefix(buf, "needle"); }
+EOF
+check_hook "g_str_has_prefix" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_str_has_prefix"
+
+# g_str_has_suffix - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_str_has_suffix(const char *a, const char *b);
+int main() { char buf[100] = {0}; return g_str_has_suffix(buf, "needle"); }
+EOF
+check_hook "g_str_has_suffix" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_str_has_suffix"
+
+# curl_strequal - cURL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int curl_strequal(const char *a, const char *b);
+int main() { char buf[100] = {0}; return curl_strequal(buf, "needle"); }
+EOF
+check_hook "curl_strequal" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@curl_strequal"
+
+# Curl_strcasecompare - cURL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int Curl_strcasecompare(const char *a, const char *b);
+int main() { char buf[100] = {0}; return Curl_strcasecompare(buf, "needle"); }
+EOF
+check_hook "Curl_strcasecompare" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@Curl_strcasecompare"
+
+# Curl_safe_strcasecompare - cURL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int Curl_safe_strcasecompare(const char *a, const char *b);
+int main() { char buf[100] = {0}; return Curl_safe_strcasecompare(buf, "needle"); }
+EOF
+check_hook "Curl_safe_strcasecompare" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@Curl_safe_strcasecompare"
+
+# strcsequal - Samba
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int strcsequal(const char *a, const char *b);
+int main() { char buf[100] = {0}; return strcsequal(buf, "needle"); }
+EOF
+check_hook "strcsequal" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@strcsequal"
+
+# stricmp - Windows/DOS
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int stricmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return stricmp(buf, "needle"); }
+EOF
+check_hook "stricmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@stricmp"
+
+# ap_cstr_casecmp - Apache httpd
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int ap_cstr_casecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return ap_cstr_casecmp(buf, "needle"); }
+EOF
+check_hook "ap_cstr_casecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@ap_cstr_casecmp"
+
+# apr_cstr_casecmp - Apache APR
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int apr_cstr_casecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return apr_cstr_casecmp(buf, "needle"); }
+EOF
+check_hook "apr_cstr_casecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@apr_cstr_casecmp"
+
+# OPENSSL_strcasecmp - OpenSSL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int OPENSSL_strcasecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return OPENSSL_strcasecmp(buf, "needle"); }
+EOF
+check_hook "OPENSSL_strcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@OPENSSL_strcasecmp"
+
+# cmsstrcasecmp - LittleCMS
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int cmsstrcasecmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return cmsstrcasecmp(buf, "needle"); }
+EOF
+check_hook "cmsstrcasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@cmsstrcasecmp"
+
+# sqlite3_stricmp - SQLite
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int sqlite3_stricmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return sqlite3_stricmp(buf, "needle"); }
+EOF
+check_hook "sqlite3_stricmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@sqlite3_stricmp"
+
+# sqlite3StrICmp - SQLite internal
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int sqlite3StrICmp(const char *a, const char *b);
+int main() { char buf[100] = {0}; return sqlite3StrICmp(buf, "needle"); }
+EOF
+check_hook "sqlite3StrICmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@sqlite3StrICmp"
+
+echo
+
+#############################################################################
+# isStrncmp: int func(ptr, ptr, size_t) -> __cmplog_rtn_hook_strn
+#############################################################################
+echo -e "${YELLOW}=== strncmp-like functions (3 params, returns int) ===${NC}"
+
+# strncmp - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#include <string.h>
+int main() { char buf[100] = {0}; return strncmp(buf, "needle", 6); }
+EOF
+check_hook "strncmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@strncmp"
+
+# strncasecmp - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#include <strings.h>
+int main() { char buf[100] = {0}; return strncasecmp(buf, "needle", 6); }
+EOF
+check_hook "strncasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@strncasecmp"
+
+# xmlStrncmp - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int xmlStrncmp(const char *a, const char *b, int len);
+int main() { char buf[100] = {0}; return xmlStrncmp(buf, "needle", 6); }
+EOF
+check_hook "xmlStrncmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@xmlStrncmp"
+
+# xmlStrncasecmp - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int xmlStrncasecmp(const char *a, const char *b, int len);
+int main() { char buf[100] = {0}; return xmlStrncasecmp(buf, "needle", 6); }
+EOF
+check_hook "xmlStrncasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@xmlStrncasecmp"
+
+# curl_strnequal - cURL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int curl_strnequal(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return curl_strnequal(buf, "needle", 6); }
+EOF
+check_hook "curl_strnequal" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@curl_strnequal"
+
+# Curl_strncasecompare - cURL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int Curl_strncasecompare(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return Curl_strncasecompare(buf, "needle", 6); }
+EOF
+check_hook "Curl_strncasecompare" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@Curl_strncasecompare"
+
+# strnicmp - Windows/DOS
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int strnicmp(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return strnicmp(buf, "needle", 6); }
+EOF
+check_hook "strnicmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@strnicmp"
+
+# ap_cstr_casecmpn - Apache httpd
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int ap_cstr_casecmpn(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return ap_cstr_casecmpn(buf, "needle", 6); }
+EOF
+check_hook "ap_cstr_casecmpn" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@ap_cstr_casecmpn"
+
+# apr_cstr_casecmpn - Apache APR
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int apr_cstr_casecmpn(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return apr_cstr_casecmpn(buf, "needle", 6); }
+EOF
+check_hook "apr_cstr_casecmpn" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@apr_cstr_casecmpn"
+
+# OPENSSL_strncasecmp - OpenSSL
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int OPENSSL_strncasecmp(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return OPENSSL_strncasecmp(buf, "needle", 6); }
+EOF
+check_hook "OPENSSL_strncasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@OPENSSL_strncasecmp"
+
+# g_strncasecmp - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_strncasecmp(const char *a, const char *b, unsigned int len);
+int main() { char buf[100] = {0}; return g_strncasecmp(buf, "needle", 6); }
+EOF
+check_hook "g_strncasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@g_strncasecmp"
+
+# g_ascii_strncasecmp - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int g_ascii_strncasecmp(const char *a, const char *b, unsigned long len);
+int main() { char buf[100] = {0}; return g_ascii_strncasecmp(buf, "needle", 6); }
+EOF
+check_hook "g_ascii_strncasecmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@g_ascii_strncasecmp"
+
+# sqlite3_strnicmp - SQLite
+cat > "$TEMP_DIR/test.c" << 'EOF'
+int sqlite3_strnicmp(const char *a, const char *b, int len);
+int main() { char buf[100] = {0}; return sqlite3_strnicmp(buf, "needle", 6); }
+EOF
+check_hook "sqlite3_strnicmp" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@sqlite3_strnicmp"
+
+echo
+
+#############################################################################
+# isStrstr: ptr func(ptr, ptr) -> __cmplog_rtn_hook_str
+#############################################################################
+echo -e "${YELLOW}=== strstr-like functions (2 params, returns ptr) ===${NC}"
+
+# strstr - standard libc
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#include <string.h>
+int main() { char buf[100] = {0}; return strstr(buf, "needle") != 0; }
+EOF
+check_hook "strstr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@strstr"
+
+# strcasestr - GNU extension
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#define _GNU_SOURCE
+#include <string.h>
+int main() { char buf[100] = {0}; return strcasestr(buf, "needle") != 0; }
+EOF
+check_hook "strcasestr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@strcasestr"
+
+# ap_strcasestr - Apache httpd
+cat > "$TEMP_DIR/test.c" << 'EOF'
+char *ap_strcasestr(const char *a, const char *b);
+int main() { char buf[100] = {0}; return ap_strcasestr(buf, "needle") != 0; }
+EOF
+check_hook "ap_strcasestr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@ap_strcasestr"
+
+# xmlStrstr - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+char *xmlStrstr(const char *a, const char *b);
+int main() { char buf[100] = {0}; return xmlStrstr(buf, "needle") != 0; }
+EOF
+check_hook "xmlStrstr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@xmlStrstr"
+
+# xmlStrcasestr - libxml2
+cat > "$TEMP_DIR/test.c" << 'EOF'
+char *xmlStrcasestr(const char *a, const char *b);
+int main() { char buf[100] = {0}; return xmlStrcasestr(buf, "needle") != 0; }
+EOF
+check_hook "xmlStrcasestr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@xmlStrcasestr"
+
+echo
+
+#############################################################################
+# isGStrstrLen: ptr func(ptr, int, ptr) -> __cmplog_rtn_hook_str
+#############################################################################
+echo -e "${YELLOW}=== g_strstr_len (3 params: ptr, int, ptr) ===${NC}"
+
+# g_strstr_len - GLib
+cat > "$TEMP_DIR/test.c" << 'EOF'
+char *g_strstr_len(const char *haystack, long haystack_len, const char *needle);
+int main() { char buf[100] = {0}; return g_strstr_len(buf, 100, "needle") != 0; }
+EOF
+check_hook "g_strstr_len" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_str" "@g_strstr_len"
+
+echo
+
+#############################################################################
+# isMemmem: ptr func(ptr, size_t, ptr, size_t) -> __cmplog_rtn_hook_n
+#############################################################################
+echo -e "${YELLOW}=== memmem (4 params) ===${NC}"
+
+# memmem - GNU extension
+cat > "$TEMP_DIR/test.c" << 'EOF'
+#define _GNU_SOURCE
+#include <string.h>
+int main() { char buf[100] = {0}; return memmem(buf, 100, "needle", 6) != 0; }
+EOF
+check_hook "memmem" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_n" "@memmem"
+
+echo
+
+#############################################################################
+# isStrnstr: ptr func(ptr, ptr, size_t) -> __cmplog_rtn_hook_strn
+#############################################################################
+echo -e "${YELLOW}=== strnstr (3 params: ptr, ptr, size_t) ===${NC}"
+
+# strnstr - BSD
+cat > "$TEMP_DIR/test.c" << 'EOF'
+char *strnstr(const char *big, const char *little, unsigned long len);
+int main() { char buf[100] = {0}; return strnstr(buf, "needle", 100) != 0; }
+EOF
+check_hook "strnstr" "$TEMP_DIR/test.c" "__cmplog_rtn_hook_strn" "@strnstr"
 
 echo
 echo "====================================="

--- a/test/test-cmplog.c
+++ b/test/test-cmplog.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -8,11 +9,14 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t i) {
 
-  if (i < 15) return -1;
+  if (i < 24) return -1;
   if (buf[0] != 'A') return 0;
   int *icmp = (int *)(buf + 1);
   if (*icmp != 0x69694141) return 0;
-  if (memcmp(buf + 5, "1234EF", 6) == 0) abort();
+  if (memmem(buf + 5, i - 5, "MEMMEM", 6) == NULL) return 0;
+  ((char *)buf)[23] = '\0';  // Ensure null-termination for strstr
+  if (strstr((char *)(buf + 11), "STRSTR") == NULL) return 0;
+  if (memcmp(buf + 17, "1234EF", 6) == 0) abort();
   return 0;
 
 }

--- a/test/test-llvm.sh
+++ b/test/test-llvm.sh
@@ -306,6 +306,15 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
       CODE=1
     }
   }
+  # Test cmplog routines pass instrumentation
+  test -e test-cmplog-routines-pass.sh && {
+    ./test-cmplog-routines-pass.sh > /dev/null 2>&1 && {
+      $ECHO "$GREEN[+] cmplog routines pass instrumentation test passed"
+    } || {
+      $ECHO "$RED[!] cmplog routines pass instrumentation test failed"
+      CODE=1
+    }
+  }
   ../afl-clang-fast -o test-persistent ../utils/persistent_mode/persistent_demo.c > /dev/null 2>&1
   test -e test-persistent && {
     echo foo | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -o /dev/null -q -r ./test-persistent && {


### PR DESCRIPTION
## Summary
- Fix signature checks for `strstr`-like functions that were listed but never matched due to checking for `int32` return type instead of pointer
- Add instrumentation for `memmem`, `strcasestr`, and `strnstr` functions
- Add `g_strstr_len` handling with correct 3-parameter signature (haystack, len, needle) 
- `apr_cstr_casecmp` (Apache APR)
- `sqlite3_stricmp` (SQLite)
- `sqlite3StrICmp` (SQLite internal)
- `apr_cstr_casecmpn` (Apache APR)
- `sqlite3_strnicmp` (SQLite)

## Added/Adjusted Tests
- [x] `test/test-cmplog-routines-pass.sh` verifies LLVM IR instrumentation
- [x] `test/test-cmplog.c` updated with `memmem` and `strstr` checks and `afl-fuzz` finds crash quickly with CmpLog enabled