### PR TITLE
Fix argument count check in argv_fuzz_demo.c

### DIFF
--- a/utils/argv_fuzzing/argv_fuzz_demo.c
+++ b/utils/argv_fuzzing/argv_fuzz_demo.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     If the number of arguments is not correct or the values do not match,
     an error message is printed. If the values do match, the program
     calls the abort() function. */
-  if (argc > 1 && strcmp(argv[1], "XYZ") == 0) {
+  if (argc > 2 && strcmp(argv[1], "XYZ") == 0) {
 
     if (strcmp(argv[2], "TEST2") == 0) { abort(); }
 


### PR DESCRIPTION

**Type of PR**: BUG FIX
**Purpose of this PR**: Fix the possibility of undefined behaviour in argument handling by validating argc before accessing argv[2].
**I have tested the changes**: yes