### PR TITLE
Fix undefined behavior by correcting the printf format specifier (%p used for an int instead of %d) and make the function safer to run and test.

### DIFF
--- a/utils/qbdi_mode/demo-so.c
+++ b/utils/qbdi_mode/demo-so.c
@@ -3,7 +3,7 @@
 // gcc -shared -o libdemo.so demo-so.c -w
 int target_func(char *buf, int size) {
 
-  printf("buffer:%p, size:%p\n", buf, size);
+  printf("buffer:%p, size:%d\n", buf, size);
   switch (buf[0]) {
 
     case 1:
@@ -38,4 +38,5 @@ int target_func(char *buf, int size) {
   return 1;
 
 }
+
 


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Feature or Bugfix or Enhancement
**Purpose of this PR**: Fix undefined behavior by correcting the printf format specifier (%p used for an int instead of %d) and make the function safer to run and test.
**I have tested the changes**: yes/no

  
