### PR TITLE
afl-showmap: report raw exit status in streaming mode

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -518,9 +518,11 @@ static ssize_t read_all(int fd, void *buf, size_t n) {
    - Output: [u16 status][u32 edge_count][{u32 edge_idx, u8 hit_ctr}*]
              [u32 stdout_len][u8 stdout_data*][u32 stderr_len][u8 stderr_data*]
    Status field:
-     bits 0-1:  exit status (0=exited, 1=timeout, 2=crash)
-     bits 2-7:  reserved (must be 0)
-     bits 8-15: signal number (only valid when status=crash)
+     bits [0:1]:  exit status (0=exited, 1=timeout, 2=crash)
+     bits [2:7]:  reserved (must be 0)
+     bits [8:15]: WEXITSTATUS when bits [0:1] = 0 (normal exit),
+                  0 when bits [0:1] = 1 (timeout),
+                  WTERMSIG when bits [0:1] = 2 (crash)
    Note: stdout_len and stderr_len are currently always 0 (not implemented).
          These fields are reserved for future use to capture target output.
 */
@@ -560,7 +562,8 @@ static void streaming_loop(void) {
 
     } else {
 
-      status = STREAMING_STATUS_EXITED;
+      /* Encode exit code in bits 8-15 */
+      status = STREAMING_STATUS_EXITED | (WEXITSTATUS(fsrv->child_status) << 8);
 
     }
 
@@ -1191,8 +1194,9 @@ static void usage(u8 *argv0) {
       "                         Output [u16 status][u32 edges][(u32,u8)*]\n"
       "                                [u32 stdout_len][stdout_data*]\n"
       "                                [u32 stderr_len][stderr_data*]\n"
-      "               Status: bits 0-1 = exit (0=ok, 1=timeout, 2=crash),\n"
-      "                       bits 2-7 = reserved (0), bits 8-15 = signal\n"
+      "               Status: bits [0:1] = exit (0=ok, 1=timeout, 2=crash),\n"
+      "                       bits [2:7] = reserved (0),\n"
+      "                       bits [8:15] = exit code (ok) or signal (crash)\n"
       "               Note: stdout_len/stderr_len are currently always 0\n"
       "                     (output capture not yet implemented)\n"
       "  -i dir     - process all files below this directory, must be combined "

--- a/utils/afl_showmap_streaming/afl_showmap_streaming_mode.py
+++ b/utils/afl_showmap_streaming/afl_showmap_streaming_mode.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 
 class ExitStatus(IntEnum):
-    """Exit status from streaming protocol (bits 0-1 of status field)."""
+    """Exit status from streaming protocol (bits [0:1] of status field)."""
 
     EXITED = 0   # Normal exit
     TIMEOUT = 1  # Execution timed out
@@ -33,14 +33,14 @@ class ExitStatus(IntEnum):
 
 
 # Status field layout (u16):
-#   bits 0-1:  exit status (0=exited, 1=timeout, 2=crash)
-#   bits 2-7:  reserved (must be 0)
-#   bits 8-15: signal number (only valid when status=crash)
+#   bits [0:1]:  exit status (0=exited, 1=timeout, 2=crash)
+#   bits [2:7]:  reserved (must be 0)
+#   bits [8:15]: WEXITSTATUS (when exited) or WTERMSIG (when crash)
 
 # Masks for status field parsing
-_STATUS_EXIT_MASK = 0x0003      # bits 0-1
-_STATUS_RESERVED_MASK = 0x00FC  # bits 2-7 (must be 0)
-_STATUS_SIGNAL_SHIFT = 8        # bits 8-15
+_STATUS_EXIT_MASK = 0x0003      # bits [0:1]
+_STATUS_RESERVED_MASK = 0x00FC  # bits [2:7] (must be 0)
+_STATUS_INFO_SHIFT = 8          # bits [8:15]
 
 
 class AflShowmapStreaming:
@@ -88,7 +88,11 @@ class AflShowmapStreaming:
         self._proc.stdin.flush()
 
     def _recv(self) -> "tuple[ExitStatus, signal.Signals | None, list[tuple[int, int]]]":
-        """Receive: [u16 status][u32 count][{u32 edge_idx, u8 hit_ctr} * count].
+        """Receive one response from the streaming protocol.
+
+        Wire format:
+            [u16 status][u32 count][{u32 edge_idx, u8 hit_ctr} * count]
+            [u32 stdout_len][u8 stdout_data*][u32 stderr_len][u8 stderr_data*]
 
         Returns:
             (exit_status, crash_signal, edges) where:
@@ -107,14 +111,25 @@ class AflShowmapStreaming:
             )
 
         exit_status = ExitStatus(status_raw & _STATUS_EXIT_MASK)
-        signal_num = status_raw >> _STATUS_SIGNAL_SHIFT
-        crash_signal = signal.Signals(signal_num) if signal_num else None
+        info_value = status_raw >> _STATUS_INFO_SHIFT
+        crash_signal = (
+            signal.Signals(info_value) if exit_status == ExitStatus.CRASH and info_value else None
+        )
 
         edge_count = struct.unpack("<I", self._read_exactly(4))[0]
         edge_data = self._read_exactly(edge_count * 5)
         edges = [
             struct.unpack_from("<IB", edge_data, i * 5) for i in range(edge_count)
         ]
+
+        # Read stdout/stderr LV fields (currently always length=0)
+        stdout_len = struct.unpack("<I", self._read_exactly(4))[0]
+        if stdout_len > 0:
+            self._read_exactly(stdout_len)  # discard
+        stderr_len = struct.unpack("<I", self._read_exactly(4))[0]
+        if stderr_len > 0:
+            self._read_exactly(stderr_len)  # discard
+
         return exit_status, crash_signal, edges
 
     def _read_exactly(self, n: int) -> bytes:


### PR DESCRIPTION
Also report the exit status for non-crashing execution when using afl-showmap's streaming mode (`-S`). Before, only the signal was encoded on exit. 