### PR TITLE
Run infoexec after saving crash file

### DIFF
--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -1079,24 +1079,29 @@ may_save_fault:
     ck_write(fd, mem, len, fn);
     close(fd);
 
-    if (unlikely(afl->infoexec)) {
+  }
 
-      // if the user wants to be informed on new crashes - do that
-#if !TARGET_OS_IPHONE
-      // we dont care if system errors, but we dont want a
-      // compiler warning either
-      // See
-      // https://stackoverflow.com/questions/11888594/ignoring-return-values-in-c
-      char infoexec_cmd[PATH_MAX * 2];
-      snprintf(infoexec_cmd, sizeof(infoexec_cmd), "%s \"%s\"", afl->infoexec,
-               fn);
-      (void)(system(infoexec_cmd) + 1);
-#else
-      WARNF("command execution unsupported");
-#endif
+  if (unlikely(afl->infoexec)) {
+
+    if (fd < 0) {
+
+      WARNF("Crash detected, but could not write testcase to '%s'", fn);
 
     }
 
+    // if the user wants to be informed on new crashes - do that
+#if !TARGET_OS_IPHONE
+    // we dont care if system errors, but we dont want a
+    // compiler warning either
+    // See
+    // https://stackoverflow.com/questions/11888594/ignoring-return-values-in-c
+    char infoexec_cmd[PATH_MAX * 2];
+    snprintf(infoexec_cmd, sizeof(infoexec_cmd), "%s \"%s\"", afl->infoexec,
+             fn);
+    (void)(system(infoexec_cmd) + 1);
+#else
+    WARNF("command execution unsupported");
+#endif
   }
 
 #ifdef __linux__

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -1081,7 +1081,7 @@ may_save_fault:
 
   }
 
-  if (unlikely(afl->infoexec)) {
+  if (unlikely(afl->infoexec) && fault == FSRV_RUN_CRASH) {
 
     if (fd < 0) {
 

--- a/src/afl-fuzz-bitmap.c
+++ b/src/afl-fuzz-bitmap.c
@@ -1056,23 +1056,6 @@ may_save_fault:
       }
 
 #endif
-      if (unlikely(afl->infoexec)) {
-
-        // if the user wants to be informed on new crashes - do that
-#if !TARGET_OS_IPHONE
-        // we dont care if system errors, but we dont want a
-        // compiler warning either
-        // See
-        // https://stackoverflow.com/questions/11888594/ignoring-return-values-in-c
-        char infoexec_cmd[PATH_MAX * 2];
-        snprintf(infoexec_cmd, sizeof(infoexec_cmd), "%s \"%s\"", afl->infoexec,
-                 fn);
-        (void)(system(infoexec_cmd) + 1);
-#else
-        WARNF("command execution unsupported");
-#endif
-
-      }
 
       afl->last_crash_time = get_cur_time();
       afl->last_crash_execs = afl->fsrv.total_execs;
@@ -1095,6 +1078,24 @@ may_save_fault:
 
     ck_write(fd, mem, len, fn);
     close(fd);
+
+    if (unlikely(afl->infoexec)) {
+
+      // if the user wants to be informed on new crashes - do that
+#if !TARGET_OS_IPHONE
+      // we dont care if system errors, but we dont want a
+      // compiler warning either
+      // See
+      // https://stackoverflow.com/questions/11888594/ignoring-return-values-in-c
+      char infoexec_cmd[PATH_MAX * 2];
+      snprintf(infoexec_cmd, sizeof(infoexec_cmd), "%s \"%s\"", afl->infoexec,
+               fn);
+      (void)(system(infoexec_cmd) + 1);
+#else
+      WARNF("command execution unsupported");
+#endif
+
+    }
 
   }
 


### PR DESCRIPTION
Move the infoexec hook until after the crash or hang testcase has been written and closed, so external commands can read the saved file when they are invoked.

## Please give basic information

**Type of PR**: Bugfix 
**Purpose of this PR**: Move the `infoexec` hook until after the crash or hang testcase is written and closed, so the configured external command can access the saved file when it runs.

**I have tested the changes**: yes
