### PR TITLE
added the missing case for x86 FP

### DIFF
--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -47,9 +47,14 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/Support/raw_ostream.h"
+#if LLVM_MAJOR <= 15
+  #include "llvm/ADT/Triple.h"
+#endif
 
 #include <set>
 #include "afl-llvm-common.h"
+
+static bool is_64_arch = false;
 
 using namespace llvm;
 
@@ -185,16 +190,17 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
   FunctionCallee c8 = M.getOrInsertFunction("__cmplog_ins_hook8", VoidTy,
                                             Int64Ty, Int64Ty, Int8Ty);
   FunctionCallee cmplogHookIns8 = c8;
+  [[maybe_unused]] FunctionCallee cmplogHookIns16;
+  [[maybe_unused]] FunctionCallee cmplogHookInsN;
 
-#if INTPTR_MAX != INT32_MAX
-  FunctionCallee c16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy,
-                                             Int128Ty, Int128Ty, Int8Ty);
-  FunctionCallee cmplogHookIns16 = c16;
+  if (is_64_arch) {
 
-  FunctionCallee cN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy,
-                                            Int128Ty, Int128Ty, Int8Ty, Int8Ty);
-  FunctionCallee cmplogHookInsN = cN;
-#endif
+    cmplogHookIns16 = M.getOrInsertFunction("__cmplog_ins_hook16", VoidTy,
+                                            Int128Ty, Int128Ty, Int8Ty);
+    cmplogHookInsN = M.getOrInsertFunction("__cmplog_ins_hookN", VoidTy,
+                                           Int128Ty, Int128Ty, Int8Ty, Int8Ty);
+
+  }
 
   GlobalVariable *AFLCmplogPtr = M.getNamedGlobal("__afl_cmp_map");
 
@@ -419,8 +425,6 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
         case 33 ... 64:
           cast_size = 64;
           break;
-        case 80:
-          continue;
         default:
           // 65-128 bit values are handled via 128-bit hooks.
           cast_size = 128;
@@ -553,20 +557,21 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
               IRB.CreateCall(cmplogHookIns8, args);
               break;
             case 128:
-#if INTPTR_MAX != INT32_MAX
-              if (use_hookN) {
+              if (is_64_arch) {
 
-                IRB.CreateCall(cmplogHookInsN, args);
+                if (use_hookN) {
 
-              } else {
+                  IRB.CreateCall(cmplogHookInsN, args);
 
-                IRB.CreateCall(cmplogHookIns16, args);
+                } else {
+
+                  IRB.CreateCall(cmplogHookIns16, args);
+
+                }
+
+                break;
 
               }
-
-#endif
-
-              break;
 
           }
 
@@ -599,6 +604,13 @@ PreservedAnalyses CmpLogInstructions::run(Module                &M,
     return &FAM.getResult<LoopAnalysis>(F);
 
   };
+
+#if LLVM_MAJOR <= 20
+  auto triple = Triple(M.getTargetTriple());
+#else
+  auto triple = M.getTargetTriple();
+#endif
+  if (triple.isArch64Bit()) { is_64_arch = true; }
 
   if (getenv("AFL_QUIET") == NULL)
     printf("Running cmplog-instructions-pass by andreafioraldi@gmail.com\n");

--- a/instrumentation/cmplog-instructions-pass.cc
+++ b/instrumentation/cmplog-instructions-pass.cc
@@ -419,6 +419,8 @@ bool CmpLogInstructions::hookInstrs(Module &M, LoopInfoCallback LICallback) {
         case 33 ... 64:
           cast_size = 64;
           break;
+        case 80:
+          continue;
         default:
           // 65-128 bit values are handled via 128-bit hooks.
           cast_size = 128;


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: Fix compilation failure with cmplog on x86 targets.
**I have tested the changes**: yes

This example code crashes during compilation:
```c++
#include <iostream>
#include <format>
#include <string>
#include <numbers>

int main() {
    double value = 3.14159;
    std::string formatted_value = std::format("Value: {:_^10.4f}", value);
    std::cout << formatted_value << std::endl;

    return 0;
}
```
Compilation flags:
```
AFL_LLVM_CMPLOG=1 afl-clang-fast++ -m32 -v -g -std=c++20 test.cc -o test
```
Error output:
```
SanitizerCoveragePCGUARD++4.36a
[+] Instrumented 1499 locations with no collisions (non-hardened mode) of which are 65 handled and 0 unhandled special instructions. 20 instrumentations saved.
Running cmplog-switches-pass by andreafioraldi@gmail.com
Hooking 22 switch instructions
Running cmplog-instructions-pass by andreafioraldi@gmail.com
Running cmplog-routines-pass by andreafioraldi@gmail.com
 "/usr/bin/ld" -z relro --hash-style=gnu --build-id --eh-frame-hdr -m elf_i386 -pie -dynamic-linker /lib/ld-linux.so.2 -o testAFL_DEBUG=12 /usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib32/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib32/crti.o /usr/lib/gcc/x86_64-linux-gnu/13/32/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/13/32 -L/usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib32 -L/lib/../lib32 -L/usr/lib/../lib32 -L/usr/lib/llvm-19/bin/../lib -L/lib -L/usr/lib /tmp/test-496979.o /usr/local/bin/../lib/afl/afl-compiler-rt-32.o --dynamic-list=/usr/local/bin/../lib/afl/dynamic_list.txt -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc /usr/lib/gcc/x86_64-linux-gnu/13/32/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib32/crtn.o
/usr/bin/ld: /tmp/test-496979.o: in function `std::basic_format_context<std::__format::_Sink_iter<char>, char>::iterator std::__format::__formatter_fp<char>::format<long double, std::__format::_Sink_iter<char> >(long double, std::basic_format_context<std::__format::_Sink_iter<char>, char>&) const':
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/format:1551:(.text._ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_[_ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_]+0x697): undefined reference to `__cmplog_ins_hookN'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/format:1565:(.text._ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_[_ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_]+0x7ff): undefined reference to `__cmplog_ins_hookN'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/format:1669:(.text._ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_[_ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_]+0xcf0): undefined reference to `__cmplog_ins_hookN'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/format:1692:(.text._ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_[_ZNKSt8__format14__formatter_fpIcE6formatIeNS_10_Sink_iterIcEEEENSt20basic_format_contextIT0_cE8iteratorET_RS7_]+0x105c): undefined reference to `__cmplog_ins_hookN'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
