### PR TITLE
Fix afl-cmin qemu mode

### DIFF
--- a/src/afl-cmin.c
+++ b/src/afl-cmin.c
@@ -2362,6 +2362,10 @@ int main(int argc, char **argv) {
 
   target_bin = argv[optind];
   target_args = (u8 **)(argv + optind);
+  if (qemu_mode) {
+    target_args = (u8**) get_qemu_argv(argv[0], &target_bin, argc - optind,
+                                       argv + optind);
+  }
 
   if (stdin_file && exec_workers > 1) {
 

--- a/src/afl-cmin.c
+++ b/src/afl-cmin.c
@@ -2363,7 +2363,7 @@ int main(int argc, char **argv) {
   target_bin = argv[optind];
   target_args = (u8 **)(argv + optind);
   if (qemu_mode) {
-    target_args = (u8**) get_qemu_argv(argv[0], &target_bin, argc - optind,
+    target_args = (u8 **)get_qemu_argv(argv[0], &target_bin, argc - optind,
                                        argv + optind);
   }
 


### PR DESCRIPTION
# Fix afl-cmin qemu mode

The c implementation for `afl-cmin` fails to convert the target arguments for qemu mode, resulting in it never using `afl-qemu-trace` and failing to run.

**Type of PR**:  Bugfix
**Purpose of this PR**:  Fix qemu mode in `afl-cmin`
**I have tested the changes**: yes
