### PR TITLE
Reset `nyx_runner` after shutdown

### DIFF
--- a/src/afl-forkserver.c
+++ b/src/afl-forkserver.c
@@ -191,6 +191,8 @@ void afl_nyx_runner_kill(afl_forkserver_t *fsrv) {
     if (fsrv->nyx_runner) {
 
       fsrv->nyx_handlers->nyx_shutdown(fsrv->nyx_runner);
+      /* clear the runner so a subsequent afl_fsrv_start() respawns QEMU-Nyx */
+      fsrv->nyx_runner = NULL;
 
     }
 


### PR DESCRIPTION
`afl_nyx_runner_kill` shuts the Nyx runner down but leaves `fsrv->nyx_runner` pointing to the now-dead runner.  As a result, any later `afl_fsrv_start` returns early without respawning QEMU-Nyx.  This causes coverage map reinitialization to fail in Nyx mode.

By resetting `nyx_runner` to `NULL` after shutting the runner down, we allow `afl_fsrv_start` to properly respawn QEMU-Nyx.

This was a latent bug exposed by the recent refactor in https://github.com/AFLplusplus/AFLplusplus/commit/ab57ddbdcac326a763862a5d11609fc2c7a7c797, which caused [*every*](https://github.com/AFLplusplus/AFLplusplus/pull/2814) run of `afl-fuzz` to reinitialize the coverage maps.  Attempting to fuzz in Nyx mode yielded:

```
[QEMU-NYX] Booting VM to start fuzzing...
[!] libnyx: input buffer is write protected
[hget] 13088 bytes received from hypervisor! (hcat_no_pt)
[hget] 13040 bytes received from hypervisor! (habort_no_pt)
[hget] 316995072 bytes received from hypervisor! (container.tar)
[hcat] 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
[capablities] host_config.bitmap_size: 0x10000
[capablities] host_config.ijon_bitmap_size: 0x1000
[capablities] host_config.payload_buffer_size: 0x100000x
[init] using TARGET_MAP_SIZE: 456089
[init] scenario not compiled with afl instrumentation
[init] payload buffer is mapped at 0x7ffff7b38000 (size: 0x100000)
[init] taking snapshot
[!] libnyx: coverage mode: compile-time instrumentation
[!] libnyx: qemu #0 is ready:
[*] Target map size: 456089
[+] Re-initializing maps to 456128 bytes
[!] libnyx: sending SIGKILL to QEMU-Nyx process...
[*] No auto-generated dictionary tokens to reuse.
[*] Attempting dry run with 'id:000000,time:0,execs:0,orig:empty'...

[-] PROGRAM ABORT : Error: QEMU-Nyx has died...
         Location : afl_fsrv_run_target(), src/afl-forkserver.c:2588
```

After this fix, QEMU-Nyx can properly respawn when the coverage map needs to be reinitialized:

```
[QEMU-NYX] Booting VM to start fuzzing...
[!] libnyx: input buffer is write protected
[hget] 13088 bytes received from hypervisor! (hcat_no_pt)
[hget] 13040 bytes received from hypervisor! (habort_no_pt)
[hget] 316995072 bytes received from hypervisor! (container.tar)
[hcat] 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
[capablities] host_config.bitmap_size: 0x10000
[capablities] host_config.ijon_bitmap_size: 0x1000
[capablities] host_config.payload_buffer_size: 0x100000x
[init] using TARGET_MAP_SIZE: 456089
[init] scenario not compiled with afl instrumentation
[init] payload buffer is mapped at 0x7ffff7b38000 (size: 0x100000)
[init] taking snapshot
[!] libnyx: coverage mode: compile-time instrumentation
[!] libnyx: qemu #0 is ready:
[*] Target map size: 456089
[+] Re-initializing maps to 456128 bytes
[!] libnyx: sending SIGKILL to QEMU-Nyx process...
[*] Spinning up the NYX backend...

... <snip> ...

[QEMU-NYX] Booting VM to start fuzzing...
[!] libnyx: input buffer is write protected
[hget] 13088 bytes received from hypervisor! (hcat_no_pt)
[hget] 13040 bytes received from hypervisor! (habort_no_pt)
[hget] 316995072 bytes received from hypervisor! (container.tar)
[hcat] 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
[capablities] host_config.bitmap_size: 0x10000
[capablities] host_config.ijon_bitmap_size: 0x1000
[capablities] host_config.payload_buffer_size: 0x100000x
[init] using TARGET_MAP_SIZE: 456089
[init] scenario not compiled with afl instrumentation
[init] payload buffer is mapped at 0x7ffff7b38000 (size: 0x100000)
[init] taking snapshot
[!] libnyx: coverage mode: compile-time instrumentation
[!] libnyx: qemu #0 is ready:
[*] Target map size: 456089
[*] No auto-generated dictionary tokens to reuse.
[*] Attempting dry run with 'id:000000,time:0,execs:0,orig:empty'...
[!] WARNING: instability detected during calibration: /tmp/smite-out/default/queue/id:000000,time:0,execs:0,orig:empty
    len = 1, map size = 1924, exec speed = 1684 us, hash = c3e6a7ed07e3c2b0
[!] WARNING: Instrumentation output varies across runs.
[+] All test cases processed.
[+] Here are some useful stats:

    Test case count : 1 favored, 1 variable, 0 ignored, 1 total
       Bitmap range : 1924 to 1924 bits (average: 1924.00 bits)
        Exec timing : 1684 to 1684 us (average: 1684 us)

[*] No -t option specified, so I'll use an exec timeout of 20 ms.
[+] All set and ready to roll!
```