### PR TITLE
nyx mode: fix exit code on errors when building

### DIFF
--- a/nyx_mode/build_nyx_support.sh
+++ b/nyx_mode/build_nyx_support.sh
@@ -12,7 +12,7 @@ echo "[*] Performing basic sanity checks..."
 if [ "$CI" = "true" ]; then
 
   echo "[-] Error: nyx_mode cannot be tested in the Github CI, skipping ..."
-  exit 0
+  exit 1
 
 fi
 
@@ -20,27 +20,27 @@ fi
 if [ -n "$NO_NYX" ]; then
 
   echo "[-] Error: the NO_NYX environment variable is set, please unset."
-  exit 0
+  exit 1
 
 fi
 
 if [ ! "$(uname -s)" = "Linux" ]; then
 
   echo "[-] Error: Nyx mode is only available on Linux."
-  exit 0
+  exit 1
 
 fi
 
 if [ ! "$(uname -m)" = "x86_64" ]; then
 
   echo "[-] Error: Nyx mode is only available on x86_64 (yet)."
-  exit 0
+  exit 1
 
 fi
 
 cargo help > /dev/null 2>&1 || {
    echo "[-] Error: Rust is not installed."
-   exit 0
+   exit 1
 }
 
 echo "[*] Making sure all Nyx is checked out"


### PR DESCRIPTION
Hi!
This is a fix to return 1 on errors instead of 0 when building Nyx mode. This helps the caller know something went wrong so it can stop the build process (and is useful for automating the build of Nyx mode).
Not sure if those `exit 0` were intended though, but below i found `exit 1`'s as well.

**I have tested the changes**: yes
