### PR TITLE
extend wasm32-wasi passthrough to cover wasm32-wasip1

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2841,7 +2841,8 @@ param_st parse_misc_params(aflcc_state_t *aflcc, u8 *cur_argv, u8 scan) {
 
     SCAN_KEEP(aflcc->preprocessor_only, 1);
 
-  } else if (!strcmp(cur_argv, "--target=wasm32-wasi")) {
+  } else if (!strcmp(cur_argv, "--target=wasm32-wasi") ||
+             !strcmp(cur_argv, "--target=wasm32-wasip1")) {
 
     SCAN_KEEP(aflcc->passthrough, 1);
 


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: wasm32-wasip1 is the new canonical name for the wasm32-wasi target (wasi Preview 1). Clang has deprecated --target=wasm32-wasi in favour of --target=wasm32-wasip1 and will start warning (and, with -Werror, erroring) when the old name is used.
**I have tested the changes**: yes