### PR TITLE
Changed afl-tmin to respect TMPDIR environment variable

### DIFF
--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -934,13 +934,10 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
 	u8 *use_dir = get_afl_env("TMPDIR");
 	
 	if (!use_dir) {
-    	u8 *use_dir = ".";
+    	use_dir = ".";
 
 	    if (access(use_dir, R_OK | W_OK | X_OK)) {
-
-			use_dir = get_afl_env("TMPDIR");
-      	
-			if (!use_dir) { use_dir = "/tmp"; }
+			use_dir = "/tmp";
 		}	
     }
 

--- a/src/afl-tmin.c
+++ b/src/afl-tmin.c
@@ -930,14 +930,18 @@ static void set_up_environment(afl_forkserver_t *fsrv, char **argv) {
   if (fsrv->dev_null_fd < 0) { PFATAL("Unable to open /dev/null"); }
 
   if (!out_file) {
+	
+	u8 *use_dir = get_afl_env("TMPDIR");
+	
+	if (!use_dir) {
+    	u8 *use_dir = ".";
 
-    u8 *use_dir = ".";
+	    if (access(use_dir, R_OK | W_OK | X_OK)) {
 
-    if (access(use_dir, R_OK | W_OK | X_OK)) {
-
-      use_dir = get_afl_env("TMPDIR");
-      if (!use_dir) { use_dir = "/tmp"; }
-
+			use_dir = get_afl_env("TMPDIR");
+      	
+			if (!use_dir) { use_dir = "/tmp"; }
+		}	
     }
 
     out_file = alloc_printf("%s/.afl-tmin-temp-%u", use_dir, (u32)getpid());


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: Makes afl-tmin uses $TMPDIR over the current working directory for temp files if it is set. Previously, afl-tmin only used $TMPDIR if the current working directory wasn't rwx.
**I have tested the changes**: yes