### PR TITLE
Check for memory allocation failure in template.cpp

### DIFF
--- a/utils/qbdi_mode/template.cpp
+++ b/utils/qbdi_mode/template.cpp
@@ -129,6 +129,11 @@ char *read_file(char *path, unsigned long *length) {
   fseek(fp, 0, SEEK_END);
   len = ftell(fp);
   buf = (char *)malloc(len);
+  if (!buf) {
+      /** It handles the failure of dynamic memory allocation **/
+      fclose(fp); 
+      return NULL;
+  }
   rewind(fp);
   fread(buf, 1, len, fp);
   fclose(fp);


### PR DESCRIPTION
Handle memory allocation failure when reading file.
--

**Type of PR**: bug fix
**Purpose of this PR**: Check for memory allocation failure in template.cpp read_file function
**I have tested the changes**: yes
