### PR TITLE
fix ngram/K-ctx crash on misaligned TLS (#1855)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,47 @@ jobs:
       - name: run tests
         run: sudo -E ./afl-system-config; make tests
 
+  check-gcc:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            gcc: 10
+            llvm: 14
+          - os: ubuntu-24.04
+            gcc: 14
+            llvm: 18
+    runs-on: ${{ matrix.os }}
+    env:
+      AFL_SKIP_CPUFREQ: 1
+      AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: update
+        run: sudo apt-get update && sudo apt-get upgrade -y
+      - name: install packages
+        run: >
+          sudo apt-get install -y -m -f
+          build-essential gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
+          clang-${{ matrix.llvm }} llvm-${{ matrix.llvm }} llvm-${{ matrix.llvm }}-dev lld-${{ matrix.llvm }}
+          libclang-${{ matrix.llvm }}-dev
+          git libtool libtool-bin automake flex bison libglib2.0-0 libc++-dev
+          findutils libcmocka-dev python3-dev python3-setuptools
+      - name: build afl++ with gcc-${{ matrix.gcc }}
+        run: >
+          CC=gcc-${{ matrix.gcc }} CXX=g++-${{ matrix.gcc }}
+          make -j$(nproc) NO_NYX=1
+          LLVM_CONFIG=llvm-config-${{ matrix.llvm }} source-only
+      - name: compile afl-compiler-rt.o with gcc-${{ matrix.gcc }}
+        # GNUmakefile.llvm overrides CC to clang, so the source-only build
+        # above does not exercise GCC on the runtime.  Compile it explicitly
+        # to catch GCC-specific issues (e.g. TLS alignment, _Static_assert).
+        run: |
+          gcc-${{ matrix.gcc }} -Iinclude -Iinstrumentation -O3 -Wno-unused-result -fPIC \
+            -c instrumentation/afl-compiler-rt.o.c -o afl-compiler-rt-gcc.o
+      - name: run tests
+        run: sudo -E ./afl-system-config; make tests
+
   linux:
     runs-on: "${{ matrix.os }}"
     strategy:

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -261,13 +261,25 @@ int        __afl_selective_coverage __attribute__((weak));
 int        __afl_selective_coverage_start_off __attribute__((weak));
 static int __afl_selective_coverage_temp = 1;
 
+/* Aligned for use as LLVM vector operands in ngram/K-ctx modes (#1855).
+   Alignment scales with PREV_LOC_T so non-default MAP_SIZE_POW2 stays safe. */
+#define AFL_PREV_LOC_ALIGN   (sizeof(PREV_LOC_T) * NGRAM_SIZE_MAX)
+#define AFL_PREV_CALLER_ALIGN (sizeof(PREV_LOC_T) * CTX_MAX_K)
+_Static_assert(AFL_PREV_LOC_ALIGN >= 32,
+               "prev_loc alignment must be >= 32 for default-config compat");
+_Static_assert(AFL_PREV_CALLER_ALIGN >= 64,
+               "prev_caller alignment must be >= 64 for default-config compat");
 #if defined(__ANDROID__) || defined(__HAIKU__) || defined(NO_TLS)
-PREV_LOC_T __afl_prev_loc[NGRAM_SIZE_MAX];
-PREV_LOC_T __afl_prev_caller[CTX_MAX_K];
+PREV_LOC_T __afl_prev_loc[NGRAM_SIZE_MAX]
+    __attribute__((aligned(AFL_PREV_LOC_ALIGN)));
+PREV_LOC_T __afl_prev_caller[CTX_MAX_K]
+    __attribute__((aligned(AFL_PREV_CALLER_ALIGN)));
 u32        __afl_prev_ctx;
 #else
-__thread PREV_LOC_T __afl_prev_loc[NGRAM_SIZE_MAX];
-__thread PREV_LOC_T __afl_prev_caller[CTX_MAX_K];
+__thread PREV_LOC_T __afl_prev_loc[NGRAM_SIZE_MAX]
+    __attribute__((aligned(AFL_PREV_LOC_ALIGN)));
+__thread PREV_LOC_T __afl_prev_caller[CTX_MAX_K]
+    __attribute__((aligned(AFL_PREV_CALLER_ALIGN)));
 __thread u32        __afl_prev_ctx;
 #endif
 


### PR DESCRIPTION
LLVM may emit AVX instructions for `__afl_prev_loc` and `__afl_prev_caller`, which may be misaligned because the RT is unaware of this constraint.

Fixes #1855