### PR TITLE
fix typo in comment

### DIFF
--- a/src/afl-fuzz-init.c
+++ b/src/afl-fuzz-init.c
@@ -3160,7 +3160,7 @@ void check_binary(afl_state_t *afl, u8 *fname) {
 
   /* Check for blatant user errors. */
 
-  /*  disabled. not a real-worl scenario where this is a problem.
+  /*  disabled. not a real-world scenario where this is a problem.
     if ((!strncmp(afl->fsrv.target_path, "/tmp/", 5) &&
          !strchr(afl->fsrv.target_path + 5, '/')) ||
         (!strncmp(afl->fsrv.target_path, "/var/tmp/", 9) &&


### PR DESCRIPTION
# Fix typo in comment

**Type of PR**: Enhancement
**Purpose of this PR**:
Fix a minor typo in a comment within `src/afl-fuzz-init.c` ("real-worl" -> "real-world").

**I have tested the changes**: yes