### PR TITLE
libqasan support arm thumb hotpatch

### DIFF
--- a/qemu_mode/libqasan/patch.c
+++ b/qemu_mode/libqasan/patch.c
@@ -65,24 +65,62 @@ uint8_t *__libqasan_patch_jump(uint8_t *addr, uint8_t *dest) {
 // so let's use it in our stub
 
 uint8_t *__libqasan_patch_jump(uint8_t *addr, uint8_t *dest) {
+  int is_thumb = (uintptr_t)addr & 1;
+  addr = (uint8_t *)((uintptr_t)addr & ~1);
 
-  // ldr r12, OFF
-  addr[0] = 0x0;
-  addr[1] = 0xc0;
-  addr[2] = 0x9f;
-  addr[3] = 0xe5;
+  if (is_thumb) {
+    // Thumb2 code (10 bytes total)
+    //
+    // Layout:
+    //   addr+0: ldr.w r12, [pc, #4]  (4 bytes)  = addr+8
+    //   addr+4: bx r12               (2 bytes)
+    //   addr+8: .word dest           (4 bytes)
+    //
+    // PC in Thumb = instruction_address + 4
 
-  // add pc, pc, r12
-  addr[4] = 0xc;
-  addr[5] = 0xf0;
-  addr[6] = 0x8f;
-  addr[7] = 0xe0;
+    // ldr.w r12, [pc, #4]
+    addr[0] = 0xdf;
+    addr[1] = 0xf8;
+    addr[2] = 0x04;
+    addr[3] = 0xc0;
 
-  // OFF: .word dest
-  *(uint32_t *)&addr[8] = (uint32_t)dest;
+    // bx r12
+    addr[4] = 0x60;
+    addr[5] = 0x47;
 
-  return &addr[12];
+    // OFF: .word dest
+    // dest address (with Thumb bit preserved for bx), written to 4 align address.
+    *(uint32_t *)&addr[8] = (uint32_t)dest;
 
+    return &addr[12];
+
+  } else {
+    // ARM code (12 bytes total)
+    //
+    // Layout:
+    //   addr+0: ldr r12, [pc, #0]  (4 bytes) - loads from PC+8 = addr+8
+    //   addr+4: bx r12             (4 bytes)
+    //   addr+8: .word dest         (4 bytes)
+    //
+    // PC in ARM = instruction_address + 8
+
+    // ldr r12, [pc, #0]
+    addr[0] = 0x0;
+    addr[1] = 0xc0;
+    addr[2] = 0x9f;
+    addr[3] = 0xe5;
+
+    // bx r12
+    addr[4] = 0x1c;
+    addr[5] = 0xff;
+    addr[6] = 0x2f;
+    addr[7] = 0xe1;
+
+    // OFF: .word dest
+    *(uint32_t *)&addr[8] = (uint32_t)dest;
+
+    return &addr[12];
+  }
 }
 
 #elif __aarch64__


### PR DESCRIPTION
## libqasan support arm thumb hotpatch

**Type of PR**: Enhancement
**Purpose of this PR**: 
in libqasan hotpatching arm libc currently assumes that the patched functions are compiled in ARM mode. However, on some ARM systems the libc implementation compiles functions in Thumb mode. Because the current patching logic does not account for this, patching these functions fails and libqasan does not work correctly in those environments.

Adding support for handling such cases is fairly easy, by checking the patched function address to determine whether the target function is in ARM or Thumb mode. Based on this check, the patching logic adjusts accordingly so the instrumentation is applied correctly.

the patched jump was modified to `bx r12` to explicitly allow jumping between arm and thumb.

**I have tested the changes**: yes


  
