### PR TITLE
Fix GCC plugin instrumentation for returns_twice calls

### DIFF
--- a/instrumentation/afl-gcc-pass.so.cc
+++ b/instrumentation/afl-gcc-pass.so.cc
@@ -127,6 +127,7 @@
 #if defined(__has_include) && __has_include("memmodel.h")
   #include "memmodel.h"
 #endif
+#include <dominance.h>
 
 /* This plugin, being under the same license as GCC, satisfies the
    "GPL-compatible Software" definition in the GCC RUNTIME LIBRARY
@@ -186,6 +187,12 @@ struct afl_pass : afl_base_pass {
 
     int blocks = 0;
 
+    /* Track whether we split any blocks (e.g., for returns_twice handling).  */
+    bool did_split = false;
+
+    /* Track blocks we've created trampolines for, to avoid reprocessing.  */
+    hash_set<basic_block> returns_twice_handled;
+
     /* These are temporaries used by inline instrumentation only, that
        are live throughout the function.  */
     tree ploc = NULL, indx = NULL, map = NULL, map_ptr = NULL, ntry = NULL,
@@ -195,6 +202,8 @@ struct afl_pass : afl_base_pass {
     FOR_EACH_BB_FN(bb, fn) {
 
       if (!instrument_block_p(bb)) continue;
+
+      if (returns_twice_handled.contains(bb)) continue;
 
       /* Generate the block identifier.  */
       unsigned bid = AFL_R(MAP_SIZE);
@@ -328,11 +337,100 @@ struct afl_pass : afl_base_pass {
       }
 
       /* Insert the generated sequence.  */
-      gimple_stmt_iterator insp = gsi_after_labels(bb);
-      gsi_insert_seq_before(&insp, seq, GSI_SAME_STMT);
+      if (block_has_returns_twice(bb)) {
 
-      /* Bump this function's instrumented block counter.  */
-      blocks++;
+        /* For blocks with returns_twice calls (setjmp), we must not
+           insert instrumentation before the call. Instead, we create a
+           trampoline block for normal entry and redirect normal edges
+           to it. Abnormal edges (from longjmp) go directly to the
+           original block.  */
+
+        /* Check if this block has any normal (non-abnormal) predecessors.
+           If not, it's only reachable via longjmp and we skip it.
+           See: https://gcc.gnu.org/onlinedocs/gccint/Edges.html  */
+        auto_vec<edge> normal_preds;
+        edge           e;
+        edge_iterator  ei;
+        FOR_EACH_EDGE(e, ei, bb->preds) {
+
+          if (!(e->flags & EDGE_ABNORMAL)) normal_preds.safe_push(e);
+
+        }
+
+        /* Only create trampoline if there are normal predecessors.  */
+        if (!normal_preds.is_empty()) {
+
+          /* GCC caches dominance information for optimization passes.
+             This info becomes invalid when we modify the CFG by
+             splitting blocks and redirecting edges.
+
+             We must free it before CFG modifications, otherwise GCC's
+             internal checks (-fchecking) will fail with errors like:
+             "error: dominator of 9 should be 2, not 3"
+
+             The TODO_update_ssa and TODO_cleanup_cfg flags in
+             todo_flags_finish ensure GCC recomputes what it needs
+             after our pass completes.  */
+          if (dom_info_available_p(CDI_DOMINATORS))
+            free_dominance_info(CDI_DOMINATORS);
+          if (dom_info_available_p(CDI_POST_DOMINATORS))
+            free_dominance_info(CDI_POST_DOMINATORS);
+
+          /* Create trampoline by splitting at the start of the block.
+             split_block_after_labels splits before any statements,
+             creating an empty predecessor block.  */
+          edge split_e = split_block_after_labels(bb);
+
+          /* After split_block_after_labels(bb):
+             - bb becomes empty (the trampoline)
+             - split_e->dest is the new block with original statements
+             - All original predecessors now point to bb (trampoline)  */
+          basic_block trampoline = bb;
+          basic_block original = split_e->dest;
+
+          /* Mark the original block as handled so we don't reprocess it
+             when we encounter it later in the FOR_EACH_BB_FN loop.  */
+          returns_twice_handled.add(original);
+
+          /* Redirect abnormal edges to bypass trampoline.
+             Iterate over a copy since we're modifying edges.  */
+          auto_vec<edge> abnormal_preds;
+          FOR_EACH_EDGE(e, ei, trampoline->preds) {
+
+            if (e->flags & EDGE_ABNORMAL) abnormal_preds.safe_push(e);
+
+          }
+
+          for (unsigned i = 0; i < abnormal_preds.length(); i++) {
+
+            redirect_edge_succ(abnormal_preds[i], original);
+
+          }
+
+          /* Insert instrumentation in trampoline.  */
+          gimple_stmt_iterator insp = gsi_start_bb(trampoline);
+          gsi_insert_seq_before(&insp, seq, GSI_NEW_STMT);
+
+          did_split = true;
+
+          /* Bump this function's instrumented block counter.  */
+          blocks++;
+
+        }
+
+        /* If no normal predecessors, skip instrumentation entirely
+           (block only reachable via longjmp).  */
+
+      } else {
+
+        /* Normal case: insert instrumentation at block start.  */
+        gimple_stmt_iterator insp = gsi_after_labels(bb);
+        gsi_insert_seq_before(&insp, seq, GSI_SAME_STMT);
+
+        /* Bump this function's instrumented block counter.  */
+        blocks++;
+
+      }
 
     }
 
@@ -357,6 +455,9 @@ struct afl_pass : afl_base_pass {
       edge e = single_succ_edge(ENTRY_BLOCK_PTR_FOR_FN(fn));
       gsi_insert_seq_on_edge_immediate(e, seq);
 
+      /* If we did any block splitting, also rebuild cgraph edges.  */
+      if (did_split) return TODO_rebuild_cgraph_edges;
+
     }
 
     return 0;
@@ -374,6 +475,25 @@ struct afl_pass : afl_base_pass {
     edge_iterator ei;
     FOR_EACH_EDGE(e, ei, bb->preds)
     if (!single_succ_p(e->src)) return true;
+
+    return false;
+
+  }
+
+  /* Check if BB contains a returns_twice call (e.g., setjmp).
+     Returns true if such a call exists anywhere in the block.  */
+  inline bool block_has_returns_twice(basic_block bb) {
+
+    for (gimple_stmt_iterator gsi = gsi_start_bb(bb); !gsi_end_p(gsi);
+         gsi_next(&gsi)) {
+
+      if (gimple_code(gsi_stmt(gsi)) == GIMPLE_CALL) {
+
+        if (gimple_call_flags(gsi_stmt(gsi)) & ECF_RETURNS_TWICE) return true;
+
+      }
+
+    }
 
     return false;
 

--- a/test/test-gcc-plugin.sh
+++ b/test/test-gcc-plugin.sh
@@ -110,6 +110,55 @@ test -e ../afl-gcc-fast -a -e ../afl-compiler-rt.o && {
     CODE=1
   }
   rm -f test-persistent
+
+  # Test setjmp/returns_twice instrumentation fix (GitHub issue #2541)
+  # GCC 13+ requires returns_twice calls to be first in their basic block.
+  # Compile with -fchecking to verify the CFG is valid.
+  $ECHO "$GREY[*] testing setjmp/returns_twice instrumentation (issue #2541)"
+  ../afl-gcc-fast -fchecking -fdump-tree-afl -o test-setjmp ./test-setjmp.c > test-setjmp.log 2>&1
+  test -e test-setjmp && {
+    # Run the binary and capture output for debugging
+    SETJMP_OUTPUT=$(./test-setjmp 2>&1)
+    SETJMP_RC=$?
+    test "$SETJMP_RC" -eq 0 && {
+      # Verify instrumentation is present via afl-showmap
+      TUPLES=`AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -o /dev/null -- ./test-setjmp 2>&1 | grep Captur | awk '{print$3}'`
+      test "$TUPLES" -gt 0 && {
+        # Verify trampoline structure in GIMPLE dump:
+        # - setjmp should be first stmt in its block (after DEBUG_STMT)
+        # - AFL instrumentation should be in a separate preceding block
+        DUMP_FILE=$(ls test-setjmp-test-setjmp.c.*.afl 2>/dev/null | head -1)
+        if test -n "$DUMP_FILE"; then
+          # Check: setjmp/sigsetjmp blocks should NOT contain afl_prev_loc before the call
+          # Extract the blocks and verify no AFL instrumentation before them
+          SETJMP_BLOCK=$(grep -B2 "_setjmp" "$DUMP_FILE" | grep -c "afl_prev_loc" || true)
+          SIGSETJMP_BLOCK=$(grep -B2 "sigsetjmp" "$DUMP_FILE" | grep -c "afl_prev_loc" || true)
+          test "$SETJMP_BLOCK" -eq 0 -a "$SIGSETJMP_BLOCK" -eq 0 && {
+            $ECHO "$GREEN[+] gcc_plugin setjmp/returns_twice instrumentation works correctly"
+            $ECHO "$GREEN[+] gcc_plugin verified: setjmp/sigsetjmp are first in block, instrumentation in trampoline"
+          } || {
+            $ECHO "$RED[!] gcc_plugin setjmp test: instrumentation incorrectly placed before setjmp/sigsetjmp"
+            CODE=1
+          }
+        else
+          $ECHO "$GREEN[+] gcc_plugin setjmp/returns_twice instrumentation works correctly"
+        fi
+      } || {
+        $ECHO "$RED[!] gcc_plugin setjmp test has no instrumentation (tuples=$TUPLES)"
+        CODE=1
+      }
+    } || {
+      $ECHO "$RED[!] gcc_plugin setjmp test execution failed (exit code $SETJMP_RC)"
+      test -n "$SETJMP_OUTPUT" && $ECHO "$RED    output: $SETJMP_OUTPUT"
+      CODE=1
+    }
+  } || {
+    $ECHO "$RED[!] gcc_plugin setjmp/returns_twice compilation failed (with -fchecking)"
+    cat test-setjmp.log
+    CODE=1
+  }
+  rm -f test-setjmp test-setjmp.log test-setjmp-test-setjmp.c.*.afl
+
   export AFL_CC=${SAVE_AFL_CC}
 } || {
   $ECHO "$YELLOW[-] gcc_plugin not compiled, cannot test"

--- a/test/test-setjmp.c
+++ b/test/test-setjmp.c
@@ -1,0 +1,79 @@
+/*
+   Test case for GCC plugin setjmp/returns_twice instrumentation fix.
+
+   GCC 13+ requires returns_twice calls (like setjmp, sigsetjmp) to be the
+   first instruction in their basic block. This test verifies that AFL++'s
+   GCC plugin correctly handles this by creating trampoline blocks for
+   instrumentation.
+
+   See GitHub issue: https://github.com/AFLplusplus/AFLplusplus/issues/2541.
+*/
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+jmp_buf    env;
+sigjmp_buf sigenv;
+int        counter = 0;
+
+void bar(void) {
+
+}
+
+void test_setjmp(void) {
+
+  bar();
+  if (setjmp(env) == 0) {
+
+    /* First return from setjmp.  */
+    counter++;
+    if (counter < 2) { longjmp(env, 1); }
+
+  } else {
+
+    /* Returned from longjmp.  */
+    counter++;
+
+  }
+
+}
+
+void test_sigsetjmp(void) {
+
+  bar();
+  if (sigsetjmp(sigenv, 1) == 0) {
+
+    /* First return from sigsetjmp.  */
+    counter++;
+    if (counter < 4) { siglongjmp(sigenv, 1); }
+
+  } else {
+
+    /* Returned from siglongjmp.  */
+    counter++;
+
+  }
+
+}
+
+int main(int argc, char **argv) {
+
+  (void)argc;
+  (void)argv;
+
+  test_setjmp();
+  test_sigsetjmp();
+
+  /* Verify setjmp/longjmp worked correctly.  */
+  if (counter != 4) {
+
+    fprintf(stderr, "Error: counter=%d, expected 4\n", counter);
+    return 1;
+
+  }
+
+  return 0;
+
+}
+


### PR DESCRIPTION
GCC 13+ requires returns_twice calls (like setjmp, sigsetjmp) to be the first instruction in their basic block. AFL++'s GCC plugin was inserting instrumentation before these calls, causing compilation errors with -fchecking enabled.

We fix this with a "trampoline" block using the following steps:
- detect blocks containing returns_twice calls
- split such a block to create an empty trampoline predecessor
- insert instrumentation in the trampoline
- redirect abnormal edges (e.g., from longjmp) to the trampoline successor (the original block, e.g. setjmp)

This ensures setjmp remains the first instruction in its block while still providing coverage that is symantically equivalent to the original instrumentation.

Fixes: https://github.com/AFLplusplus/AFLplusplus/issues/2541
