### PR TITLE
Fix afl-cmin crash-only mode abort on non-crashing input

### DIFF
--- a/src/afl-cmin.c
+++ b/src/afl-cmin.c
@@ -1834,7 +1834,7 @@ static void test_target_binary(void) {
   } else {
 
     if (crashes_only)
-      FATAL("Target did not crash on input file '%s/%s', but -C specified.",
+      WARNF("Input '%s/%s' did not crash in -C mode; continuing.",
             f->dir, f->name);
 
   }


### PR DESCRIPTION
## Description

Fixes #2706 

When running `afl-cmin` with `-C` (crash-only mode), the tool incorrectly aborts if the first input file tested does not crash. This fix changes the premature abort to a warning, allowing crash filtering to happen correctly in the worker processes.

## Problem

The current implementation aborts with this error when the first input doesn't crash:
```
[-] PROGRAM ABORT : Target did not crash on input file 'all_inputs//file', but -C specified.
     Location : test_target_binary(), src/afl-cmin.c:1837
```

This is incorrect because:
1. `test_target_binary()` is meant to validate the target binary works, not enforce corpus semantics
2. In crash-only mode, it's expected that some inputs won't crash - they should be filtered out
3. Crash filtering is already handled by worker processes
4. The Python version (`afl-cmin.py`) does not abort in this situation

## Solution

Changed line 1837 in `src/afl-cmin.c` from:
```c
FATAL("Target did not crash on input file '%s/%s', but -C specified.", ...)
```

To:
```c
WARNF("Input '%s/%s' did not crash in -C mode; continuing.", ...)
```

This defers crash enforcement to the worker processing phase, aligning C behavior with the Python implementation.

## Changes

- **1 line changed** in `src/afl-cmin.c` (line 1837)
- No whitespace modifications
- No other code changes

## Testing

The fix can be verified by:
1. Creating a corpus with mixed crashing and non-crashing inputs
2. Running `afl-cmin -C -i input_dir -o output_dir -- ./target`
3. Verifying that:
   - No abort occurs
   - Warning is shown for non-crashing inputs
   - Only crashing inputs are written to output directory
   - Non-crashing inputs are filtered out

## Impact

- **Fixes:** Issue #2706
- **Component:** `afl-cmin` crash-only mode (`-C` flag)
- **Risk:** Low - minimal change, defers existing logic to correct phase
- **Compatibility:** Maintains backward compatibility, fixes broken functionality