### PR TITLE
LTO riscv64

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -369,9 +369,18 @@ man:    $(MANPAGES)
 test:	tests
 
 .PHONY: tests
+ifdef ARCH
+tests:
+	@command -v docker >/dev/null 2>&1 || { echo "[-] Error: docker is required for ARCH testing"; exit 1; }
+	@echo "[*] Running tests in $(ARCH) Docker container via QEMU..."
+	@echo "[*] Output logged to test/test-$(ARCH).log"
+	@docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null 2>&1 || true
+	docker build --progress=plain --platform linux/$(ARCH) -f test/Dockerfile.qemu -t aflpp-test-$(ARCH) . 2>&1 | tee test/test-$(ARCH).log
+else
 tests:	source-only binary-only
 	@cd test ; ./test-all.sh
 	@rm -f test/errors
+endif
 
 .PHONY: performance-tests
 performance-tests:	performance-test

--- a/test/Dockerfile.qemu
+++ b/test/Dockerfile.qemu
@@ -1,0 +1,16 @@
+FROM alpine:latest AS base
+
+RUN apk add --no-cache \
+    build-base clang clang-dev lld llvm-dev llvm-static \
+    python3 bash coreutils linux-headers
+
+ENV NO_NYX=1 AFL_NO_X86=1 LLVM_LTO=1 \
+    AFL_SKIP_CPUFREQ=1 AFL_TRY_AFFINITY=1 \
+    AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+
+FROM base
+WORKDIR /AFLplusplus
+COPY . .
+
+RUN make -j$(nproc) source-only
+RUN cd test && ./test-all.sh

--- a/test/test-llvm-lto.sh
+++ b/test/test-llvm-lto.sh
@@ -14,7 +14,7 @@ test -e ../afl-clang-lto -a -e ../SanitizerCoverageLTO.so && {
   }
 
   rm -f test-instr.plain
-  ../afl-clang-lto -o test-instr.plain ../test-instr.c > /dev/null 2>&1
+  AFL_DEBUG=1 ../afl-clang-lto -o test-instr.plain ../test-instr.c > test-lto.out 2>&1
   test -e test-instr.plain && {
     chmod +x test-instr.plain
     ls -l test-instr.plain
@@ -41,10 +41,13 @@ test -e ../afl-clang-lto -a -e ../SanitizerCoverageLTO.so && {
     }
     rm -f test-instr.plain.0 test-instr.plain.1
   } || {
+    echo CUT------------------------------------------------------------------CUT
+    cat test-lto.out
+    echo CUT------------------------------------------------------------------CUT
     $ECHO "$RED[!] LTO llvm_mode failed"
     CODE=1
   }
-  rm -f test-instr.plain
+  rm -f test-instr.plain test-lto.out
 
   echo foobar.c > instrumentlist.txt
   AFL_DEBUG=1 AFL_LLVM_INSTRUMENT_FILE=instrumentlist.txt ../afl-clang-lto -o test-compcov test-compcov.c > test.out 2>&1
@@ -59,11 +62,14 @@ test -e ../afl-clang-lto -a -e ../SanitizerCoverageLTO.so && {
       CODE=1
     }
   } || {
+    echo CUT------------------------------------------------------------------CUT
+    cat test.out
+    echo CUT------------------------------------------------------------------CUT
     $ECHO "$RED[!] llvm_mode LTO instrumentlist feature compilation failed"
     CODE=1
   }
   rm -f test-compcov test.out instrumentlist.txt
-  ../afl-clang-lto -o test-persistent ../utils/persistent_mode/persistent_demo.c > /dev/null 2>&1
+  AFL_DEBUG=1 ../afl-clang-lto -o test-persistent ../utils/persistent_mode/persistent_demo.c > test-lto.out 2>&1
   test -e test-persistent && {
     echo foo | AFL_QUIET=1 ../afl-showmap -m none -o /dev/null -q -r ./test-persistent && {
       $ECHO "$GREEN[+] llvm_mode LTO persistent mode feature works correctly"
@@ -72,10 +78,13 @@ test -e ../afl-clang-lto -a -e ../SanitizerCoverageLTO.so && {
       CODE=1
     }
   } || {
+    echo CUT------------------------------------------------------------------CUT
+    cat test-lto.out
+    echo CUT------------------------------------------------------------------CUT
     $ECHO "$RED[!] llvm_mode LTO persistent mode feature compilation failed"
     CODE=1
   }
-  rm -f test-persistent
+  rm -f test-persistent test-lto.out
 } || {
   $ECHO "$YELLOW[-] LTO llvm_mode not compiled, cannot test"
   INCOMPLETE=1

--- a/test/test-llvm.sh
+++ b/test/test-llvm.sh
@@ -165,7 +165,7 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
               CODE=1
               ;;
         esac
-        rm -f in2/in*
+        rm -rf in2
       }
       export AFL_QUIET=1
       if type bash >/dev/null ; then {
@@ -221,7 +221,7 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
 
   AFL_LLVM_INSTRUMENT=AFL AFL_DEBUG=1 AFL_LLVM_LAF_SPLIT_SWITCHES=1 AFL_LLVM_LAF_TRANSFORM_COMPARES=1 AFL_LLVM_LAF_SPLIT_COMPARES=1 ../afl-clang-fast -o test-compcov.compcov test-compcov.c > test.out 2>&1
   test -e test-compcov.compcov && test_compcov_binary_functionality ./test-compcov.compcov && {
-    grep --binary-files=text -Eq " [ 123][0-9][0-9] location| [3-9][0-9] location" test.out && {
+    grep $GREPAOPTION -Eq " [ 123][0-9][0-9] location| [3-9][0-9] location" test.out && {
       $ECHO "$GREEN[+] llvm_mode laf-intel/compcov feature works correctly"
     } || {
       $ECHO "$RED[!] llvm_mode laf-intel/compcov feature failed"


### PR DESCRIPTION
Bug seem to be fixed upstream. Add support to run tests on different architectures using QEMU and fix errors in the RISCV build. Not sure if we want to add them to the CI for ARM & RISCV?

Fixes #2064