### PR TITLE
afl-cc: set have_c for -x c++-header / -x c-header (PCH builds)

### DIFF
--- a/src/afl-cc.c
+++ b/src/afl-cc.c
@@ -2840,6 +2840,17 @@ param_st parse_misc_params(aflcc_state_t *aflcc, u8 *cur_argv, u8 scan) {
 
     SCAN_KEEP(aflcc->x_set, 1);
 
+  } else if (aflcc->x_set &&
+             (!strcmp(cur_argv, "c++-header") ||
+              !strcmp(cur_argv, "c-header"))) {
+
+    /* Precompiled-header build (-x c++-header / -x c-header): treat as
+     * compile-only so add_runtime skips afl-compiler-rt.o and
+     * afl-llvm-rt-lto.o.  Those are link-time artefacts; appending them
+     * alongside the single PCH output causes clang to error with
+     * "cannot specify -o when generating multiple output files".*/
+    SCAN_KEEP(aflcc->have_c, 1);
+
   } else if (!strcmp(cur_argv, "-E")) {
 
     SCAN_KEEP(aflcc->preprocessor_only, 1);


### PR DESCRIPTION
**Type of PR**: Enhancement
**Purpose of this PR**: Fixing afl-clang-lto compilation flow when PCH rules are present (e.g. Verilator 5)
**I have tested the changes**: yes

Verilator >= 5.019 (2023-10-01) added automatic precompiled-header support in verilated.mk.  Its PCH rules invoke the compiler as:

    $(CXX) ... -x c++-header $< -o $@

In AFL-LTO mode, add_runtime() unconditionally appends afl-compiler-rt.o and afl-llvm-rt-lto.o to every invocation unless have_c is set.  Those artefacts are link-time only; injecting them into a PCH build gives clang multiple inputs against a single -o:

    clang: error: cannot specify -o when generating multiple output files

Fix: in parse_misc_params(), when x_set is already true and the current argument is "c++-header" or "c-header", set have_c via SCAN_KEEP — the same mechanism the "-c" handler uses.
This suppresses the runtime injection (and the add_lto_linker/add_lto_passes calls) while leaving all instrumentation defines and optimisation flags intact.
The resulting .gch file is a valid CPCH binary.