### PR TITLE
Support shared ASAN by only using weak declarations without definitions

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -2694,18 +2694,19 @@ void __sanitizer_cov_trace_switch(uint64_t val, uint64_t *cases) {
 
 }
 
-__attribute__((weak)) void *__asan_region_is_poisoned(void *beg, size_t size) {
-
-  return NULL;
-
-}
+__attribute__((weak)) void *__asan_region_is_poisoned(void *beg, size_t size);
 
 // POSIX shenanigan to see if an area is mapped.
 // If it is mapped as X-only, we have a problem, so maybe we should add a check
 // to avoid to call it on .text addresses
 static int area_is_valid(void *ptr, size_t len) {
 
-  if (unlikely(!ptr || __asan_region_is_poisoned(ptr, len))) { return 0; }
+  if (unlikely(!ptr || (__asan_region_is_poisoned &&
+                        __asan_region_is_poisoned(ptr, len)))) {
+
+    return 0;
+
+  }
 
 #ifdef __HAIKU__
   long r = _kern_write(__afl_dummy_fd[1], -1, ptr, len);

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2032,12 +2032,6 @@ void add_sanitizers(aflcc_state_t *aflcc, char **envp) {
     if (getenv("AFL_HARDEN"))
       FATAL("ASAN and AFL_HARDEN are mutually exclusive");
 
-    if (aflcc->compiler_mode == GCC_PLUGIN && !aflcc->have_staticasan) {
-
-      insert_param(aflcc, "-static-libasan");
-
-    }
-
     add_defs_fortify(aflcc, 0);
     if (!aflcc->have_asan) {
 

--- a/utils/aflpp_driver/aflpp_driver.c
+++ b/utils/aflpp_driver/aflpp_driver.c
@@ -132,25 +132,12 @@ __attribute__((weak)) void    LLVMFuzzerCleanup(void);
 __attribute__((weak)) int     LLVMFuzzerRunDriver(
         int *argc, char ***argv, int (*callback)(const uint8_t *data, size_t size));
 
-// Default nop ASan hooks for manual poisoning when not linking the ASan
-// runtime
+// ASan manual poisoning hooks, if present
 // https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning
 __attribute__((weak)) void __asan_poison_memory_region(
-    void const volatile *addr, size_t size) {
-
-  (void)addr;
-  (void)size;
-
-}
-
+    void const volatile *addr, size_t size);
 __attribute__((weak)) void __asan_unpoison_memory_region(
-    void const volatile *addr, size_t size) {
-
-  (void)addr;
-  (void)size;
-
-}
-
+    void const volatile *addr, size_t size);
 __attribute__((weak)) void *__asan_region_is_poisoned(void *beg, size_t size);
 
 // Notify AFL about persistent mode.
@@ -269,8 +256,9 @@ static int ExecuteFilesOnyByOne(int argc, char **argv,
                                                 size_t         size)) {
 
   unsigned char *buf = (unsigned char *)malloc(MAX_FILE);
+  bool           have_asan = __asan_region_is_poisoned;
 
-  __asan_poison_memory_region(buf, MAX_FILE);
+  if (have_asan) { __asan_poison_memory_region(buf, MAX_FILE); }
   ssize_t prev_length = 0;
 
   for (int i = 1; i < argc; i++) {
@@ -289,13 +277,18 @@ static int ExecuteFilesOnyByOne(int argc, char **argv,
 
     if (length > 0) {
 
-      if (length < prev_length) {
+      if (have_asan) {
 
-        __asan_poison_memory_region(buf + length, prev_length - length);
+        if (length < prev_length) {
 
-      } else {
+          __asan_poison_memory_region(buf + length, prev_length - length);
 
-        __asan_unpoison_memory_region(buf + prev_length, length - prev_length);
+        } else {
+
+          __asan_unpoison_memory_region(buf + prev_length,
+                                        length - prev_length);
+
+        }
 
       }
 
@@ -436,11 +429,12 @@ __attribute__((weak)) int LLVMFuzzerRunDriver(
 
   __afl_manual_init();
 
-  __asan_poison_memory_region(__afl_fuzz_ptr, MAX_FILE);
   size_t prev_length = 0;
 
   // for speed only insert asan functions if the target is linked with asan
   if (unlikely(__asan_region_is_poisoned)) {
+
+    __asan_poison_memory_region(__afl_fuzz_ptr, MAX_FILE);
 
     while (__afl_persistent_loop(N)) {
 


### PR DESCRIPTION
**Type of PR**: Bugfix/Enhancement
**Purpose of this PR**: Provide an alternative fix to #1716 to support shared ASAN
**I have tested the changes**: yes

The root of #1716 is that, with dynamic linking, AFL++'s `__attribute__((weak))` no-op ASAN stubs still end up interposing the real ASAN interceptors. The workaround added in #1966 was to just force `-static-libasan` for GCC where shared ASAN is the default.

This PR removes that workaround, and instead fixes the issue by replacing the weak definitions with weak declarations. This makes the symbols `STB_WEAK` + `SHN_UNDEF`, so the dynamic linker either resolves the real ones from `libasan.so` or leaves them `NULL` (which each callsite must check).

You can replicate the original issue and test the fix by running the following Dockerfile:

```
FROM debian:trixie
RUN apt-get update && apt-get install -y --no-install-recommends \
        build-essential clang llvm-dev libclang-rt-dev \
        gcc-14-plugin-dev \
        python3 git ca-certificates \
    && rm -rf /var/lib/apt/lists/*

RUN git clone --depth=1 --branch stable \
        https://github.com/AFLplusplus/AFLplusplus.git /aflpp-upstream && \
    cd /aflpp-upstream && make -j$(nproc) source-only NO_NYX=1 2>&1 | tail -1
RUN git clone --depth=1 --branch shared-asan \
        https://github.com/Scott-Guest/AFLplusplus.git /aflpp-fixed && \
    cd /aflpp-fixed && make -j$(nproc) source-only NO_NYX=1 2>&1 | tail -1

RUN cat > /harness.c <<'EOF'
#include <string.h>
#include <stdio.h>
#include <stdlib.h>
int main() {
  char *x = (char*)malloc(5 * sizeof(char));
  memset(x, 0, 5);
  char *y = (char*)malloc(10 * sizeof(char));
  memcpy(y, x, 10);
  free(x);
  free(y);
  return 0;
}
EOF

RUN cat > /test.sh <<'EOF'
#!/bin/bash
ASAN_LIB=$(clang -print-file-name=libclang_rt.asan-$(uname -m).so)

echo '=== upstream (afl-clang-fast) ==='
AFL_USE_ASAN=1 /aflpp-upstream/afl-clang-fast /harness.c -o /tmp/harness -shared-libasan -O0 2>/dev/null
LD_PRELOAD=$ASAN_LIB /tmp/harness

echo
echo '=== fixed (afl-clang-fast) ==='
AFL_USE_ASAN=1 /aflpp-fixed/afl-clang-fast /harness.c -o /tmp/harness -shared-libasan -O0 2>/dev/null
LD_PRELOAD=$ASAN_LIB /tmp/harness

echo
echo '=== fixed (afl-gcc-fast) ==='
AFL_USE_ASAN=1 /aflpp-fixed/afl-gcc-fast /harness.c -o /tmp/harness -O0 2>/dev/null
/tmp/harness
EOF
RUN chmod +x /test.sh

CMD ["/test.sh"]
```