### PR TITLE
add crash file path argument when use -I command/script option

### DIFF
--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -1051,7 +1051,10 @@ may_save_fault:
         // compiler warning either
         // See
         // https://stackoverflow.com/questions/11888594/ignoring-return-values-in-c
-        (void)(system(afl->infoexec) + 1);
+        char infoexec_cmd[PATH_MAX * 2];
+        snprintf(infoexec_cmd, sizeof(infoexec_cmd), "%s \"%s\"", afl->infoexec,
+                 fn);
+        (void)(system(infoexec_cmd) + 1);
 #else
         WARNF("command execution unsupported");
 #endif

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -308,6 +308,8 @@ static void usage(u8 *argv0, int more_help) {
       "  -T text       - text banner to show on the screen\n"
       "  -I command    - execute this command/script when a new crash is "
       "found\n"
+      "                  (crash file path is passed as the first argument to\n"
+      "                  the command/script)\n"
       //"  -B bitmap.txt - mutate a specific test case, use the
       // out/default/fuzz_bitmap file\n"
       "  -C            - crash exploration mode (the peruvian rabbit thing)\n"


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Feature
**Purpose of this PR**: When using the -I command/script option, the path to the new crash sample, which starts with the directory specified by -o, is passed as the first argument to the command/script.
**I have tested the changes**: yes

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
  
