### PR TITLE
afl-whatsup: show stability information

### DIFF
--- a/afl-whatsup
+++ b/afl-whatsup
@@ -135,6 +135,7 @@ TOTAL_HANGS=0
 TOTAL_PFAV=0
 TOTAL_PENDING=0
 TOTAL_COVERAGE=
+LOWEST_STABILITY=
 
 # Time since last find / crash / hang, formatted as string
 FMT_TIME="0 days 0 hours"
@@ -199,13 +200,14 @@ for j in `find . -maxdepth 2 -iname fuzzer_setup | sort`; do
     RUN_DAYS=$((RUN_UNIX / 60 / 60 / 24))
     RUN_HRS=$(((RUN_UNIX / 60 / 60) % 24))
     COVERAGE=$(echo $bitmap_cvg|tr -d %)
+    STABILITY=$(echo $stability|tr -d %)
     if [ -n "$TOTAL_COVERAGE" -a -n "$COVERAGE" -a -n "$BC" ]; then
       if [ "$(echo "$TOTAL_COVERAGE < $COVERAGE" | bc)" -eq 1 ]; then
         TOTAL_COVERAGE=$COVERAGE
       fi
     fi
     if [ -z "$TOTAL_COVERAGE" ]; then TOTAL_COVERAGE=$COVERAGE ; fi
-    
+
     test -n "$cycles_wo_finds" && {
       test -z "$FIRST" && TOTAL_WCOP="${TOTAL_WCOP}/"
       TOTAL_WCOP="${TOTAL_WCOP}${cycles_wo_finds}"
@@ -293,6 +295,13 @@ for j in `find . -maxdepth 2 -iname fuzzer_setup | sort`; do
     TOTAL_HANGS=$((TOTAL_HANGS + saved_hangs))
     TOTAL_PENDING=$((TOTAL_PENDING + pending_total))
     TOTAL_PFAV=$((TOTAL_PFAV + pending_favs))
+    if [ -n "$STABILITY" -a -n "$BC" ]; then
+      if [ -z "$LOWEST_STABILITY" ]; then
+        LOWEST_STABILITY=$STABILITY
+        elif [ "$(echo "$STABILITY < $LOWEST_STABILITY" | bc)" -eq 1 ]; then
+        LOWEST_STABILITY=$STABILITY
+      fi
+    fi
     
     if [ "$last_find" -gt "$TOTAL_LAST_FIND" ]; then
       TOTAL_LAST_FIND=$last_find
@@ -329,6 +338,7 @@ for j in `find . -maxdepth 2 -iname fuzzer_setup | sort`; do
         echo "  cycles_wo_finds : $FMT_CWOP"
       fi
       echo "  coverage        : $COVERAGE%"
+      echo "  stability       : $STABILITY%"
       
       if [ -z "$MINIMAL_ONLY" ]; then
         
@@ -441,6 +451,9 @@ if [ "$ALIVE_CNT" -gt "1" -o -n "$MINIMAL_ONLY" ]; then
 fi
 
 echo "     Coverage reached : ${TOTAL_COVERAGE}%"
+if [ -n "$LOWEST_STABILITY" ]; then
+  echo "     Lowest stability : ${LOWEST_STABILITY}%"
+fi
 echo "        Crashes saved : $TOTAL_CRASHES"
 if [ -z "$MINIMAL_ONLY" ]; then
   echo "          Hangs saved : $TOTAL_HANGS"


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Enhancement
**Purpose of this PR**: Show stability information in `afl-whatsup` output. For the summary output, show the lowest stability found among all fuzzer instances.
**I have tested the changes**: yes

Example of updated per-fuzzer output:
```bash
  last_find       : 33 minutes, 21 seconds
  last_crash      : none seen yet
  last_hang       : none seen yet
  cycles_wo_finds : 16212
  coverage        : 3.22%
  stability       : 76.92%
  cpu usage 23.7%, memory usage 0.0%
  cycles 16242, lifetime speed 29582 execs/sec, items 8/10 (80%)
  pending 0/0, coverage 3.22%, no crashes yet
```

Example of updated summary output:
```bash
Summary stats
=============

        Fuzzers alive : 8
       Total run time : 4 hours, 26 minutes
          Total execs : 473 millions
     Cumulative speed : 236899 execs/sec
  Total average speed : 29612 execs/sec
Current average speed : 235537 execs/sec
        Pending items : 0 faves, 0 total
   Pending per fuzzer : 0 faves, 0 total (on average)
     Coverage reached : 3.22%
     Lowest stability : 76.92%
        Crashes saved : 0
          Hangs saved : 0
 Cycles without finds : 23706/20532/17689/5335/4429/878/13189/16212
   Time without finds : 33 minutes, 2 seconds
```


## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- AFL++ is using the Apache 2.0 license. By creating a PR you accept that your code submission will be under this license.
  
