### PR TITLE
Fix two PCGUARD sub-block coverage bugs for atomic instructions

### DIFF
--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -1049,17 +1049,10 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
 
         } else if (cxchg) {
 
-          if (cxchg->getType()->isIntegerTy(1)) {
-
-            block_is_instrumented = true;
-            cnt_sel++;
-            cnt_sel_inc += 2;
-
-          } else {
-
-            unhandled++;
-
-          }
+          // cmpxchg returns {T, i1}, always a struct — no type guard needed
+          block_is_instrumented = true;
+          cnt_sel++;
+          cnt_sel_inc += 2;
 
         } else if (rmw) {
 
@@ -1230,8 +1223,6 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
           // fprintf(stderr, "Fcmp!\n");
 
         } else if (cxchg) {
-
-          if (!cxchg->getType()->isIntegerTy(1)) { continue; }
 
           if (debug) printDebugInfo(IN);
 

--- a/instrumentation/SanitizerCoveragePCGUARD.so.cc
+++ b/instrumentation/SanitizerCoveragePCGUARD.so.cc
@@ -1056,17 +1056,10 @@ bool ModuleSanitizerCoverageAFL::InjectCoverage(
 
         } else if (rmw) {
 
-          if (rmw->getType()->isIntegerTy(1)) {
-
-            block_is_instrumented = true;
-            cnt_sel++;
-            cnt_sel_inc += 2;
-
-          } else {
-
-            unhandled++;
-
-          }
+          // atomicrmw returns the old value (e.g. i32) — no type guard needed
+          block_is_instrumented = true;
+          cnt_sel++;
+          cnt_sel_inc += 2;
 
         } else if ((selectInst = dyn_cast<SelectInst>(&IN))) {
 

--- a/test/test-pcguard-atomic.sh
+++ b/test/test-pcguard-atomic.sh
@@ -3,8 +3,8 @@
 #
 # Regression tests for PCGUARD sub-block coverage of atomic instructions.
 #
-# Tests that AtomicCmpXchgInst is properly instrumented for sub-block
-# coverage, not reported as "unhandled".
+# Tests that AtomicCmpXchgInst and AtomicRMWInst (min/max) are properly
+# instrumented for sub-block coverage, not reported as "unhandled".
 #
 
 . ./test-pre.sh
@@ -54,6 +54,42 @@ test -e ../afl-clang-fast && {
     rm -f test-pcguard-cmpxchg
   } || {
     $ECHO "$RED[!] cmpxchg test compilation failed"
+    CODE=1
+  }
+
+  # --- Test 2: AtomicRMWInst min/max sub-block coverage ---
+  $ECHO "$BLUE[*] Testing: atomicrmw min/max sub-block coverage"
+  RESULT=$(AFL_DEBUG=1 ../afl-clang-fast -O0 -o test-pcguard-atomicrmw test-pcguard-atomicrmw.c 2>&1)
+  test -e test-pcguard-atomicrmw && {
+    COUNTS=$(extract_handled_unhandled "$RESULT")
+    HANDLED=
+    UNHANDLED=
+    test -n "$COUNTS" && {
+      HANDLED=${COUNTS%% *}
+      UNHANDLED=${COUNTS##* }
+    }
+    test "$UNHANDLED" = "0" && {
+      test -n "$HANDLED" && test "$HANDLED" -gt 0 && {
+        $ECHO "$GREEN[+] atomicrmw min/max sub-block coverage works correctly ($HANDLED handled, $UNHANDLED unhandled)"
+      } || {
+        test -z "$HANDLED" && {
+          $ECHO "$RED[!] failed to parse handled/unhandled counts from compiler output"
+        } || {
+          $ECHO "$RED[!] atomicrmw not instrumented for sub-block coverage (handled=$HANDLED)"
+        }
+        CODE=1
+      }
+    } || {
+      test -z "$UNHANDLED" && {
+        $ECHO "$RED[!] failed to parse handled/unhandled counts from compiler output"
+      } || {
+        $ECHO "$RED[!] atomicrmw reported as unhandled ($UNHANDLED unhandled)"
+      }
+      CODE=1
+    }
+    rm -f test-pcguard-atomicrmw
+  } || {
+    $ECHO "$RED[!] atomicrmw test compilation failed"
     CODE=1
   }
 

--- a/test/test-pcguard-atomic.sh
+++ b/test/test-pcguard-atomic.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+#
+# Regression tests for PCGUARD sub-block coverage of atomic instructions.
+#
+# Tests that AtomicCmpXchgInst is properly instrumented for sub-block
+# coverage, not reported as "unhandled".
+#
+
+. ./test-pre.sh
+
+$ECHO "$BLUE[*] Testing: PCGUARD sub-block coverage for atomic instructions"
+
+extract_handled_unhandled() {
+
+  echo "$1" | sed -n 's/.*of which are \([0-9][0-9]*\) handled and \([0-9][0-9]*\) unhandled.*/\1 \2/p' | tail -n 1
+
+}
+
+test -e ../afl-clang-fast && {
+
+  # --- Test 1: AtomicCmpXchgInst sub-block coverage ---
+  $ECHO "$BLUE[*] Testing: cmpxchg sub-block coverage"
+  RESULT=$(AFL_DEBUG=1 ../afl-clang-fast -O0 -o test-pcguard-cmpxchg test-pcguard-cmpxchg.c 2>&1)
+  test -e test-pcguard-cmpxchg && {
+    COUNTS=$(extract_handled_unhandled "$RESULT")
+    HANDLED=
+    UNHANDLED=
+    test -n "$COUNTS" && {
+      HANDLED=${COUNTS%% *}
+      UNHANDLED=${COUNTS##* }
+    }
+    # Check that cmpxchg is handled (0 unhandled), not skipped
+    test "$UNHANDLED" = "0" && {
+      # Check that sub-block coverage was emitted (handled > 0)
+      test -n "$HANDLED" && test "$HANDLED" -gt 0 && {
+        $ECHO "$GREEN[+] cmpxchg sub-block coverage works correctly ($HANDLED handled, $UNHANDLED unhandled)"
+      } || {
+        test -z "$HANDLED" && {
+          $ECHO "$RED[!] failed to parse handled/unhandled counts from compiler output"
+        } || {
+          $ECHO "$RED[!] cmpxchg not instrumented for sub-block coverage (handled=$HANDLED)"
+        }
+        CODE=1
+      }
+    } || {
+      test -z "$UNHANDLED" && {
+        $ECHO "$RED[!] failed to parse handled/unhandled counts from compiler output"
+      } || {
+        $ECHO "$RED[!] cmpxchg reported as unhandled ($UNHANDLED unhandled)"
+      }
+      CODE=1
+    }
+    rm -f test-pcguard-cmpxchg
+  } || {
+    $ECHO "$RED[!] cmpxchg test compilation failed"
+    CODE=1
+  }
+
+} || {
+  $ECHO "$YELLOW[-] afl-clang-fast not built, skipping atomic sub-block tests"
+}
+
+. ./test-post.sh

--- a/test/test-pcguard-atomicrmw.c
+++ b/test/test-pcguard-atomicrmw.c
@@ -1,0 +1,37 @@
+/*
+ * Regression test for PCGUARD sub-block coverage of AtomicRMWInst min/max.
+ *
+ * AtomicRMWInst::getType() returns the operand type (e.g. i32), not i1.
+ * The PCGUARD pass had a buggy isIntegerTy(1) check in the counting phase
+ * that always failed for rmw, so no guard slots were allocated.  However
+ * the instrumentation phase had no such guard and proceeded to emit code
+ * that consumed guard slots, causing an out-of-bounds access on the
+ * guard array.
+ *
+ * Compile with: AFL_DEBUG=1 afl-clang-fast -O0 -o test-pcguard-atomicrmw this.c
+ * Verify: output should show "0 ... unhandled" (not "2 ... unhandled")
+ */
+
+#include <stdio.h>
+
+unsigned shared_min = 100;
+unsigned shared_max = 0;
+
+unsigned test_atomic_minmax(unsigned val) {
+
+  /* These builtins compile to atomicrmw umin / umax instructions.
+     The PCGUARD pass should provide sub-block coverage for the
+     update/no-update outcome of each operation. */
+  unsigned old_min = __atomic_fetch_min(&shared_min, val, __ATOMIC_SEQ_CST);
+  unsigned old_max = __atomic_fetch_max(&shared_max, val, __ATOMIC_SEQ_CST);
+  return old_min + old_max;
+
+}
+
+int main(void) {
+
+  printf("result: %u\n", test_atomic_minmax(42));
+  return 0;
+
+}
+

--- a/test/test-pcguard-cmpxchg.c
+++ b/test/test-pcguard-cmpxchg.c
@@ -1,0 +1,41 @@
+/*
+ * Regression test for PCGUARD sub-block coverage of AtomicCmpXchgInst.
+ *
+ * AtomicCmpXchgInst::getType() returns {T, i1} (a StructType), not i1.
+ * The PCGUARD pass had a buggy isIntegerTy(1) check that always failed
+ * for cmpxchg, causing it to be counted as "unhandled" and never
+ * instrumented for sub-block coverage.
+ *
+ * Compile with: AFL_DEBUG=1 afl-clang-fast -O0 -o test-pcguard-cmpxchg this.c
+ * Verify: output should show "0 ... unhandled" (not "1 ... unhandled")
+ */
+
+#include <stdio.h>
+
+int shared = 0;
+
+int test_cmpxchg(int expected, int desired) {
+
+  /* __atomic_compare_exchange_n compiles to a cmpxchg instruction.
+     The PCGUARD pass should provide sub-block coverage for the
+     success/failure outcome of this atomic operation. */
+  if (__atomic_compare_exchange_n(&shared, &expected, desired, 0,
+                                  __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+
+    return 1;
+
+  } else {
+
+    return 0;
+
+  }
+
+}
+
+int main(void) {
+
+  printf("result: %d\n", test_cmpxchg(0, 42));
+  return 0;
+
+}
+


### PR DESCRIPTION
# Summary
The current LLVM pass has two bugs in handling atomic instructions:
- `AtomicCmpXchgInst` was incorrectly gated by `isIntegerTy(1)`, so cmpxchg sub-block instrumentation was skipped.
- `AtomicRMWInst` min/max/umin/umax was incorrectly gated in counting, causing guard under-allocation while instrumentation still consumed guard slots.

The root cause for both issues came from type checks that seems to have been copied from scalar compare handling (`i1`), but:
- `cmpxchg` returns `{T, i1}` (struct), not `i1`
- `atomicrmw` returns the old operand type (e.g. `i32`), not `i1`

The fix was to 1) remove invalid type gating for `cmpxchg` in counting and instrumentation, and 2) remove invalid type gating for `atomicrmw` in counting so guard sizing matches emitted instrumentation.
