### PR TITLE
afl-cmin: fix frida/qemu/unicorn mode flags set after afl_fsrv_setup_preload 

### DIFF
--- a/src/afl-cmin.c
+++ b/src/afl-cmin.c
@@ -886,6 +886,13 @@ static char **prepare_fsrv(afl_forkserver_t *fsrv, sharedmem_t *shm,
   // Init fsrv
   afl_fsrv_init(fsrv);
   set_sanitizer_defaults();
+
+  /* Set binary-only mode flags before afl_fsrv_setup_preload() so the
+     correct LD_PRELOAD (e.g. afl-frida-trace.so) is injected. */
+  fsrv->frida_mode   = frida_mode;
+  fsrv->qemu_mode    = qemu_mode;
+  fsrv->unicorn_mode = unicorn_mode;
+
   afl_fsrv_setup_preload(fsrv, target_bin);
 
   // Init SHM
@@ -899,9 +906,6 @@ static char **prepare_fsrv(afl_forkserver_t *fsrv, sharedmem_t *shm,
   fsrv->exec_tmout = time_limit;
   if (!fsrv->exec_tmout) fsrv->exec_tmout = 120 * 1000;
 
-  if (frida_mode) fsrv->frida_mode = 1;
-  if (qemu_mode) fsrv->qemu_mode = 1;
-  if (unicorn_mode) fsrv->unicorn_mode = 1;
   if (nyx_mode) {
 
 #ifdef __linux__
@@ -1052,6 +1056,18 @@ static void exec_worker(worker_data_t *data, u32 *shared_cmin_idx) {
 
   afl_fsrv_start(fsrv, argv, &stop_soon, debug_mode);
 
+  /* Post-handshake: if target did not negotiate shmem-fuzz (e.g. Frida
+     non-persistent mode), tear down the allocation and fall back to
+     out_fd/stdin delivery — mirrors afl-showmap.c behaviour. */
+  if (fsrv->support_shmem_fuzz && !fsrv->use_shmem_fuzz) {
+
+    afl_shm_deinit(&shm_fuzz);
+    fsrv->support_shmem_fuzz = 0;
+    fsrv->shmem_fuzz_len     = NULL;
+    fsrv->shmem_fuzz         = NULL;
+
+  }
+
   u8 *last_exec_dir = NULL;
   int last_exec_dirfd = -1;
 
@@ -1123,7 +1139,7 @@ static void exec_worker(worker_data_t *data, u32 *shared_cmin_idx) {
 
   afl_fsrv_deinit(fsrv);
   afl_shm_deinit(&data->shm);
-  if (fsrv->support_shmem_fuzz) afl_shm_deinit(&shm_fuzz);
+  if (fsrv->use_shmem_fuzz) afl_shm_deinit(&shm_fuzz);
   cleanup_fsrv_allocs(fsrv, argv);
 
 }
@@ -1225,6 +1241,12 @@ static void cmin_detect_map_size(void) {
     // Init fsrv
     afl_fsrv_init(&fsrv);
     set_sanitizer_defaults();
+
+    /* Propagate binary-only mode flags before preload setup. */
+    fsrv.frida_mode   = frida_mode;
+    fsrv.qemu_mode    = qemu_mode;
+    fsrv.unicorn_mode = unicorn_mode;
+
     afl_fsrv_setup_preload(&fsrv, target_bin);
     fsrv.target_path = target_bin;
 
@@ -1821,7 +1843,36 @@ static void test_target_binary(void) {
 
   char **argv = prepare_fsrv(&fsrv, &shm, map_size, (u32)-1, NULL);
 
+  /* Set up shared-memory test-case delivery; the fork server negotiates
+     shmem-fuzz support during the handshake (needed for Frida/QEMU). */
+  sharedmem_t shm_fuzz = {0};
+  u8 *fuzz_map =
+      afl_shm_init(&shm_fuzz, MAX_FILE + sizeof(u32), 1, DEFAULT_PERMISSION, 0);
+
+  if (fuzz_map) {
+
+    shm_fuzz.shmemfuzz_mode = 1;
+    fsrv.support_shmem_fuzz = 1;
+    fsrv.shmem_fuzz_len = (u32 *)fuzz_map;
+    fsrv.shmem_fuzz = fuzz_map + sizeof(u32);
+
+    u8 *shm_fuzz_map_size_str = alloc_printf("%lu", MAX_FILE + sizeof(u32));
+    setenv(SHM_FUZZ_MAP_SIZE_ENV_VAR, shm_fuzz_map_size_str, 1);
+    ck_free(shm_fuzz_map_size_str);
+
+  }
+
   afl_fsrv_start(&fsrv, (char **)argv, &stop_soon, debug_mode ? 1 : 0);
+
+  /* Same post-handshake fallback as exec_worker() and afl-showmap. */
+  if (fsrv.support_shmem_fuzz && !fsrv.use_shmem_fuzz) {
+
+    afl_shm_deinit(&shm_fuzz);
+    fsrv.support_shmem_fuzz = 0;
+    fsrv.shmem_fuzz_len     = NULL;
+    fsrv.shmem_fuzz         = NULL;
+
+  }
 
   // Use the first file for testing
   cmin_file_t      *f = files[0];
@@ -1873,6 +1924,7 @@ static void test_target_binary(void) {
   }
 
   // Cleanup
+  if (fsrv.use_shmem_fuzz) afl_shm_deinit(&shm_fuzz);
   afl_fsrv_deinit(&fsrv);
   afl_shm_deinit(&shm);
 


### PR DESCRIPTION
Fix afl-cmin -O (Frida mode) fork server timeout
Fixes #2732
Root Cause
frida_mode/qemu_mode/unicorn_mode flags were assigned after afl_fsrv_setup_preload() in both prepare_fsrv() and cmin_detect_map_size(), so the preload ran without knowing the execution mode — meaning afl-frida-trace.so was never injected.
Fix
Move the flag assignments before afl_fsrv_setup_preload() in both call sites.
Before / After
Before:
[-] PROGRAM ABORT : Timeout while initializing fork server
    Location : afl_fsrv_start(), src/afl-forkserver.c:1638
After:
[+] All right - new fork server model v1 is up.
[+] ok, 3 tuples recorded
[+] Wrote 1 files.
Tested
Reproduced and verified in Docker with a binary-only target using afl-cmin -O.

  
