### PR TITLE
Define _GNU_SOURCE in afl-cmin.c so that it compiles with older glibc

### DIFF
--- a/src/afl-cmin.c
+++ b/src/afl-cmin.c
@@ -27,6 +27,10 @@
 #define AFL_MAIN
 #define AFL_CMIN
 
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
+
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>


### PR DESCRIPTION
**Type of PR**: Enhancement
**Purpose of this PR**: Define _GNU_SOURCE in afl-cmin.c so that it compiles with older glibc
**I have tested the changes**: yes

`afl-cmin.c` uses `O_DIRECTORY`, which is only exposed when you `#define _GNU_SOURCE` for glibc 2.11 and earlier. 

(Obviously this is a very old version, but I am stuck using it at the moment :smile:, and this is the only AFL++ build issue I've run into with it.)
