### PR TITLE
fix NaN result for float predicates in split-compares pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Thank you! (For people sending pull requests - please add yourself to this list
     Ziqiao Kong                           Ryan Berger
     Sangjun Park                          Scott Guest
     Fabian Keil                           @Jay-1409
+    Gergely Nagy
   ```
 
 </details>

--- a/instrumentation/split-compares-pass.so.cc
+++ b/instrumentation/split-compares-pass.so.cc
@@ -1089,10 +1089,10 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
     bb->getInstList().insert(BasicBlock::iterator(bb->getTerminator()), is_nan);
 #endif
 
-    /* the result of the comparison, when at least one op is NaN
-       is true only for the "NOT EQUAL" predicates. */
-    bool NaNcmp_result = FcmpInst->getPredicate() == CmpInst::FCMP_ONE ||
-                         FcmpInst->getPredicate() == CmpInst::FCMP_UNE;
+    /* the result of the comparison, when at least one op is NaN,
+       is defined by ordered vs. unordered: ordered (FCMP_O*) predicates yield
+       false, unordered (FCMP_U*) predicates yield true. */
+    bool NaNcmp_result = CmpInst::isUnordered(FcmpInst->getPredicate());
 
     BasicBlock *nonan_bb =
         BasicBlock::Create(C, "noNaN", end_bb->getParent(), end_bb);


### PR DESCRIPTION
**Type of PR**:  Bugfix
**Purpose of this PR**: fix NaN result for float predicates in split-compares pass
**I have tested the changes**: yes

In `splitFPCompares()` (`instrumentation/split-compares-pass.so.cc`), the result used when a split float comparison has a NaN operand was wrong. Per [LLVM LangRef](https://llvm.org/docs/LangRef.html#id321), the NaN result depends only on ordered (`FCMP_O*` → false) vs unordered (`FCMP_U*` → true).

The old code only returned true for `ONE`/`UNE`: https://github.com/AFLplusplus/AFLplusplus/blob/aadc8df1e3cf564b9c22c889a52b3ac9083039e9/instrumentation/split-compares-pass.so.cc#L1092-L1095

This is wrong for `ONE` (should be false) and `UEQ`/`UGT`/`ULT` (should be true). E.g. `isfinite(x)` lowers to `fcmp one (fabs x), inf`, so instrumented `isfinite(NaN)` wrongly returns 1.

Example reproducer:

```c
int main(void) {
  volatile double z = 0.0; // volatile just to avoid constant folding 
  return !(z / z <= 1.0); // `!(NaN <= 1.0)` should be true
}
```

```sh
AFL_LLVM_LAF_SPLIT_FLOATS=1 ./afl-clang-fast -o bug bug.c
./bug; echo $?   # before: 0 (wrong), after: 1 (correct)
```

