### PR TITLE
CmpLog: bound routine string hook reads

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -2783,8 +2783,13 @@ static u8 get_prog_addr_attr(const void *addr) {
 
 #endif
 
-/* hook for string with length functions, eg. strncmp, strncasecmp etc.
-   Note that we ignore the len parameter and take longer strings if present. */
+static inline u32 cmplog_string_len_with_nul(u32 len, u32 cap) {
+
+  return len < cap ? len + 1U : cap;
+
+}
+
+/* hook for string with length functions, eg. strncmp, strncasecmp etc. */
 void __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len) {
 
   // fprintf(stderr, "RTN1 %p %p %u\n", ptr1, ptr2, len);
@@ -2792,23 +2797,19 @@ void __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len) {
   if (unlikely(!ptr1 || !ptr2)) return;
   if (unlikely(!len || len > __afl_cmplog_max_len)) return;
 
-  int len0 = MIN(len, 32);
+  u32 cap = (u32)MIN(len, 32ULL);
+  int l1 = area_is_valid(ptr1, cap);
+  int l2 = area_is_valid(ptr2, cap);
+  if (l1 <= 0 || l2 <= 0) return;
 
-  int len1 = strnlen(ptr1, len0);
+  cap = (u32)MIN(l1, l2);
 
-  int len2 = strnlen(ptr2, len0);
+  u32 len1 = (u32)strnlen((char *)ptr1, cap);
+  u32 len2 = (u32)strnlen((char *)ptr2, cap);
 
-  int l;
-  if (!len1)
-    l = len2;
-  else if (!len2)
-    l = len1;
-  else
-    l = MAX(len1, len2);
+  u32 l = MAX(cmplog_string_len_with_nul(len1, cap),
+              cmplog_string_len_with_nul(len2, cap));
 
-  l = MIN(area_is_valid(ptr1, l + 1), area_is_valid(ptr2, l + 1));
-
-  if (l > 32) l = 32;
   if (l < 2) return;
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);
@@ -2857,19 +2858,16 @@ void __cmplog_rtn_hook_str(u8 *ptr1, u8 *ptr2) {
   // fprintf(stderr, "RTN1 %p %p\n", ptr1, ptr2);
   if (likely(!__afl_cmp_map)) return;
   if (unlikely(!ptr1 || !ptr2)) return;
-  int len1 = strnlen(ptr1, 31) + 1;
-  int len2 = strnlen(ptr2, 31) + 1;
 
-  int l;
-  if (!len1)
-    l = len2;
-  else if (!len2)
-    l = len1;
-  else
-    l = MAX(len1, len2);
-  l = MIN(area_is_valid(ptr1, l + 1), area_is_valid(ptr2, l + 1));
+  int l1 = area_is_valid(ptr1, 32);
+  int l2 = area_is_valid(ptr2, 32);
+  if (l1 <= 0 || l2 <= 0) return;
 
-  if (l > 32) l = 32;
+  u32 cap = (u32)MIN(l1, l2);
+  u32 len1 = cmplog_string_len_with_nul((u32)strnlen((char *)ptr1, cap), cap);
+  u32 len2 = cmplog_string_len_with_nul((u32)strnlen((char *)ptr2, cap), cap);
+  u32 l = MAX(len1, len2);
+
   if (l < 2) return;
 
   uintptr_t k = (uintptr_t)__builtin_return_address(0);

--- a/test/test-cmplog-routines-bounds.sh
+++ b/test/test-cmplog-routines-bounds.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AFL_DIR="$SCRIPT_DIR/.."
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+
+  rm -rf "$TEMP_DIR"
+
+}
+trap cleanup EXIT
+
+cat > "$TEMP_DIR/cmplog-rtn-bounds.c" << 'EOF'
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "types.h"
+#include "cmplog.h"
+
+#ifndef MAP_ANONYMOUS
+  #define MAP_ANONYMOUS MAP_ANON
+#endif
+
+extern struct cmp_map *__afl_cmp_map;
+void                   __cmplog_rtn_hook_str(u8 *ptr1, u8 *ptr2);
+void                   __cmplog_rtn_hook_strn(u8 *ptr1, u8 *ptr2, u64 len);
+
+static unsigned count_rtn_headers(const struct cmp_map *cmp_map) {
+
+  unsigned count = 0;
+  for (u32 i = 0; i < CMP_MAP_W; ++i) {
+
+    if (cmp_map->headers[i].type == CMP_TYPE_RTN &&
+        cmp_map->headers[i].hits) {
+
+      ++count;
+
+    }
+
+  }
+
+  return count;
+
+}
+
+static char *guarded_tail(char **map_base, size_t *map_len) {
+
+  long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0) return NULL;
+
+  /* Map two adjacent pages, then protect the second page. A read past the
+     final byte of the first page will fault deterministically. */
+  *map_len = (size_t)page_size * 2U;
+  char *map = mmap(NULL, *map_len, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (map == MAP_FAILED) return NULL;
+
+  if (mprotect(map + page_size, (size_t)page_size, PROT_NONE) != 0) {
+
+    munmap(map, *map_len);
+    return NULL;
+
+  }
+
+  *map_base = map;
+  /* Return a one-byte non-NUL string prefix at the end of the readable page. */
+  char *tail = map + page_size - 1;
+  tail[0] = 'A';
+  return tail;
+
+}
+
+int main(void) {
+
+  struct cmp_map *cmp_map = calloc(1, sizeof(struct cmp_map));
+  if (!cmp_map) return 1;
+  __afl_cmp_map = cmp_map;
+
+  char  *map = NULL;
+  size_t map_len = 0;
+  char  *tail = guarded_tail(&map, &map_len);
+  if (!tail) {
+
+    free(cmp_map);
+    return 1;
+
+  }
+
+  char other[32];
+  memset(other, 'A', sizeof(other));
+  other[sizeof(other) - 1] = 0;
+
+  int probe_pipe[2] = {-1, -1};
+  int saved_stderr = dup(STDERR_FILENO);
+  if (saved_stderr < 0 || pipe(probe_pipe) != 0 ||
+      dup2(probe_pipe[1], STDERR_FILENO) < 0) {
+
+    if (saved_stderr >= 0) { close(saved_stderr); }
+    if (probe_pipe[0] >= 0) { close(probe_pipe[0]); }
+    if (probe_pipe[1] >= 0) { close(probe_pipe[1]); }
+    munmap(map, map_len);
+    free(cmp_map);
+    return 1;
+
+  }
+
+  /* area_is_valid() writes the probed range to a static dummy fd. Because this
+     test calls the hooks directly, that fd still points at stderr. Redirect
+     stderr to a pipe so the probe stays quiet but still makes the kernel copy
+     bytes from the tested pointer. */
+
+  /* Regression check: these calls must not read tail[1]. */
+  __cmplog_rtn_hook_str((u8 *)tail, (u8 *)other);
+  __cmplog_rtn_hook_strn((u8 *)tail, (u8 *)other, 32);
+
+  /* Sanity check: normal strings should still produce routine CmpLog data. */
+  __cmplog_rtn_hook_str((u8 *)"abc", (u8 *)"abd");
+  __cmplog_rtn_hook_strn((u8 *)"abc", (u8 *)"abd", 3);
+  if (!count_rtn_headers(cmp_map)) return 2;
+
+  if (saved_stderr >= 0) {
+
+    dup2(saved_stderr, STDERR_FILENO);
+    close(saved_stderr);
+
+  }
+
+  close(probe_pipe[0]);
+  close(probe_pipe[1]);
+
+  munmap(map, map_len);
+  free(cmp_map);
+  return 0;
+
+}
+EOF
+
+AFL_QUIET=1 "$AFL_DIR/afl-clang-fast" -I"$AFL_DIR/include" \
+  -o "$TEMP_DIR/cmplog-rtn-bounds" "$TEMP_DIR/cmplog-rtn-bounds.c"
+
+"$TEMP_DIR/cmplog-rtn-bounds"

--- a/test/test-llvm.sh
+++ b/test/test-llvm.sh
@@ -314,6 +314,15 @@ test -e ../afl-clang-fast -a -e ../split-switches-pass.so && {
       CODE=1
     }
   }
+  # Test cmplog routine hooks on page-boundary strings
+  test -e test-cmplog-routines-bounds.sh && {
+    ./test-cmplog-routines-bounds.sh > /dev/null 2>&1 && {
+      $ECHO "$GREEN[+] cmplog routines bounds test passed"
+    } || {
+      $ECHO "$RED[!] cmplog routines bounds test failed"
+      CODE=1
+    }
+  }
   # Test cmplog instructions pass with non-standard integer sizes (issue #2704)
   test -e test-cmplog-bitint.sh && {
     ./test-cmplog-bitint.sh > /dev/null 2>&1 && {


### PR DESCRIPTION
Fixes the routine string CmpLog hooks so they validate the readable operand range before calling `strnlen()`.

Previously, `__cmplog_rtn_hook_str()` and `__cmplog_rtn_hook_strn()` could call `strnlen()` across a page boundary before checking whether the full range was readable. If an operand pointed near the end of a mapped page and the next page was inaccessible, the hook could crash the target.

The hooks now first use `area_is_valid()` to determine the readable prefix, cap string scanning to the readable range shared by both operands, and preserve the existing bounded copy behavior for routine CmpLog entries.