### PR TITLE
Cmin coverage collect for timeout during binary test

### DIFF
--- a/src/afl-showmap.c
+++ b/src/afl-showmap.c
@@ -290,7 +290,7 @@ static u32 write_results_to_file(afl_forkserver_t *fsrv, u8 *outfile) {
 
   }
 
-  if (cmin_mode && (run_timed_out() || (!caa && child_crashed != cco))) {
+  if (cmin_mode && !caa && (run_timed_out() || child_crashed != cco)) {
 
     if (strcmp(outfile, "-")) {
 
@@ -1225,7 +1225,7 @@ static void usage(u8 *argv0) {
       "LD_BIND_LAZY: do not set LD_BIND_NOW env var for target\n"
       "AFL_CMIN_CRASHES_ONLY: (cmin_mode) only write tuples for crashing "
       "inputs\n"
-      "AFL_CMIN_ALLOW_ANY: (cmin_mode) write tuples for crashing inputs also\n"
+      "AFL_CMIN_ALLOW_ANY: (cmin_mode) write tuples for crashing and timeout inputs also\n"
       "AFL_CRASH_EXITCODE: optional child exit code to be interpreted as "
       "crash\n"
       "AFL_DEBUG: enable extra developer output\n"


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Enhancement
**Purpose of this PR**: Implements (#2798) by allowing via `AFL_CMIN_ALLOW_ANY` to collect coverage during cmin not only for crashes, but for timeouts too.
**I have tested the changes**: yes
Validation:
- `make all`
- `./test-basic.sh`

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
  
