### PR TITLE
LTO perf regression

### DIFF
--- a/instrumentation/SanitizerCoverageLTO.so.cc
+++ b/instrumentation/SanitizerCoverageLTO.so.cc
@@ -205,17 +205,6 @@ class ModuleSanitizerCoverageLTO
   void InjectCoverageAtBlock(Function &F, BasicBlock &BB, size_t Idx,
                              bool IsLeafFunc = true);
 
-  void SetNoSanitizeMetadata(Instruction *I) {
-
-#if LLVM_VERSION_MAJOR >= 19
-    I->setNoSanitizeMetadata();
-#else
-    I->setMetadata(I->getModule()->getMDKindID("nosanitize"),
-                   MDNode::get(*C, None));
-#endif
-
-  }
-
   std::string    getSectionName(const std::string &Section) const;
   FunctionCallee SanCovTracePC /*, SanCovTracePCGuard*/;
   Type *IntptrTy, *IntptrPtrTy, *Int64Ty, *Int64PtrTy, *Int32Ty, *Int32PtrTy,
@@ -264,6 +253,7 @@ class ModuleSanitizerCoverageLTO
   GlobalVariable                  *AFLIJONState = NULL;
   const char                      *ijon_enabled = nullptr;
   Value                           *MapPtrFixed = NULL;
+  Value                           *FuncMapPtr = NULL;
   AllocaInst                      *CTX_add = NULL;
   std::ofstream                    dFile;
   size_t                           found = 0;
@@ -1130,7 +1120,7 @@ bool ModuleSanitizerCoverageLTO::instrumentModule(
           M, Int64Tyi, true, GlobalValue::ExternalLinkage, 0, "__afl_map_addr");
       ConstantInt *MapAddr = ConstantInt::get(Int64Tyi, map_addr);
       StoreInst   *StoreMapAddr = IRB.CreateStore(MapAddr, AFLMapAddrFixed);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(StoreMapAddr);
+      setNoSanitizeMetadata(StoreMapAddr);
 
     }
 
@@ -1145,7 +1135,7 @@ bool ModuleSanitizerCoverageLTO::instrumentModule(
                              "__afl_final_loc");
       ConstantInt *const_loc = ConstantInt::get(Int32Tyi, write_loc);
       StoreInst   *StoreFinalLoc = IRB.CreateStore(const_loc, AFLFinalLoc);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(StoreFinalLoc);
+      setNoSanitizeMetadata(StoreFinalLoc);
 
     }
 
@@ -1193,7 +1183,7 @@ bool ModuleSanitizerCoverageLTO::instrumentModule(
                                0, "__afl_dictionary_len");
         ConstantInt *const_len = ConstantInt::get(Int32Tyi, offset);
         StoreInst *StoreDictLen = IRB.CreateStore(const_len, AFLDictionaryLen);
-        ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(StoreDictLen);
+        setNoSanitizeMetadata(StoreDictLen);
 
         ArrayType *ArrayTy = ArrayType::get(IntegerType::get(Ctx, 8), offset);
         GlobalVariable *AFLInternalDictionary = new GlobalVariable(
@@ -1212,7 +1202,7 @@ bool ModuleSanitizerCoverageLTO::instrumentModule(
         Value *AFLDictOff = IRB.CreateGEP(Int8Ty, AFLInternalDictionary, Zero);
         Value *AFLDictPtr = IRB.CreatePointerCast(AFLDictOff, PtrTy);
         StoreInst *StoreDict = IRB.CreateStore(AFLDictPtr, AFLDictionary);
-        ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(StoreDict);
+        setNoSanitizeMetadata(StoreDict);
 
       }
 
@@ -1795,7 +1785,7 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
         IRB.getInt32Ty(),
 #endif
         CTX_add);
-    ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(CTX_load);
+    setNoSanitizeMetadata(CTX_load);
     return IRB.CreateAdd(V, CTX_load);
 
   };
@@ -1814,9 +1804,7 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
   auto updateBitmapForResult = [&](IRBuilder<> &IRB, Value *Result,
                                    uint32_t vector_cnt) {
 
-    uint32_t  vector_cur = 0;
-    LoadInst *MapPtr = IRB.CreateLoad(PtrTy, AFLMapPtr);
-    ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(MapPtr);
+    uint32_t vector_cur = 0;
 
     while (1) {
 
@@ -1824,12 +1812,12 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
 
       if (!vector_cnt) {
 
-        MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, Result);
+        MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, Result);
 
       } else {
 
         auto element = IRB.CreateExtractElement(Result, vector_cur++);
-        MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, element);
+        MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, element);
 
       }
 
@@ -1847,21 +1835,18 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
       } else {
 
         LoadInst *Counter = IRB.CreateLoad(IRB.getInt8Ty(), MapPtrIdx);
-        ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(Counter);
+        setNoSanitizeMetadata(Counter);
 
         Value *Incr = IRB.CreateAdd(Counter, One);
 
         if (skip_nozero == NULL) {
 
-          auto cf = IRB.CreateICmpEQ(Incr, Zero);
-          markAflSkip(cf);
-          auto carry = IRB.CreateZExt(cf, Int8Ty);
-          Incr = IRB.CreateAdd(Incr, carry);
+          Incr = IRB.CreateBinaryIntrinsic(Intrinsic::umax, Incr, One);
 
         }
 
         auto nosan = IRB.CreateStore(Incr, MapPtrIdx);
-        ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(nosan);
+        setNoSanitizeMetadata(nosan);
 
       }
 
@@ -1870,6 +1855,19 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
     }
 
   };
+
+  /* Set up FuncMapPtr before the select/switch instrumentation loop,
+     because updateBitmapForResult uses it.  InjectCoverage (called later)
+     will reuse the same value. */
+  if (map_addr) {
+
+    FuncMapPtr = MapPtrFixed;
+
+  } else if (AFLMapPtr) {
+
+    FuncMapPtr = hoistMapPointerLoad(F, AFLMapPtr, PtrTy);
+
+  }
 
   for (auto &BB : F) {
 
@@ -2323,7 +2321,7 @@ void ModuleSanitizerCoverageLTO::InjectCoverageAtBlock(Function   &F,
           IRB.getInt32Ty(),
 #endif
           CTX_add);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(CTX_load);
+      setNoSanitizeMetadata(CTX_load);
       val = IRB.CreateAdd(CurLoc, CTX_load);
 
     }
@@ -2332,31 +2330,19 @@ void ModuleSanitizerCoverageLTO::InjectCoverageAtBlock(Function   &F,
     if (ijon_enabled && AFLIJONState) {
 
       LoadInst *IJONStateVal = IRB.CreateLoad(Int32Tyi, AFLIJONState);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(IJONStateVal);
+      setNoSanitizeMetadata(IJONStateVal);
       // Apply IJON formula: state XOR coverage_index
       Value *XorResult = IRB.CreateXor(IJONStateVal, val);
       // Ensure result stays within map bounds to prevent buffer overruns
       LoadInst *CovMapSize = IRB.CreateLoad(Int32Tyi, AFLCovMapSize);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(CovMapSize);
+      setNoSanitizeMetadata(CovMapSize);
       val = IRB.CreateURem(XorResult, CovMapSize);
 
     }
 
-    /* Load SHM pointer */
+    /* GEP into the SHM map (pointer loaded once in preamble) */
 
-    Value *MapPtrIdx;
-
-    if (map_addr) {
-
-      MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtrFixed, val);
-
-    } else {
-
-      LoadInst *MapPtr = IRB.CreateLoad(PtrTy, AFLMapPtr);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(MapPtr);
-      MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, val);
-
-    }
+    Value *MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, val);
 
     /* Update bitmap */
     if (use_threadsafe_counters) {                                /* Atomic */
@@ -2370,21 +2356,18 @@ void ModuleSanitizerCoverageLTO::InjectCoverageAtBlock(Function   &F,
     } else {
 
       LoadInst *Counter = IRB.CreateLoad(IRB.getInt8Ty(), MapPtrIdx);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(Counter);
+      setNoSanitizeMetadata(Counter);
 
       Value *Incr = IRB.CreateAdd(Counter, One);
 
       if (skip_nozero == NULL) {
 
-        auto cf = IRB.CreateICmpEQ(Incr, Zero);
-        markAflSkip(cf);
-        auto carry = IRB.CreateZExt(cf, Int8Tyi);
-        Incr = IRB.CreateAdd(Incr, carry);
+        Incr = IRB.CreateBinaryIntrinsic(Intrinsic::umax, Incr, One);
 
       }
 
       auto nosan = IRB.CreateStore(Incr, MapPtrIdx);
-      ModuleSanitizerCoverageLTO::SetNoSanitizeMetadata(nosan);
+      setNoSanitizeMetadata(nosan);
 
     }
 

--- a/instrumentation/SanitizerCoverageLTO.so.cc
+++ b/instrumentation/SanitizerCoverageLTO.so.cc
@@ -253,7 +253,7 @@ class ModuleSanitizerCoverageLTO
   GlobalVariable                  *AFLIJONState = NULL;
   const char                      *ijon_enabled = nullptr;
   Value                           *MapPtrFixed = NULL;
-  Value                           *FuncMapPtr = NULL;
+  Value                           *HoistedMapPtr = NULL;
   AllocaInst                      *CTX_add = NULL;
   std::ofstream                    dFile;
   size_t                           found = 0;
@@ -1812,12 +1812,12 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
 
       if (!vector_cnt) {
 
-        MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, Result);
+        MapPtrIdx = IRB.CreateGEP(Int8Ty, HoistedMapPtr, Result);
 
       } else {
 
         auto element = IRB.CreateExtractElement(Result, vector_cur++);
-        MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, element);
+        MapPtrIdx = IRB.CreateGEP(Int8Ty, HoistedMapPtr, element);
 
       }
 
@@ -1856,16 +1856,16 @@ void ModuleSanitizerCoverageLTO::instrumentFunction(
 
   };
 
-  /* Set up FuncMapPtr before the select/switch instrumentation loop,
+  /* Set up HoistedMapPtr before the select/switch instrumentation loop,
      because updateBitmapForResult uses it.  InjectCoverage (called later)
      will reuse the same value. */
   if (map_addr) {
 
-    FuncMapPtr = MapPtrFixed;
+    HoistedMapPtr = MapPtrFixed;
 
-  } else if (AFLMapPtr) {
+  } else {
 
-    FuncMapPtr = hoistMapPointerLoad(F, AFLMapPtr, PtrTy);
+    HoistedMapPtr = hoistMapPointerLoad(F, AFLMapPtr, PtrTy);
 
   }
 
@@ -2342,7 +2342,7 @@ void ModuleSanitizerCoverageLTO::InjectCoverageAtBlock(Function   &F,
 
     /* GEP into the SHM map (pointer loaded once in preamble) */
 
-    Value *MapPtrIdx = IRB.CreateGEP(Int8Ty, FuncMapPtr, val);
+    Value *MapPtrIdx = IRB.CreateGEP(Int8Ty, HoistedMapPtr, val);
 
     /* Update bitmap */
     if (use_threadsafe_counters) {                                /* Atomic */

--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -162,7 +162,7 @@ class ModuleSanitizerCoverageAFL
   void   setupIJONSymbols(Module &M, bool uses_ijon_state);
   Value *createGuardPointer(IRBuilder<> &IRB, uint32_t index);
   void   updateCoverageBitmap(IRBuilder<> &IRB, Value *CoverageIndex,
-                              LoadInst *MapPtr);
+                              Value *MapPtr);
   void   printDebugInfo(Instruction &IN);
   Value *instrumentVectorSelect(IRBuilder<> &IRB, Value *condition,
                                 FixedVectorType *tt, uint32_t &local_selects,
@@ -170,21 +170,8 @@ class ModuleSanitizerCoverageAFL
                                 uint32_t               special,
                                 ArrayRef<BasicBlock *> AllBlocks);
   void   updateCoverageForSelect(IRBuilder<> &IRB, Value *result,
-                                 LoadInst *MapPtr, uint32_t &vector_cnt);
+                                 Value *MapPtr, uint32_t &vector_cnt);
   void   setNoInstrumentMetadata(Value *V);
-
-  void SetNoSanitizeMetadata(Instruction *I) {
-
-#if LLVM_MAJOR >= 19
-    I->setNoSanitizeMetadata();
-#elif LLVM_MAJOR >= 16
-    I->setMetadata(LLVMContext::MD_nosanitize, MDNode::get(*C, std::nullopt));
-#else
-    I->setMetadata(I->getModule()->getMDKindID("nosanitize"),
-                   MDNode::get(*C, None));
-#endif
-
-  }
 
   std::string     getSectionName(const std::string &Section) const;
   std::string     getSectionStart(const std::string &Section) const;
@@ -209,6 +196,7 @@ class ModuleSanitizerCoverageAFL
   GlobalVariable *AFLMapPtr = NULL;
   GlobalVariable *AFLCovMapSize = NULL;
   GlobalVariable *AFLIJONState = NULL;
+  Value          *FuncMapPtr = NULL;
   ConstantInt    *One = NULL;
   ConstantInt    *Zero = NULL;
   bool            deny_exec = false;
@@ -417,7 +405,7 @@ void ModuleSanitizerCoverageAFL::setNoInstrumentMetadata(Value *V) {
 
 void ModuleSanitizerCoverageAFL::updateCoverageBitmap(IRBuilder<> &IRB,
                                                       Value    *CoverageIndex,
-                                                      LoadInst *MapPtr) {
+                                                      Value *MapPtr) {
 
   Value *MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, CoverageIndex);
 
@@ -431,21 +419,18 @@ void ModuleSanitizerCoverageAFL::updateCoverageBitmap(IRBuilder<> &IRB,
   } else {
 
     LoadInst *Counter = IRB.CreateLoad(IRB.getInt8Ty(), MapPtrIdx);
-    SetNoSanitizeMetadata(Counter);
+    setNoSanitizeMetadata(Counter);
 
     Value *Incr = IRB.CreateAdd(Counter, One);
 
     if (skip_nozero == NULL) {
 
-      auto cf = IRB.CreateICmpEQ(Incr, Zero);
-      setNoInstrumentMetadata(cf);
-      auto carry = IRB.CreateZExt(cf, Int8Ty);
-      Incr = IRB.CreateAdd(Incr, carry);
+      Incr = IRB.CreateBinaryIntrinsic(Intrinsic::umax, Incr, One);
 
     }
 
     StoreInst *StoreCtx = IRB.CreateStore(Incr, MapPtrIdx);
-    SetNoSanitizeMetadata(StoreCtx);
+    setNoSanitizeMetadata(StoreCtx);
 
   }
 
@@ -511,7 +496,7 @@ Value *ModuleSanitizerCoverageAFL::instrumentVectorSelect(
 
 void ModuleSanitizerCoverageAFL::updateCoverageForSelect(IRBuilder<> &IRB,
                                                          Value       *result,
-                                                         LoadInst    *MapPtr,
+                                                         Value       *MapPtr,
                                                          uint32_t &vector_cnt) {
 
   uint32_t vector_cur = 0;
@@ -523,7 +508,7 @@ void ModuleSanitizerCoverageAFL::updateCoverageForSelect(IRBuilder<> &IRB,
     if (!vector_cnt) {
 
       LoadInst *CurLoc = IRB.CreateLoad(IRB.getInt32Ty(), result);
-      SetNoSanitizeMetadata(CurLoc);
+      setNoSanitizeMetadata(CurLoc);
       MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, CurLoc);
 
     } else {
@@ -531,7 +516,7 @@ void ModuleSanitizerCoverageAFL::updateCoverageForSelect(IRBuilder<> &IRB,
       auto element = IRB.CreateExtractElement(result, vector_cur++);
       auto elementptr = IRB.CreateIntToPtr(element, Int32PtrTy);
       auto elementld = IRB.CreateLoad(IRB.getInt32Ty(), elementptr);
-      SetNoSanitizeMetadata(elementld);
+      setNoSanitizeMetadata(elementld);
       MapPtrIdx = IRB.CreateGEP(Int8Ty, MapPtr, elementld);
 
     }
@@ -546,21 +531,18 @@ void ModuleSanitizerCoverageAFL::updateCoverageForSelect(IRBuilder<> &IRB,
     } else {
 
       LoadInst *Counter = IRB.CreateLoad(IRB.getInt8Ty(), MapPtrIdx);
-      SetNoSanitizeMetadata(Counter);
+      setNoSanitizeMetadata(Counter);
 
       Value *Incr = IRB.CreateAdd(Counter, One);
 
       if (skip_nozero == NULL) {
 
-        auto cf = IRB.CreateICmpEQ(Incr, Zero);
-        setNoInstrumentMetadata(cf);
-        auto carry = IRB.CreateZExt(cf, Int8Ty);
-        Incr = IRB.CreateAdd(Incr, carry);
+        Incr = IRB.CreateBinaryIntrinsic(Intrinsic::umax, Incr, One);
 
       }
 
       StoreInst *StoreCtx = IRB.CreateStore(Incr, MapPtrIdx);
-      SetNoSanitizeMetadata(StoreCtx);
+      setNoSanitizeMetadata(StoreCtx);
 
     }
 
@@ -1145,6 +1127,9 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
   if (first) { first = 0; }
   selects += cnt_sel;
 
+  FuncMapPtr = NULL;
+  if (AFLMapPtr) { FuncMapPtr = hoistMapPointerLoad(F, AFLMapPtr, PtrTy); }
+
   uint32_t special = 0, local_selects = 0;
 
   for (auto &BB : F) {
@@ -1170,7 +1155,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
         Value *GuardPtr = createGuardPointer(
             IRB, special++ + local_selects + AllBlocks.size() - skip_blocks);
         LoadInst *Idx = IRB.CreateLoad(IRB.getInt32Ty(), GuardPtr);
-        SetNoSanitizeMetadata(Idx);
+        setNoSanitizeMetadata(Idx);
 
         auto *callInst = dyn_cast<CallInst>(&IN);
         callInst->setOperand(1, Idx);
@@ -1356,11 +1341,7 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
 
         }
 
-        // Load SHM pointer and update coverage bitmap
-        LoadInst *MapPtr = IRB.CreateLoad(PtrTy, AFLMapPtr);
-        SetNoSanitizeMetadata(MapPtr);
-
-        updateCoverageForSelect(IRB, result, MapPtr, vector_cnt);
+        updateCoverageForSelect(IRB, result, FuncMapPtr, vector_cnt);
         instr += vector_cnt;
 
       }
@@ -1443,12 +1424,7 @@ void ModuleSanitizerCoverageAFL::InjectCoverageAtBlock(Function   &F,
     Value *GuardPtr = createGuardPointer(IRB, Idx);
 
     LoadInst *CurLoc = IRB.CreateLoad(IRB.getInt32Ty(), GuardPtr);
-    ModuleSanitizerCoverageAFL::SetNoSanitizeMetadata(CurLoc);
-
-    /* Load SHM pointer */
-
-    LoadInst *MapPtr = IRB.CreateLoad(PtrTy, AFLMapPtr);
-    ModuleSanitizerCoverageAFL::SetNoSanitizeMetadata(MapPtr);
+    setNoSanitizeMetadata(CurLoc);
 
     /* Load counter for CurLoc */
 
@@ -1458,17 +1434,17 @@ void ModuleSanitizerCoverageAFL::InjectCoverageAtBlock(Function   &F,
     if (ijon_enabled && AFLIJONState) {
 
       LoadInst *IJONStateVal = IRB.CreateLoad(Int32Ty, AFLIJONState);
-      SetNoSanitizeMetadata(IJONStateVal);
+      setNoSanitizeMetadata(IJONStateVal);
       // Apply IJON formula: state XOR coverage_index
       Value *XorResult = IRB.CreateXor(IJONStateVal, CoverageIndex);
       // Ensure result stays within map bounds to prevent buffer overruns
       LoadInst *CovMapSize = IRB.CreateLoad(Int32Ty, AFLCovMapSize);
-      SetNoSanitizeMetadata(CovMapSize);
+      setNoSanitizeMetadata(CovMapSize);
       CoverageIndex = IRB.CreateURem(XorResult, CovMapSize);
 
     }
 
-    updateCoverageBitmap(IRB, CoverageIndex, MapPtr);
+    updateCoverageBitmap(IRB, CoverageIndex, FuncMapPtr);
 
     // done :)
 

--- a/instrumentation/afl-llvm-common.h
+++ b/instrumentation/afl-llvm-common.h
@@ -82,5 +82,41 @@ IS_EXTERN int be_quiet;
                                                \
   } while (0)
 
+/* Mark an instruction so sanitizer passes ignore it. */
+inline void setNoSanitizeMetadata(llvm::Instruction *I) {
+
+#if LLVM_VERSION_MAJOR >= 19
+  I->setNoSanitizeMetadata();
+#elif LLVM_VERSION_MAJOR >= 16
+  I->setMetadata(llvm::LLVMContext::MD_nosanitize,
+                 llvm::MDNode::get(I->getContext(), std::nullopt));
+#else
+  I->setMetadata(I->getModule()->getMDKindID("nosanitize"),
+                 llvm::MDNode::get(I->getContext(), llvm::None));
+#endif
+
+}
+
+/* Load __afl_area_ptr once at function entry and return the loaded value.
+   Creates a preamble basic block so later per-block instrumentation never
+   sees or displaces this load.  The load is marked invariant because
+   __afl_area_ptr is set once at process start and never changes. */
+inline llvm::Value *hoistMapPointerLoad(llvm::Function       &F,
+                                        llvm::GlobalVariable *AFLMapPtr,
+                                        llvm::Type           *PtrTy) {
+
+  using namespace llvm;
+  LLVMContext &Ctx = F.getContext();
+  BasicBlock  *OldEntry = &F.getEntryBlock();
+  BasicBlock *Preamble = BasicBlock::Create(Ctx, "afl.entry", &F, OldEntry);
+  IRBuilder<> IRB(Preamble);
+  auto       *Load = IRB.CreateLoad(PtrTy, AFLMapPtr);
+  setNoSanitizeMetadata(Load);
+  Load->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(Ctx, {}));
+  IRB.CreateBr(OldEntry);
+  return Load;
+
+}
+
 #endif
 

--- a/instrumentation/afl-llvm-pass.so.cc
+++ b/instrumentation/afl-llvm-pass.so.cc
@@ -55,6 +55,7 @@ typedef long double max_align_t;
 #include "llvm/IR/CFG.h"
 
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Intrinsics.h"
 
 #include "afl-llvm-common.h"
 #include "llvm-alternative-coverage.h"
@@ -726,10 +727,7 @@ PreservedAnalyses AFLCoverage::run(Module &M, ModuleAnalysisManager &MAM) {
            * Counter + OverflowFlag -> Counter
            */
 
-          ConstantInt *Zero = ConstantInt::get(Int8Ty, 0);
-          auto         cf = IRB.CreateICmpEQ(Incr, Zero);
-          auto         carry = IRB.CreateZExt(cf, Int8Ty);
-          Incr = IRB.CreateAdd(Incr, carry);
+          Incr = IRB.CreateBinaryIntrinsic(llvm::Intrinsic::umax, Incr, One);
 
         }
 

--- a/test/test-neverzero.sh
+++ b/test/test-neverzero.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+. ./test-pre.sh
+
+$ECHO "$BLUE[*] Testing: never-zero counter behavior"
+
+# Test with each available compiler that supports never-zero
+for AFL_COMPILER in afl-clang-fast afl-clang-lto; do
+
+  test -e ../${AFL_COMPILER} || continue
+
+  $ECHO "$GREY[*] Testing ${AFL_COMPILER} never-zero counters"
+
+  # Write a test program whose loop body executes exactly 256 times,
+  # which wraps an 8-bit counter back to 0.  With never-zero the
+  # counter must stay non-zero and therefore appear in afl-showmap
+  # output.
+  cat > test-neverzero.c <<'EOF'
+#include <stdlib.h>
+int main(void) {
+    volatile int x = 0;
+    /* 256 iterations wraps an 8-bit counter to 0. */
+    for (int i = 0; i < 256; i++) { x++; }
+    for (int i = 0; i < 256; i++) { x--; }
+    for (int i = 0; i < 256; i++) { x ^= i; }
+    /* 255 iterations must show 255 in both modes. */
+    for (int i = 0; i < 255; i++) { x++; }
+    for (int i = 0; i < 255; i++) { x--; }
+    for (int i = 0; i < 255; i++) { x ^= i; }
+    return 0;
+}
+EOF
+
+  # Build with never-zero enabled (default)
+  ../${AFL_COMPILER} -O0 -o test-neverzero-nz test-neverzero.c \
+      > /dev/null 2>&1
+  test -e test-neverzero-nz || {
+    $ECHO "$YELLOW[-] ${AFL_COMPILER} compilation failed, skipping"
+    continue
+  }
+
+  # Build with never-zero disabled
+  AFL_LLVM_SKIP_NEVERZERO=1 \
+      ../${AFL_COMPILER} -O0 -o test-neverzero-skip test-neverzero.c \
+      > /dev/null 2>&1
+  test -e test-neverzero-skip || {
+    $ECHO "$YELLOW[-] ${AFL_COMPILER} compilation (skip-nz) failed, skipping"
+    rm -f test-neverzero-nz
+    continue
+  }
+
+  # Run both through afl-showmap.  Output contains only non-zero
+  # edge:count pairs, so any counter that wrapped to 0 disappears.
+  echo | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} \
+      -o test-neverzero-nz.map -- ./test-neverzero-nz > /dev/null 2>&1
+  echo | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} \
+      -o test-neverzero-skip.map -- ./test-neverzero-skip > /dev/null 2>&1
+
+  test -s test-neverzero-nz.map -a -s test-neverzero-skip.map || {
+    $ECHO "$RED[!] ${AFL_COMPILER} afl-showmap produced no output"
+    CODE=1
+    rm -f test-neverzero-nz test-neverzero-skip test-neverzero-nz.map \
+          test-neverzero-skip.map test-neverzero.c
+    continue
+  }
+
+  NZ_EDGES=$(wc -l < test-neverzero-nz.map)
+  SKIP_EDGES=$(wc -l < test-neverzero-skip.map)
+
+  if [ "$NZ_EDGES" -gt "$SKIP_EDGES" ]; then
+    $ECHO "$GREEN[+] ${AFL_COMPILER} never-zero counters work: $NZ_EDGES edges vs $SKIP_EDGES without ($((NZ_EDGES - SKIP_EDGES)) preserved)"
+  else
+    $ECHO "$RED[!] ${AFL_COMPILER} never-zero counters BROKEN: $NZ_EDGES edges (should be more than $SKIP_EDGES)"
+    CODE=1
+  fi
+
+  rm -f test-neverzero-nz test-neverzero-skip test-neverzero-nz.map \
+        test-neverzero-skip.map test-neverzero.c
+
+done
+
+. ./test-post.sh


### PR DESCRIPTION
This hoists the map ptr to the function level and uses an intrinsic for saturating addition instead of a manual implementation. This reduced the LTO compile time for `lnav` (see #2399) to 5 minutes for me. Without the patch, building took +20 minutes (canceled the build at that point).

The improvements have been applied to LTO and PCGUARD, as a drive-by, I refactored code shared between the two passes.

Fixes #2399