### PR TITLE
Add FreeBSD build support to AFL++.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -178,7 +178,10 @@ override CFLAGS += -g -Wno-pointer-sign -Wno-variadic-macros -Wall -Wextra -Wno-
 
 ifeq "$(SYS)" "FreeBSD"
   override CFLAGS  += -I /usr/local/include/
-  override LDFLAGS += -L /usr/local/lib/
+  # execinfo needed for backtrace under FreeBSD
+  override LDFLAGS += -L /usr/local/lib/ -lexecinfo
+  # Unicorn doesn't work on FreeBSD: doesn't get native library.
+  NO_UNICORN=1
 endif
 
 ifeq "$(SYS)" "DragonFly"

--- a/GNUmakefile.gcc_plugin
+++ b/GNUmakefile.gcc_plugin
@@ -93,6 +93,13 @@ ifeq "$(SYS)" "OpenBSD"
     PLUGIN_FLAGS += -I/usr/local/include
 endif
 
+# Needed for backtrace under FreeBSD
+ifeq "$(SYS)" "FreeBSD"
+    LDFLAGS += -lexecinfo
+	# special flag variable for afl-compiler-rt library
+	COMPILER_RT_LDFLAGS := -lexecinfo
+endif
+
 ifeq "$(SYS)" "DragonFly"
   	PLUGIN_FLAGS += -I/usr/local/include
 endif
@@ -135,15 +142,15 @@ afl-common.o: ./src/afl-common.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@ $(LDFLAGS)
 
 ./afl-compiler-rt.o: instrumentation/afl-compiler-rt.o.c
-	$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) -O3 -Wno-unused-result -fPIC -c $< -o $@
+	$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) $(COMPILER_RT_LDFLAGS) -O3 -Wno-unused-result -fPIC -c $< -o $@
 
 ./afl-compiler-rt-32.o: instrumentation/afl-compiler-rt.o.c
 	@printf "[*] Building 32-bit variant of the runtime (-m32)... "
-	@$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) -O3 -Wno-unused-result -m32 -fPIC -c $< -o $@ 2>/dev/null; if [ "$$?" = "0" ]; then echo "success!"; else echo "failed (that's fine)"; fi
+	@$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) $(COMPILER_RT_LDFLAGS) -O3 -Wno-unused-result -m32 -fPIC -c $< -o $@ 2>/dev/null; if [ "$$?" = "0" ]; then echo "success!"; else echo "failed (that's fine)"; fi
 
 ./afl-compiler-rt-64.o: instrumentation/afl-compiler-rt.o.c
 	@printf "[*] Building 64-bit variant of the runtime (-m64)... "
-	@$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) -O3 -Wno-unused-result -m64 -fPIC -c $< -o $@ 2>/dev/null; if [ "$$?" = "0" ]; then echo "success!"; else echo "failed (that's fine)"; fi
+	@$(CC) $(CFLAGS_SAFE) $(CPPFLAGS) $(COMPILER_RT_LDFLAGS) -O3 -Wno-unused-result -m64 -fPIC -c $< -o $@ 2>/dev/null; if [ "$$?" = "0" ]; then echo "success!"; else echo "failed (that's fine)"; fi
 
 $(PASSES): instrumentation/afl-gcc-common.h
 
@@ -196,6 +203,8 @@ all_done: test_build
 	@echo Apache License Version 2.0, January 2004 >> ./$@
 	ln -sf afl-cc.8 ./afl-g++-fast.8
 
+OS := $(shell uname -s)
+
 .PHONY: install
 install: all
 	ln -sf afl-cc $${DESTDIR}$(BIN_PATH)/afl-gcc-fast
@@ -204,7 +213,12 @@ install: all
 	install -m 755 ./afl-gcc-pass.so $${DESTDIR}$(HELPER_PATH)
 	install -m 755 ./afl-gcc-cmplog-pass.so $${DESTDIR}$(HELPER_PATH)
 	install -m 755 ./afl-gcc-cmptrs-pass.so $${DESTDIR}$(HELPER_PATH)
-	install -m 644 -T instrumentation/README.gcc_plugin.md $${DESTDIR}$(DOC_PATH)/README.gcc_plugin.md
+	ifneq "$(SYS)" "FreeBSD"
+		install -m 644 -T instrumentation/README.gcc_plugin.md $${DESTDIR}$(DOC_PATH)/README.gcc_plugin.md
+	else
+		# no -T on FreeBSD/CheriBSD
+		install -m 644 instrumentation/README.gcc_plugin.md $${DESTDIR}$(DOC_PATH)/README.gcc_plugin.md
+	endif
 
 .PHONY: clean
 clean:

--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -356,6 +356,11 @@ ifeq "$(SYS)" "OpenBSD"
   LDFLAGS += -lc++abi -lpthread
 endif
 
+# needed for backtrace under FreeBSD
+ifeq "$(SYS)" "FreeBSD"
+  LDFLAGS += -lexecinfo
+endif
+
 ifeq "$(shell echo '$(HASH)include <sys/ipc.h>@$(HASH)include <sys/shm.h>@int main() { int _id = shmget(IPC_PRIVATE, 65536, IPC_CREAT | IPC_EXCL | 0600); shmctl(_id, IPC_RMID, 0); return 0;}' | tr @ '\n' | $(CC) -x c - -o .test2 2>/dev/null && echo 1 || echo 0 ; rm -f .test2 )" "1"
         SHMAT_OK=1
 else

--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -3812,6 +3812,12 @@ static void edit_params(aflcc_state_t *aflcc, u32 argc, char **argv,
 
     }
 
+// link in execinfo on FreeBSD to include backtrace library used by
+// instrumentation.
+#ifdef __FreeBSD__
+    insert_param(aflcc, "-lexecinfo");
+#endif
+
   }
 
   /* Inspect the command line parameters. */

--- a/utils/argv_fuzzing/Makefile
+++ b/utils/argv_fuzzing/Makefile
@@ -27,6 +27,12 @@ _LDFLAGS_ADD=$(UNAME_SAYS_LINUX:1=)
 LDFLAGS_ADD=$(_LDFLAGS_ADD:0=-ldl)
 LDFLAGS  += $(LDFLAGS_ADD)
 
+# Needed for backtrace under FreeBSD
+ifeq "$(SYS)" "FreeBSD"
+    LDFLAGS += -lexecinfo
+	COMPILER_RT_LDFLAGS += -lexecinfo
+endif
+
 # on gcc for arm there is no -m32, but -mbe32
 M32FLAG = -m32
 M64FLAG = -m64
@@ -55,10 +61,18 @@ install: argvfuzz32.so argvfuzz64.so
 	if [ -f argvfuzz64.so ]; then set -e; install -m 755 argvfuzz64.so $(DESTDIR)$(HELPER_PATH)/; fi
 
 argv_fuzz_persistent_demo: argv_fuzz_persistent_demo.c
-	../../afl-cc -g -o $@ $^
+	ifeq "$(SYS)" "FreeBSD"
+		../../afl-cc -lexecinfo -g -o $@ $^
+	else
+		../../afl-cc -g -o $@ $^
+	endif
 
 argv_fuzz_demo: argv_fuzz_demo.c
-	../../afl-cc -g -o $@ $^
+	ifeq "$(SYS)" "FreeBSD"
+		../../afl-cc -lexecinfo -g -o $@ $^
+	else
+		../../afl-cc -g -o $@ $^
+	endif
 
 demo: argv_fuzz_persistent_demo argv_fuzz_demo
 

--- a/utils/argv_fuzzing/Makefile
+++ b/utils/argv_fuzzing/Makefile
@@ -61,18 +61,10 @@ install: argvfuzz32.so argvfuzz64.so
 	if [ -f argvfuzz64.so ]; then set -e; install -m 755 argvfuzz64.so $(DESTDIR)$(HELPER_PATH)/; fi
 
 argv_fuzz_persistent_demo: argv_fuzz_persistent_demo.c
-	ifeq "$(SYS)" "FreeBSD"
-		../../afl-cc -lexecinfo -g -o $@ $^
-	else
-		../../afl-cc -g -o $@ $^
-	endif
+	../../afl-cc -g -o $@ $^
 
 argv_fuzz_demo: argv_fuzz_demo.c
-	ifeq "$(SYS)" "FreeBSD"
-		../../afl-cc -lexecinfo -g -o $@ $^
-	else
-		../../afl-cc -g -o $@ $^
-	endif
+	../../afl-cc -g -o $@ $^
 
 demo: argv_fuzz_persistent_demo argv_fuzz_demo
 


### PR DESCRIPTION
**Type of PR**: Enhancement
**Purpose of this PR**: This adds basic support for building and running AFL on FreeBSD 15. The basic instrumentation (afl-cc) and fuzzing (afl-fuzz) tools work. Only the basic "make all" target works at the moment, though, but unsupported functionality is disabled by default. (Unicorn Engine does not run on FreeBSD 15 X86-64.) All code should be built as before on other targets with no changes.
**I have tested the changes**: Yes. Regression testing (make test) has been also performed on Linux (Ubuntu 24.04). Testing on FreeBSD has been more manual due to the lack of docker, but has worked in our test/use cases.
