### PR TITLE
Prevent orphaned forkserver

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -3154,6 +3154,11 @@ int main(int argc, char **argv_orig, char **envp) {
 
     }
 
+    // Kill the forkserver that might have been started by
+    // afl_fsrv_get_mapsize() earlier, so we don't leak an orphaned forkserver
+    // process and its pipe fds.
+    afl_fsrv_kill(&afl->fsrv);
+
     afl_fsrv_start(&afl->fsrv, afl->argv, &afl->stop_soon,
                    afl->afl_env.afl_debug_child);
 


### PR DESCRIPTION
## Please give basic information

**Type of PR**: Bugfix
**Purpose of this PR**: Earlier, when fetching map_size with `afl_fsrv_get_mapsize` is started. Here in fast_resume branch the forkserver is started again, so the old one should be killed to prevent having an orphaned forkserver.
**I have tested the changes**: yes

I don't think leaving the orphaned forkserver hanging around is/was a big problem, but still it is more correct to kill it instead of leaving it orphaned.

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
  
