### PR TITLE
fix CmpLog compilation failure with annotate attribute

### DIFF
--- a/instrumentation/cmplog-routines-pass.cc
+++ b/instrumentation/cmplog-routines-pass.cc
@@ -170,6 +170,7 @@ bool CmpLogRoutines::hookRtns(Module &M) {
 
           Function *Callee = callInst->getCalledFunction();
           if (!Callee) continue;
+          if (Callee->isIntrinsic()) continue;
           if (callInst->getCallingConv() != llvm::CallingConv::C) continue;
 
           FunctionType *FT = Callee->getFunctionType();

--- a/test/test-cmplog-annotate.sh
+++ b/test/test-cmplog-annotate.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Test for https://github.com/AFLplusplus/AFLplusplus/issues/2723
+# Verifies that cmplog does not break compilation when __attribute__((annotate))
+# is used. The annotate attribute causes clang to emit an llvm.ptr.annotation
+# intrinsic call that the cmplog-routines-pass incorrectly tries to instrument,
+# because it matches the isPtrRtn heuristic (2+ ptr args, non-void return).
+# The intrinsic's string argument lives in section "llvm.metadata" and must not
+# be referenced by emitted code.
+
+cd "$(dirname "$0")/.." || exit 1
+
+TEMP_DIR=$(mktemp -d)
+cleanup() { rm -rf "$TEMP_DIR"; }
+trap cleanup EXIT
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+if [ ! -x "./afl-clang-fast++" ]; then
+    echo "Error: afl-clang-fast++ not found. Build AFL++ first."
+    exit 1
+fi
+
+test_annotate() {
+    local name="$1" src="$2"
+
+    echo "$src" > "$TEMP_DIR/test.cc"
+
+    # Baseline: must compile without cmplog
+    if ! AFL_QUIET=1 ./afl-clang-fast++ -c "$TEMP_DIR/test.cc" -o "$TEMP_DIR/test.o" 2>/dev/null; then
+        printf "%-40s ${RED}FAIL${NC} (baseline compilation failed)\n" "$name"
+        ((FAIL++))
+        return
+    fi
+
+    # With cmplog: the actual bug
+    if ! AFL_QUIET=1 AFL_CMPLOG=1 ./afl-clang-fast++ -c "$TEMP_DIR/test.cc" -o "$TEMP_DIR/test.o" 2>/dev/null; then
+        printf "%-40s ${RED}FAIL${NC} (cmplog compilation failed)\n" "$name"
+        ((FAIL++))
+        return
+    fi
+
+    printf "%-40s ${GREEN}PASS${NC}\n" "$name"
+    ((PASS++))
+}
+
+echo "Testing cmplog with __attribute__((annotate))..."
+echo "(Regression test for GitHub issue #2723)"
+echo
+
+test_annotate "struct field annotate" \
+'struct S {
+    __attribute__((annotate("dummy"))) int x = 0;
+};
+void f() { S s; }'
+
+test_annotate "function annotate + strcmp" \
+'__attribute__((annotate("fuzz_me")))
+int compare(const char *a, const char *b) {
+    return __builtin_strcmp(a, b);
+}'
+
+test_annotate "local variable annotate" \
+'void g() {
+    __attribute__((annotate("important"))) int val = 42;
+    (void)val;
+}'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Skip LLVM intrinsics in cmplog-routines-pass to prevent instrumenting `llvm.ptr.annotation` calls whose string args live in llvm.metadata and cannot be referenced by emitted code.

Fixes https://github.com/AFLplusplus/AFLplusplus/issues/2723