### PR TITLE
Restore `afl->map_size` after zeroing it

### DIFF
--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -49,7 +49,8 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
 
   mopt_adaptive_init(afl);
 
-  afl->shm.map_size = map_size ? map_size : MAP_SIZE;
+  map_size = map_size ? map_size : MAP_SIZE;
+  afl->shm.map_size = map_size;
   afl->map_size = map_size;
 
   afl->smallest_favored = -1;

--- a/src/afl-fuzz-state.c
+++ b/src/afl-fuzz-state.c
@@ -50,6 +50,7 @@ void afl_state_init(afl_state_t *afl, uint32_t map_size) {
   mopt_adaptive_init(afl);
 
   afl->shm.map_size = map_size ? map_size : MAP_SIZE;
+  afl->map_size = map_size;
 
   afl->smallest_favored = -1;
   afl->afl_ijon_history_limit = 20;


### PR DESCRIPTION
https://github.com/AFLplusplus/AFLplusplus/commit/ab57ddbdcac326a763862a5d11609fc2c7a7c797 eliminated the local `map_size` variable from `main`, instead saving the value in `afl->map_size`.  But `afl_state_init` actually zeroes the entire `afl` struct, including `afl->map_size`.  As a result, the coverage maps *always* get reinitialized since `afl->map_size` is always zero, causing an unnecessary forkserver kill and restart.

To restore the original behavior, we restore `afl->map_size` after zeroing it.  We also fix a latent bug where `afl->shm.map_size` would be normalized in `afl_state_init` but none of the other related fields would be.

This was discovered when trying to fuzz in Nyx mode after upgrading to AFL++ v5.00c:

```
[QEMU-NYX] Booting VM to start fuzzing...
[!] libnyx: input buffer is write protected
[hget] 13088 bytes received from hypervisor! (hcat_no_pt)
[hget] 13040 bytes received from hypervisor! (habort_no_pt)
[hget] 316995072 bytes received from hypervisor! (container.tar)
[hcat] 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
[capablities] host_config.bitmap_size: 0x10000
[capablities] host_config.ijon_bitmap_size: 0x1000
[capablities] host_config.payload_buffer_size: 0x100000x
[init] using TARGET_MAP_SIZE: 456089
[init] scenario not compiled with afl instrumentation
[init] payload buffer is mapped at 0x7ffff7b38000 (size: 0x100000)
[init] taking snapshot
[!] libnyx: coverage mode: compile-time instrumentation
[!] libnyx: qemu #0 is ready:
[*] Target map size: 456089
[+] Re-initializing maps to 456128 bytes
[!] libnyx: sending SIGKILL to QEMU-Nyx process...
[*] No auto-generated dictionary tokens to reuse.
[*] Attempting dry run with 'id:000000,time:0,execs:0,orig:empty'...

[-] PROGRAM ABORT : Error: QEMU-Nyx has died...
         Location : afl_fsrv_run_target(), src/afl-forkserver.c:2588
```

The maps are unnecessarily reinitialized, and `afl-fuzz` crashes because the reinit logic is [broken](https://github.com/AFLplusplus/AFLplusplus/pull/2815) for Nyx mode.