### PR TITLE
Fix GCC 13+ compilation error with returns_twice calls

### DIFF
--- a/instrumentation/afl-gcc-pass.so.cc
+++ b/instrumentation/afl-gcc-pass.so.cc
@@ -370,6 +370,21 @@ struct afl_pass : afl_base_pass {
 
     if (AFL_R(100) >= (long int)inst_ratio) return false;
 
+    /* Skip blocks with returns_twice calls (e.g., setjmp, vfork).
+       Since GCC 13, these calls must be first in their basic block. */
+    gimple_stmt_iterator gsi;
+    for (gsi = gsi_start_bb(bb); !gsi_end_p(gsi); gsi_next(&gsi)) {
+
+      gimple stmt = gsi_stmt(gsi);
+      if (is_gimple_call(stmt)) {
+
+        int flags = gimple_call_flags(stmt);
+        if (flags & ECF_RETURNS_TWICE) return false;
+
+      }
+
+    }
+
     edge          e;
     edge_iterator ei;
     FOR_EACH_EDGE(e, ei, bb->preds)


### PR DESCRIPTION
Fixes #2541

## Problem

GCC 13+ requires that `returns_twice` calls like setjmp and vfork must be the first instruction in their basic block. The plugin was inserting instrumentation before these calls, which breaks this requirement and causes compilation to fail.

This was blocking compilation of projects like PostgreSQL on newer GCC versions.

## Solution

Skip instrumentation for any basic block that contains a `returns_twice` call. The check uses `gimple_call_flags()` to detect the `ECF_RETURNS_TWICE` flag.

## Trade-off

We lose coverage on these blocks. But:
- They're pretty rare in most code
- The alternative is a compilation error
- Can always revisit with a more sophisticated approach later if needed

## Changes

Just 15 lines added to afl-gcc-pass.so.cc, no other changes.

## Testing

Compiles cleanly and should fix the PostgreSQL issue mentioned in #2541.