### PR TITLE
INSTALL.md: Remove typo

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,3 @@
-/bin/sh: aspell: command not found
 # Building and installing AFL++
 
 ## Linux on x86


### PR DESCRIPTION
A small typo was introduced recently in INSTALL.md

> /bin/sh: aspell: command not found
