### PR TITLE
gcc_plugin: avoid coroutine EH ICE on GCC < 15

### DIFF
--- a/instrumentation/afl-gcc-pass.so.cc
+++ b/instrumentation/afl-gcc-pass.so.cc
@@ -201,7 +201,7 @@ struct afl_pass : afl_base_pass {
     basic_block bb;
     FOR_EACH_BB_FN(bb, fn) {
 
-      if (!instrument_block_p(bb)) continue;
+      if (!instrument_block_p(fn, bb)) continue;
 
       if (returns_twice_handled.contains(bb)) continue;
 
@@ -467,9 +467,29 @@ struct afl_pass : afl_base_pass {
   /* Decide whether to instrument block BB.  Skip it due to the random
      distribution, or if it's the single successor of all its
      predecessors.  */
-  inline bool instrument_block_p(basic_block bb) {
+  inline bool instrument_block_p(function *fn, basic_block bb) {
 
     if (AFL_R(100) >= (long int)inst_ratio) return false;
+
+/* GCC versions < 15 can ICE in purge_dead_edges during RTL CFG cleanup when
+   side-effecting instrumentation is injected into EH-only dispatcher/resx
+   blocks produced by coroutine lowering. Restrict this workaround to
+   coroutine-related functions. */
+#if GCC_VERSION < 15000
+    if (fn->coroutine_component) {
+
+      for (gimple_stmt_iterator gsi = gsi_start_bb(bb); !gsi_end_p(gsi);
+           gsi_next(&gsi)) {
+
+        gimple           stmt = gsi_stmt(gsi);
+        enum gimple_code code = gimple_code(stmt);
+        if (code == GIMPLE_EH_DISPATCH || code == GIMPLE_RESX) return false;
+
+      }
+
+    }
+
+#endif
 
     edge          e;
     edge_iterator ei;


### PR DESCRIPTION
This fixes a GCC plugin crash when compiling C++20 coroutines with GCC < 15 (reproducible on GCC 11 and GCC 14).  The root cause is that side-effects instrumentation injected into EH-only blocks generated by coroutine lowering  (GIMPLE_EH_DISPATCH / GIMPLE_RESX) cases an ICE. For GCC < 15, we now skip instrumenting those EH-only blocks.  To ensure that we don't skip all EH blocks in general, we limit the check to those blocks resulting from coroutines.

Fixes #2684 