### PR TITLE
afl-fuzz: keep slow calibration runs in timeout sizing

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -288,7 +288,8 @@ struct queue_entry {
       fuzz_level,                       /* Number of fuzzing iterations     */
       n_fuzz_entry;                     /* offset in n_fuzz                 */
 
-  u64 exec_us,                          /* Execution time (us)              */
+  u64 exec_us,                          /* Average execution time (us)      */
+      exec_us_max,                      /* Slowest calibration run (us)     */
       handicap,                         /* Number of queue cycles behind    */
       depth,                            /* Path depth                       */
       exec_cksum,                       /* Checksum of the execution trace  */

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -474,7 +474,7 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
   u8 fault = 0, new_bits = 0, var_detected = 0, hnb = 0,
      first_run = (q->exec_cksum == 0);
-  u64 start_us, stop_us, diff_us;
+  u64 start_us, stop_us, diff_us, exec_start_us, exec_run_us, max_exec_us = 0;
   s32 old_sc = afl->stage_cur, old_sm = afl->stage_max;
   u32 use_tmout = afl->fsrv.exec_tmout;
   u8 *old_sn = afl->stage_name;
@@ -582,7 +582,11 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
     (void)write_to_testcase(afl, (void **)&use_mem, q->len, 1);
 
+    exec_start_us = get_cur_time_us();
     fault = fuzz_run_target(afl, &afl->fsrv, use_tmout);
+    exec_run_us = get_cur_time_us() - exec_start_us;
+    if (unlikely(!exec_run_us)) { ++exec_run_us; }
+    if (exec_run_us > max_exec_us) { max_exec_us = exec_run_us; }
 
     // update the time spend in calibration after each execution, as those may
     // be slow
@@ -688,6 +692,7 @@ u8 calibrate_case(afl_state_t *afl, struct queue_entry *q, u8 *use_mem,
 
   q->exec_us = diff_us / afl->stage_max;
   if (unlikely(!q->exec_us)) { q->exec_us = 1; }
+  q->exec_us_max = MAX(q->exec_us, max_exec_us);
 
   q->bitmap_size = count_bytes(afl, afl->fsrv.trace_bits);
   q->handicap = handicap;

--- a/src/afl-fuzz-stats.c
+++ b/src/afl-fuzz-stats.c
@@ -2397,8 +2397,10 @@ void show_init_stats(afl_state_t *afl) {
     q = afl->queue_buf[i];
     if (unlikely(q->disabled)) { continue; }
 
+    u64 q_max_us = MAX(q->exec_us, q->exec_us_max);
+
     if (!min_us || q->exec_us < min_us) { min_us = q->exec_us; }
-    if (q->exec_us > max_us) { max_us = q->exec_us; }
+    if (q_max_us > max_us) { max_us = q_max_us; }
 
     if (!min_bits || q->bitmap_size < min_bits) { min_bits = q->bitmap_size; }
     if (q->bitmap_size > max_bits) { max_bits = q->bitmap_size; }

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -3316,10 +3316,17 @@ int main(int argc, char **argv_orig, char **envp) {
 
       u64 max_ms = 0;
 
-      for (entry = 0; entry < afl->queued_items; ++entry)
-        if (!afl->queue_buf[entry]->disabled)
-          if ((afl->queue_buf[entry]->exec_us / 1000) > max_ms)
-            max_ms = afl->queue_buf[entry]->exec_us / 1000;
+      for (entry = 0; entry < afl->queued_items; ++entry) {
+
+        struct queue_entry *q = afl->queue_buf[entry];
+        u64                 q_max_us;
+
+        if (q->disabled) { continue; }
+
+        q_max_us = MAX(q->exec_us, q->exec_us_max);
+        if ((q_max_us / 1000) > max_ms) { max_ms = q_max_us / 1000; }
+
+      }
 
       // Add 20% as a safety margin, capped to exec_tmout given in -t option
       max_ms *= 1.2;

--- a/test/test-persistent-timeout.c
+++ b/test/test-persistent-timeout.c
@@ -1,0 +1,30 @@
+#include <unistd.h>
+
+static volatile int sink;
+
+int main(void) {
+
+  unsigned char buf[8];
+  int           first_run = 1;
+
+  while (__AFL_LOOP(100000)) {
+
+    ssize_t len;
+
+    if (first_run) {
+
+      first_run = 0;
+      usleep(220000);
+
+    }
+
+    len = read(0, buf, sizeof(buf));
+
+    if (len > 0 && buf[0] == 'A') { sink++; }
+    if (len > 1 && buf[1] == 'B') { sink++; }
+
+  }
+
+  return 0;
+
+}

--- a/test/test-persistent-timeout.sh
+++ b/test/test-persistent-timeout.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+. ./test-pre.sh
+
+$ECHO "$BLUE[*] Testing: persistent calibration timeout selection"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/afl-persistent-timeout.XXXXXX")"
+TARGET="${WORKDIR}/test-persistent-timeout"
+MIN_TIMEOUT_MS=200
+
+cleanup() {
+
+  rm -rf "${WORKDIR}"
+
+}
+
+fail() {
+
+  $ECHO "$RED[!] $*"
+  CODE=1
+
+}
+
+trap cleanup EXIT INT TERM
+
+test -e ../afl-clang-fast -a -e ../afl-fuzz && {
+
+  ../afl-clang-fast -O0 -o "${TARGET}" test-persistent-timeout.c \
+    > "${WORKDIR}/compile.log" 2>&1 || {
+
+    cat "${WORKDIR}/compile.log"
+    fail "persistent timeout target failed to compile"
+
+  }
+
+  mkdir -p "${WORKDIR}/in"
+  printf "A" > "${WORKDIR}/in/seed"
+
+  env AFL_EXIT_WHEN_DONE= AFL_EXIT_ON_TIME= AFL_NO_UI=1 AFL_QUIET=1 \
+    AFL_SKIP_CPUFREQ=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+    AFL_TRY_AFFINITY=1 \
+    ../afl-fuzz -V1 -m ${MEM_LIMIT} -i "${WORKDIR}/in" \
+      -o "${WORKDIR}/out" -- "${TARGET}" \
+      > "${WORKDIR}/fuzz.log" 2>&1 || {
+
+    cat "${WORKDIR}/fuzz.log"
+    fail "afl-fuzz failed during persistent timeout calibration test"
+
+  }
+
+  STATS="${WORKDIR}/out/default/fuzzer_stats"
+  EXEC_TIMEOUT="$(awk '$1 == "exec_timeout" { print $3 }' "${STATS}")"
+
+  case "${EXEC_TIMEOUT}" in
+    ""|*[!0-9]*)
+      cat "${WORKDIR}/fuzz.log"
+      fail "could not read exec_timeout from fuzzer_stats"
+      ;;
+    *)
+      if [ "${EXEC_TIMEOUT}" -lt "${MIN_TIMEOUT_MS}" ]; then
+
+        cat "${WORKDIR}/fuzz.log"
+        fail "exec_timeout ${EXEC_TIMEOUT}ms should include slow persistent fork run"
+
+      else
+
+        $ECHO "$GREEN[+] persistent calibration kept ${EXEC_TIMEOUT}ms timeout"
+
+      fi
+      ;;
+  esac
+
+} || {
+
+  $ECHO "$YELLOW[-] afl is not compiled, cannot test"
+  INCOMPLETE=1
+
+}
+
+cleanup
+trap - EXIT INT TERM
+
+. ./test-post.sh


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Bugfix
**Purpose of this PR**: Fixes #1545 by tracking the slowest successful calibration execution separately from the average execution time, then using that slowest run when AFL++ derives timeout limits. This keeps persistent-mode fork/init costs from being averaged away by faster loop iterations.
**I have tested the changes**: yes

Validation:
- `make -j2 NO_NYX=1 NO_QEMU=1 NO_UNICORN=1 NO_FRIDA=1 all`
- `test/test-persistent-timeout.sh`

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
