### PR TITLE
Fix CmpLog ICE with non-standard integer sizes

### DIFF
--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -418,9 +418,12 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
           cast_size = 64;
           break;
         default:
+          // 65-128 bit values are handled via 128-bit hooks.
           cast_size = 128;
 
       }
+
+      bool use_hookN = cast_size == 128 && cast_size != max_size;
 
       // XXX FIXME BUG TODO
       if (is_fp && vector_cnt) { continue; }
@@ -521,7 +524,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
           ConstantInt *attribute = ConstantInt::get(Int8Ty, attr);
           args.push_back(attribute);
 
-          if (cast_size != max_size) {
+          if (use_hookN) {
 
             ConstantInt *bitsize = ConstantInt::get(Int8Ty, (max_size / 8) - 1);
             args.push_back(bitsize);
@@ -546,13 +549,13 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
               IRB.CreateCall(cmplogHookIns8, args);
               break;
             case 128:
-              if (max_size == 128) {
+              if (use_hookN) {
 
-                IRB.CreateCall(cmplogHookIns16, args);
+                IRB.CreateCall(cmplogHookInsN, args);
 
               } else {
 
-                IRB.CreateCall(cmplogHookInsN, args);
+                IRB.CreateCall(cmplogHookIns16, args);
 
               }
 
@@ -604,4 +607,3 @@ PreservedAnalyses CmpLogInstructions::run(Module                &M,
     return PreservedAnalyses();
 
 }
-

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -186,6 +186,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
                                             Int64Ty, Int64Ty, Int8Ty);
   FunctionCallee cmplogHookIns8 = c8;
 
+#if INTPTR_MAX != INT32_MAX
   FunctionCallee c16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy,
                                              Int128Ty, Int128Ty, Int8Ty);
   FunctionCallee cmplogHookIns16 = c16;
@@ -193,6 +194,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
   FunctionCallee cN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy,
                                             Int128Ty, Int128Ty, Int8Ty, Int8Ty);
   FunctionCallee cmplogHookInsN = cN;
+#endif
 
   GlobalVariable *AFLCmplogPtr = M.getNamedGlobal("__afl_cmp_map");
 
@@ -549,6 +551,7 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
               IRB.CreateCall(cmplogHookIns8, args);
               break;
             case 128:
+#if INTPTR_MAX != INT32_MAX
               if (use_hookN) {
 
                 IRB.CreateCall(cmplogHookInsN, args);
@@ -558,6 +561,8 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
                 IRB.CreateCall(cmplogHookIns16, args);
 
               }
+
+#endif
 
               break;
 
@@ -607,3 +612,4 @@ PreservedAnalyses CmpLogInstructions::run(Module                &M,
     return PreservedAnalyses();
 
 }
+

--- a/test/test-cmplog-bitint.sh
+++ b/test/test-cmplog-bitint.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Regression test for GitHub issue #2704:
+# cmplog-instructions-pass ICE with non-standard integer sizes (_BitInt).
+#
+# For non-standard integer sizes, the pass should cast to the next supported
+# width up to 64-bit and only use __cmplog_ins_hookN for >64-bit sizes.
+
+cd "$(dirname "$0")/.." || exit 1
+
+TEMP_DIR=$(mktemp -d)
+cleanup() { rm -rf "$TEMP_DIR"; }
+trap cleanup EXIT
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+# Check if afl-clang-fast exists
+if [ ! -x "./afl-clang-fast" ]; then
+    echo "Error: afl-clang-fast not found. Build AFL++ first."
+    exit 1
+fi
+
+# Check if the compiler supports _BitInt
+echo "int main(){_BitInt(24) x=0;return(int)x;}" > "$TEMP_DIR/check.c"
+if ! AFL_QUIET=1 ./afl-clang-fast -o /dev/null -c "$TEMP_DIR/check.c" 2>/dev/null; then
+    echo "Compiler does not support _BitInt, skipping test"
+    exit 0
+fi
+
+test_bitint() {
+    local name="$1" bits="$2" expected_hook="$3"
+
+    cat > "$TEMP_DIR/test.c" << EOF
+__attribute__((noinline)) int test(volatile _BitInt($bits) *a,
+                                   volatile _BitInt($bits) *b) {
+    return *a == *b;
+}
+int main(void) {
+    volatile _BitInt($bits) x = 1, y = 2;
+    return test(&x, &y);
+}
+EOF
+
+    AFL_LLVM_CMPLOG=1 AFL_QUIET=1 ./afl-clang-fast -S -emit-llvm \
+        -o "$TEMP_DIR/test.ll" "$TEMP_DIR/test.c" 2>/dev/null
+    if [ $? -ne 0 ]; then
+        printf "%-16s ${RED}FAIL${NC} (compilation failed)\n" "$name"
+        ((FAIL++))
+        return
+    fi
+
+    # Extract only the test() function and look for the hook call
+    local hook
+    hook=$(sed -n '/^define.*@test(/,/^}$/p' "$TEMP_DIR/test.ll" 2>/dev/null \
+        | grep -o '__cmplog_ins_hook[A-Za-z0-9]*')
+
+    if [ -z "$hook" ]; then
+        printf "%-16s ${RED}FAIL${NC} (no cmplog hook found)\n" "$name"
+        ((FAIL++))
+        return
+    fi
+
+    if [ "$hook" = "$expected_hook" ]; then
+        printf "%-16s hook=%-24s ${GREEN}PASS${NC}\n" "$name" "$hook"
+        ((PASS++))
+    else
+        printf "%-16s hook=%-24s ${RED}FAIL${NC} (expected %s)\n" \
+            "$name" "$hook" "$expected_hook"
+        ((FAIL++))
+    fi
+}
+
+echo "Testing cmplog-instructions-pass with non-standard integer sizes..."
+echo "(Regression test for GitHub issue #2704)"
+echo
+
+# Non-standard sizes <=64: cast to next supported hook width.
+test_bitint "_BitInt(24)" 24 "__cmplog_ins_hook4"
+test_bitint "_BitInt(33)" 33 "__cmplog_ins_hook8"
+test_bitint "_BitInt(40)" 40 "__cmplog_ins_hook8"
+test_bitint "_BitInt(48)" 48 "__cmplog_ins_hook8"
+
+# Standard sizes: must use the efficient specialized hooks
+test_bitint "_BitInt(16)" 16 "__cmplog_ins_hook2"
+test_bitint "_BitInt(32)" 32 "__cmplog_ins_hook4"
+test_bitint "_BitInt(64)" 64 "__cmplog_ins_hook8"
+test_bitint "_BitInt(100)" 100 "__cmplog_ins_hookN"
+test_bitint "_BitInt(128)" 128 "__cmplog_ins_hook16"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/test/test-cmplog-bitint.sh
+++ b/test/test-cmplog-bitint.sh
@@ -84,8 +84,14 @@ test_bitint "_BitInt(48)" 48 "__cmplog_ins_hook8"
 test_bitint "_BitInt(16)" 16 "__cmplog_ins_hook2"
 test_bitint "_BitInt(32)" 32 "__cmplog_ins_hook4"
 test_bitint "_BitInt(64)" 64 "__cmplog_ins_hook8"
-test_bitint "_BitInt(100)" 100 "__cmplog_ins_hookN"
-test_bitint "_BitInt(128)" 128 "__cmplog_ins_hook16"
+
+if [ "$(getconf LONG_BIT 2>/dev/null)" = "64" ]; then
+    # >64-bit compares are only supported on 64-bit systems.
+    test_bitint "_BitInt(100)" 100 "__cmplog_ins_hookN"
+    test_bitint "_BitInt(128)" 128 "__cmplog_ins_hook16"
+else
+    echo "Skipping >64-bit hook checks on 32-bit host"
+fi
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/test/test-llvm.sh
+++ b/test/test-llvm.sh
@@ -315,6 +315,15 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
       CODE=1
     }
   }
+  # Test cmplog instructions pass with non-standard integer sizes (issue #2704)
+  test -e test-cmplog-bitint.sh && {
+    ./test-cmplog-bitint.sh > /dev/null 2>&1 && {
+      $ECHO "$GREEN[+] cmplog non-standard integer size test passed (issue #2704)"
+    } || {
+      $ECHO "$RED[!] cmplog non-standard integer size test failed (issue #2704)"
+      CODE=1
+    }
+  }
   ../afl-clang-fast -o test-persistent ../utils/persistent_mode/persistent_demo.c > /dev/null 2>&1
   test -e test-persistent && {
     echo foo | AFL_QUIET=1 ../afl-showmap -m ${MEM_LIMIT} -o /dev/null -q -r ./test-persistent && {


### PR DESCRIPTION
Fix internal compiler errors in cmplog-instructions-pass when instrumenting comparisons on non-standard integer widths (e.g., _BitInt(24) and _BitInt(40)). Currently, the pass appends a 4th size argument in this cases, which produces invalid 4-argument calls to 3-argument hooks (`__cmplog_ins_hook4` / `__cmplog_ins_hook8`) triggering assertion failures onLLVM assertion builds.

This PR fixes hook selection and argument passing by:
- Routing non-standard widths up to 64-bit to the next supported hook width (32/64)
- Using `__cmplog_ins_hookN` only for 65..127-bit compares
- Passing the 4th size argument only when calling `__cmplog_ins_hookN`
- Guarding 128-bit hook declarations/calls on 32-bit targets

Fixes #2704 