### PR TITLE
Rate-limit cycle-boundary syncing in main to reduce overhead for fast targets

### DIFF
--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -568,6 +568,30 @@ static void fasan_check_afl_preload(char *afl_preload) {
 
 }
 
+/* Throttle syncs by `sync_time` and `sync_interval_cnt`. Pass NULL for
+   sync_interval_cnt to only limit by sync_time. Main node sync time is half of
+   secondary nodes, and a third of SYNC_INTERVAL
+ */
+static void maybe_sync_fuzzers(afl_state_t *afl, u64 cur_time,
+                               u32 *sync_interval_cnt) {
+
+  u64 sync_time = afl->is_main_node ? afl->sync_time >> 1 : afl->sync_time;
+
+  if (unlikely(cur_time > sync_time + afl->last_sync_time)) {
+
+    u32 sync_interval = afl->is_main_node ? SYNC_INTERVAL / 3 : SYNC_INTERVAL;
+
+    if (NULL == sync_interval_cnt ||
+        !((*sync_interval_cnt)++ % sync_interval)) {
+
+      sync_fuzzers(afl);
+
+    }
+
+  }
+
+}
+
 /* Main entry point */
 
 int main(int argc, char **argv_orig, char **envp) {
@@ -3365,7 +3389,8 @@ int main(int argc, char **argv_orig, char **envp) {
 
         }
 
-        sync_fuzzers(afl);
+        /* sync only based on sync_time, not sync_interval_cnt */
+        maybe_sync_fuzzers(afl, get_cur_time(), NULL);
 
       }
 
@@ -3696,27 +3721,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
     if (likely(!afl->stop_soon && afl->sync_id)) {
 
-      if (unlikely(afl->is_main_node)) {
-
-        if (unlikely(cur_time > (afl->sync_time >> 1) + afl->last_sync_time)) {
-
-          if (!(sync_interval_cnt++ % (SYNC_INTERVAL / 3))) {
-
-            sync_fuzzers(afl);
-
-          }
-
-        }
-
-      } else {
-
-        if (unlikely(cur_time > afl->sync_time + afl->last_sync_time)) {
-
-          if (!(sync_interval_cnt++ % SYNC_INTERVAL)) { sync_fuzzers(afl); }
-
-        }
-
-      }
+      maybe_sync_fuzzers(afl, cur_time, &sync_interval_cnt);
 
     }
 


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Enhancement
**Purpose of this PR**

I somewhat arbitrarily choose 10 seconds as the minimum time between two syncs. In `benchmark.py` I see an improvement of about 2.34% on my AMD Epyc for multicore. No change beyond noise in singlecore.

|CPU                                                 | MHz   | threads | singlecore | multicore | afl-*-config |
|----------------------------------------------------|-------|---------|------------|-----------|--------------|
|AMD EPYC 9354P 32-Core Processor (before this PR) | 3802  | 64      | 42944      | 1384121   | system       |
|AMD EPYC 9354P 32-Core Processor (after this PR) | 3800  | 64      | 42982      | 1416570   | system       | 


I have also tried an implementation based on `sync_time_us` which works as well, but I find the hardcoded 10 second simpler:

```cpp
/* Rate-limit cycle-boundary syncing to avoid overhead with fast
   targets that complete queue cycles very quickly. Sync time shouldn't
   take more than 5% of the runtime. */
if (unlikely(afl->start_time * 1000 >
             afl->last_sync_time * 1000 + afl->sync_time_us * 20)) {
  sync_fuzzers(afl);
}
```

**I have tested the changes**: yes

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
  
