### PR TITLE
Disable incompatible MAP_NORESERVE mmap flag in instrumentation on FreeBSD

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -51,6 +51,11 @@ __attribute__((weak)) void __sanitizer_symbolize_pc(void *, const char *fmt,
   #include <execinfo.h>
 #endif
 
+/* FreeBSD, as of FreeBSD 15.1, has no support for MAP_NORESERVE for mmap */
+#ifndef MAP_NORESERVE
+  #define MAP_NORESERVE 0
+#endif
+
 #define XXH_INLINE_ALL
 #include "xxhash.h"
 #undef XXH_INLINE_ALL


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: The recent commit c85d209ac9cad36b2d157f18d0a12f3220ed83d8 broke support for compiling AFL++ on FreeBSD due to using the "MAP_NORESERVE" flag for mmap, which does not exist on FreeBSD. This PR disables the usage of MAP_NORESERVE there when building under FreeBSD. 

Since this exists as an optimization, this will have no effect on functionality under FreeBSD and Linux, Windows, and other builds should be unaffected by this PR entirely.
**I have tested the changes**:  yes
