### PR TITLE
use correct precision for bfloat16 in split-compares pass

### DIFF
--- a/instrumentation/split-compares-pass.so.cc
+++ b/instrumentation/split-compares-pass.so.cc
@@ -987,9 +987,10 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
     const unsigned int precision = sizeInBits == 32    ? 24
                                    : sizeInBits == 64  ? 53
                                    : sizeInBits == 128 ? 113
-                                   : sizeInBits == 16  ? 11
-                                   : sizeInBits == 80  ? 65
-                                                       : sizeInBits - 8;
+                                   : sizeInBits == 16
+                                       ? (op0->getType()->isBFloatTy() ? 8 : 11)
+                                   : sizeInBits == 80 ? 65
+                                                      : sizeInBits - 8;
 
     const unsigned           shiftR_exponent = precision - 1;
     const unsigned long long mask_fraction =


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: use correct precision for bfloat16 in split-compares pass
**I have tested the changes**: yes

`splitFPCompares()` hard-codes 16-bit floats as IEEE half (`precision = 11`). `bfloat16` is also 16 bits but has precision 8 (8-bit exponent, 7-bit mantissa), so its masks, `NaN_lowend`, and field widths come out wrong.

Fixing calculation of the `precision` variable fixes all derived constants. The LLVM version guard is needed because `bfloat16` support only exists from LLVM 11.