### PR TITLE
Refer to Zulip instead of Discord in the docs and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Questions? Concerns? Bug reports?
 * Take a look at our [FAQ](docs/FAQ.md). If you find an interesting or important
   question missing, submit it via
   [https://github.com/AFLplusplus/AFLplusplus/discussions](https://github.com/AFLplusplus/AFLplusplus/discussions).
-* Best: join the [Awesome Fuzzing](https://discord.gg/gCraWct) Discord server.
+* Best: join the [Fuzzing Zulip server](https://fuzz.zulipchat.com/).
 * There is a (not really used) mailing list for the AFL/AFL++ project
   ([browse archive](https://groups.google.com/group/afl-users)). To compare
   notes with other users or to get notified about major new features, send an

--- a/frida_mode/DEBUGGING.md
+++ b/frida_mode/DEBUGGING.md
@@ -173,7 +173,7 @@ already there, then it may not be overwritten.
 
 ## Reach out
 
-Get in touch on discord and ask for help. The groups are pretty active so
+Get in touch on Zulip and ask for help. The groups are pretty active so
 someone may well be able to offer some advice. Better still, if you are able to
 create a minimal reproducer for your problem, it will make it easier to diagnose
 the issue.

--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -1680,7 +1680,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
            "    - Less likely, there is a horrible bug in the fuzzer. If other "
            "options\n"
-           "      fail, poke the Awesome Fuzzing Discord for troubleshooting "
+           "      fail, poke the Fuzzing Zulip server for troubleshooting "
            "tips.\n");
 
     } else {
@@ -1725,7 +1725,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
            "    - Less likely, there is a horrible bug in the fuzzer. If other "
            "options\n"
-           "      fail, poke the Awesome Fuzzing Discord for troubleshooting "
+           "      fail, poke the Fuzzing Zulip server for troubleshooting "
            "tips.\n",
            stringify_mem_size(val_buf, sizeof(val_buf), fsrv->mem_limit << 20),
            fsrv->mem_limit - 1);
@@ -1775,7 +1775,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
          "      Retry with setting AFL_MAP_SIZE=10000000.\n\n"
 
          "Otherwise there is a horrible bug in the fuzzer.\n"
-         "Poke the Awesome Fuzzing Discord for troubleshooting tips.\n");
+         "Poke the Fuzzing Zulip server for troubleshooting tips.\n");
 
   } else {
 
@@ -1824,7 +1824,7 @@ void afl_fsrv_start(afl_forkserver_t *fsrv, char **argv,
 
         "    - Less likely, there is a horrible bug in the fuzzer. If other "
         "options\n"
-        "      fail, poke the Awesome Fuzzing Discord for troubleshooting "
+        "      fail, poke the Fuzzing Zulip server for troubleshooting "
         "tips.\n",
         getenv(DEFER_ENV_VAR)
             ? "    - You are using deferred forkserver, but __AFL_INIT() is "

--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -1123,8 +1123,8 @@ void perform_dry_run(afl_state_t *afl) {
 
                "    - Least likely, there is a horrible bug in the fuzzer. If "
                "other options\n"
-               "      fail, poke the Awesome Fuzzing Discord for "
-               "troubleshooting tips.\n",
+               "      fail, poke the Fuzzing Zulip server for troubleshooting "
+               "tips.\n",
                msg_exit_code,
                stringify_mem_size(val_buf, sizeof(val_buf),
                                   afl->fsrv.mem_limit << 20),
@@ -1154,8 +1154,8 @@ void perform_dry_run(afl_state_t *afl) {
 
                "    - Least likely, there is a horrible bug in the fuzzer. If "
                "other options\n"
-               "      fail, poke the Awesome Fuzzing Discord for "
-               "troubleshooting tips.\n",
+               "      fail, poke the Fuzzing Zulip server for troubleshooting "
+               "tips.\n",
                msg_exit_code);
 
         }


### PR DESCRIPTION
Large parts of the Discord community have recently moved to [Zulip](https://fuzz.zulipchat.com/) because of increasing enshittification of Discord. This PR therefore replaces mentions of Discord with Zulip in both the docs and in error messages suggesting people reach out.

**Type of PR**: Enhancement
**Purpose of this PR**: Refer to Zulip instead of Discord in the docs and error messages
**I have tested the changes**: no, since the PR only contains docs changes
