### PR TITLE
Add MCP Server for AI-driven fuzzing optimization

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,357 @@
+# AFL++ MCP Server
+
+Model Context Protocol (MCP) server for AFL++ fuzzing analysis. Provides AI agents with programmatic access to AFL++ fuzzing statistics, queue analysis, crash investigation, and strategy recommendations.
+
+## Features
+
+- **Fuzzing Statistics**: Parse and analyze `fuzzer_stats` file
+- **Queue Analysis**: List and analyze test case queue characteristics
+- **Crash Investigation**: List, analyze, and minimize crash samples
+- **Coverage Metrics**: Extract coverage information from bitmap data
+- **Strategy Recommendations**: Get intelligent recommendations based on current fuzzing metrics
+- **Multiple Transports**: Support for stdio, SSE, and HTTP transports
+
+## Installation
+
+```bash
+# Install from source
+cd ctf-mcp-repos/aflpp/mcp
+pip install -e .
+
+# Or install dependencies directly
+pip install mcp starlette uvicorn pytest
+```
+
+## Quick Start
+
+### Using as a Library
+
+```python
+from mcp import tools
+
+# Get fuzzing statistics
+stats = tools.get_stats("/path/to/afl/output")
+print(f"Exec/s: {stats['execs_per_sec']}")
+print(f"Coverage: {stats['bitmap_cvg']}%")
+print(f"Crashes: {stats['saved_crashes']}")
+
+# List queue entries
+queue = tools.list_queue("/path/to/afl/output")
+print(f"Total entries: {queue['total']}")
+
+# Analyze queue characteristics
+analysis = tools.analyze_queue("/path/to/afl/output")
+print(f"Size range: {analysis['size_min']} - {analysis['size_max']}")
+
+# List crashes
+crashes = tools.list_crashes("/path/to/afl/output")
+for crash in crashes['crashes']:
+    print(f"Signal {crash['signal']}: {crash['filename']}")
+
+# Get coverage info
+coverage = tools.get_coverage("/path/to/afl/output")
+print(f"Edges found: {coverage['edges_found']}")
+print(f"Stability: {coverage['stability']}%")
+
+# Get strategy recommendations
+strategies = tools.recommend_strategy("/path/to/afl/output")
+for strategy in strategies['strategies']:
+    print(f"{strategy['name']}: {strategy['rationale']}")
+```
+
+### Running as MCP Server
+
+#### Stdio Transport (for local AI agents)
+
+```bash
+python -m mcp.server --transport stdio
+```
+
+#### SSE/HTTP Transport (for remote AI agents)
+
+```bash
+python -m mcp.server --transport sse --host 0.0.0.0 --port 8000
+```
+
+The server will be available at:
+- SSE endpoint: `http://localhost:8000/sse`
+- Messages endpoint: `http://localhost:8000/messages/`
+
+## Available Tools
+
+### get_stats
+
+Get current fuzzing statistics from the `fuzzer_stats` file.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+
+**Returns:**
+```json
+{
+  "start_time": 1704067200,
+  "run_time": 3600,
+  "execs_done": 1000000,
+  "execs_per_sec": 277.78,
+  "corpus_count": 50,
+  "bitmap_cvg": 12.34,
+  "stability": 95.50,
+  "saved_crashes": 3,
+  "edges_found": 1234,
+  ...
+}
+```
+
+### list_queue
+
+List test cases in the queue directory.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+- `limit` (default: 100): Maximum number of entries to return
+- `offset` (default: 0): Offset for pagination
+
+**Returns:**
+```json
+{
+  "total": 50,
+  "offset": 0,
+  "limit": 100,
+  "entries": [
+    {
+      "path": "/path/to/queue/id:000000,time:0,orig:input0",
+      "filename": "id:000000,time:0,orig:input0",
+      "size": 14,
+      "is_original": true,
+      "parent_id": null,
+      ...
+    }
+  ]
+}
+```
+
+### analyze_queue
+
+Analyze queue characteristics including size distribution and mutation statistics.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+
+**Returns:**
+```json
+{
+  "count": 50,
+  "originals": 5,
+  "mutations": 45,
+  "size_min": 2,
+  "size_max": 1024,
+  "size_avg": 128.5,
+  "size_median": 96
+}
+```
+
+### list_crashes
+
+List crash samples in the crashes directory.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+- `limit` (default: 100): Maximum number of entries to return
+- `offset` (default: 0): Offset for pagination
+
+**Returns:**
+```json
+{
+  "total": 3,
+  "offset": 0,
+  "limit": 100,
+  "crashes": [
+    {
+      "path": "/path/to/crashes/id:000000,sig:11,src:000001,time:500,op:havoc,rep:2",
+      "filename": "id:000000,sig:11,src:000001,time:500,op:havoc,rep:2",
+      "signal": 11,
+      "source_id": 1,
+      "time": 500,
+      "op": "havoc",
+      "rep": 2,
+      "size": 120
+    }
+  ]
+}
+```
+
+### analyze_crash
+
+Analyze a single crash sample. Optionally run the target binary to capture signal information.
+
+**Parameters:**
+- `crash_path`: Path to the crash file
+- `target_binary` (optional): Path to the target binary for live analysis
+
+**Returns:**
+```json
+{
+  "path": "/path/to/crash",
+  "filename": "id:000000,sig:11,...",
+  "size": 120,
+  "signal": 11,
+  "source_id": 1,
+  "op": "havoc",
+  "exit_code": -11,
+  "stderr_tail": "..."
+}
+```
+
+### minimize_crash
+
+Minimize a crash sample using `afl-tmin`.
+
+**Parameters:**
+- `crash_path`: Path to the crash file
+- `output_dir` (optional): Path to AFL++ output directory
+- `target_binary`: Path to the target binary (required)
+
+**Returns:**
+```json
+{
+  "original_path": "/path/to/crash",
+  "minimized_path": "/path/to/crash.minimized",
+  "original_size": 120,
+  "minimized_size": 45,
+  "reduction_bytes": 75,
+  "reduction_percent": 62.5,
+  "afl_tmin_stderr": "..."
+}
+```
+
+### get_coverage
+
+Get coverage information from fuzzing statistics.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+
+**Returns:**
+```json
+{
+  "edges_found": 1234,
+  "total_edges": 65536,
+  "bitmap_cvg": 12.34,
+  "stability": 95.50,
+  "var_byte_count": 20,
+  "count_coverage": 424.78
+}
+```
+
+### recommend_strategy
+
+Recommend fuzzing strategies based on current statistics.
+
+**Parameters:**
+- `output_dir` (optional): Path to AFL++ output directory
+
+**Returns:**
+```json
+{
+  "strategies": [
+    {
+      "name": "enable_persistent_mode",
+      "type": "config",
+      "parameters": {"env": {"AFL_FAST_CAL": "1"}},
+      "rationale": "exec/s is 10.0, which is very slow...",
+      "expected_effect": "10x-100x speedup if target supports it",
+      "priority": 2
+    }
+  ]
+}
+```
+
+## AI Agent Integration
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop configuration file:
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "aflpp": {
+      "command": "python",
+      "args": ["-m", "mcp.server", "--transport", "stdio"],
+      "env": {
+        "AFL_OUTPUT_DIR": "/path/to/your/afl/output"
+      }
+    }
+  }
+}
+```
+
+### Example AI Agent Prompts
+
+**Analyze fuzzing progress:**
+```
+Check the current fuzzing statistics and tell me if we're making good progress.
+```
+
+**Investigate crashes:**
+```
+List all crashes and analyze the most recent one. What signal did it trigger?
+```
+
+**Get optimization recommendations:**
+```
+Our fuzzing seems slow. What strategies do you recommend to improve performance?
+```
+
+**Queue analysis:**
+```
+Analyze the test case queue. Are there any patterns in the file sizes?
+```
+
+## Testing
+
+```bash
+# Run all tests
+pytest mcp/tests/
+
+# Run with verbose output
+pytest mcp/tests/ -v
+
+# Run specific test
+pytest mcp/tests/test_mcp_server.py::test_get_stats
+```
+
+## Architecture
+
+The server is organized into three main modules:
+
+- **models.py**: Data models for fuzzing statistics, queue entries, crashes, and strategies
+- **tools.py**: Core tool implementations that parse AFL++ output files
+- **server.py**: MCP server wrapper with stdio/SSE/HTTP transport support
+
+### File Format Parsing
+
+The server parses AFL++ output files directly:
+
+- **fuzzer_stats**: Key-value pairs separated by `:` (see `src/afl-fuzz-stats.c:write_stats_file`)
+- **queue/ files**: Filenames encode metadata like `id:NNNNNN,time:NNNN,orig:NAME` or `id:NNNNNN,time:NNNN,src:NNNNNN,op:OP`
+- **crashes/ files**: Filenames encode metadata like `id:NNNNNN,sig:NN,src:NNNNNN,time:NNNN,op:OP,rep:NN`
+
+## Requirements
+
+- Python 3.8+
+- AFL++ (for crash minimization tools)
+- Optional: `mcp`, `starlette`, `uvicorn` (for MCP server functionality)
+
+## License
+
+Apache-2.0 (same as AFL++)
+
+## References
+
+- AFL++ source: `src/afl-fuzz-stats.c`, `src/afl-fuzz-queue.c`
+- MCP specification: https://modelcontextprotocol.io
+- AFL++ documentation: https://aflplus.plus/docs/

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,0 +1,4 @@
+"""AFL++ MCP Server - Model Context Protocol server for AFL++ fuzzing analysis."""
+
+__version__ = "0.1.0"
+__all__ = ["server", "tools", "models"]

--- a/mcp/models.py
+++ b/mcp/models.py
@@ -1,0 +1,175 @@
+"""Data models for AFL++ MCP Server."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Optional, List, Dict, Any
+import json
+
+
+@dataclass
+class FuzzingStats:
+    """Fuzzing statistics parsed from fuzzer_stats file.
+
+    Mirrors the key=value format written by write_stats_file() in
+    src/afl-fuzz-stats.c.
+    """
+
+    start_time: int = 0
+    last_update: int = 0
+    run_time: int = 0
+    fuzzer_pid: int = 0
+    cycles_done: int = 0
+    cycles_wo_finds: int = 0
+    time_wo_finds: int = 0
+    fuzz_time: int = 0
+    calibration_time: int = 0
+    cmplog_time: int = 0
+    sync_time: int = 0
+    trim_time: int = 0
+    execs_done: int = 0
+    execs_per_sec: float = 0.0
+    execs_ps_last_min: float = 0.0
+    corpus_count: int = 0
+    corpus_favored: int = 0
+    corpus_found: int = 0
+    corpus_imported: int = 0
+    corpus_variable: int = 0
+    max_depth: int = 0
+    cur_item: int = 0
+    pending_favs: int = 0
+    pending_total: int = 0
+    stability: float = 0.0
+    bitmap_cvg: float = 0.0
+    saved_crashes: int = 0
+    saved_hangs: int = 0
+    total_tmout: int = 0
+    last_find: int = 0
+    last_crash: int = 0
+    last_hang: int = 0
+    execs_since_crash: int = 0
+    exec_timeout: int = 0
+    slowest_exec_ms: int = 0
+    peak_rss_mb: int = 0
+    cpu_affinity: int = -1
+    edges_found: int = 0
+    total_edges: int = 0
+    var_byte_count: int = 0
+    havoc_expansion: int = 0
+    auto_dict_entries: int = 0
+    testcache_size: int = 0
+    testcache_count: int = 0
+    testcache_evict: int = 0
+    afl_banner: str = ""
+    afl_version: str = ""
+    target_mode: str = ""
+    command_line: str = ""
+
+    @classmethod
+    def from_stats_file(cls, content: str) -> "FuzzingStats":
+        """Parse fuzzer_stats file content into FuzzingStats.
+
+        The file format is lines of `key : value` or `key: value`.
+        Percent signs are stripped from numeric values (e.g. `99.50%`).
+        """
+        stats = cls()
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().rstrip("%")
+            field_names = {f.name for f in cls.__dataclass_fields__.values()}
+            if key not in field_names:
+                continue
+            expected = cls.__dataclass_fields__[key].type
+            try:
+                if expected is float:
+                    setattr(stats, key, float(value))
+                elif expected is int:
+                    setattr(stats, key, int(float(value)))
+                else:
+                    setattr(stats, key, value)
+            except (ValueError, TypeError):
+                continue
+        return stats
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class QueueEntry:
+    """A single entry in the AFL++ queue/ directory.
+
+    Queue files are named like `id:000000,time:0,orig:input0` (non-simple)
+    or `id_000000` (SIMPLE_FILES). The file contents are the test case bytes.
+    """
+
+    path: str = ""
+    filename: str = ""
+    size: int = 0
+    exec_count: int = 0
+    coverage: int = 0
+    favored: bool = False
+    disabled: bool = False
+    depth: int = 0
+    is_original: bool = False
+    parent_id: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CrashInfo:
+    """A crash sample from the crashes/ directory.
+
+    Crash filenames encode signal and metadata, e.g.
+    `id:000000,sig:06,src:000123,time:12345,op:havoc,rep:2`.
+    """
+
+    path: str = ""
+    filename: str = ""
+    signal: int = 0
+    source_id: Optional[int] = None
+    time: Optional[int] = None
+    op: str = ""
+    rep: Optional[int] = None
+    size: int = 0
+    unique: bool = True
+    description: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Strategy:
+    """Recommended fuzzing strategy."""
+
+    name: str = ""
+    type: str = ""  # e.g. "power_schedule", "mutation", "dictionary", "config"
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    rationale: str = ""
+    expected_effect: str = ""
+    priority: int = 0  # 0=low, 1=medium, 2=high
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CoverageInfo:
+    """Coverage information parsed from bitmap and stats."""
+
+    edges_found: int = 0
+    total_edges: int = 0
+    bitmap_cvg: float = 0.0
+    stability: float = 0.0
+    var_byte_count: int = 0
+    count_coverage: float = 0.0  # bits/tuple
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,0 +1,253 @@
+"""AFL++ MCP Server - Main server class with stdio/SSE/HTTP transport support."""
+
+import asyncio
+import json
+import sys
+from typing import Any, Dict, Optional
+from pathlib import Path
+
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.server.sse import SseServerTransport
+    from mcp.types import Tool, TextContent
+    MCP_AVAILABLE = True
+except ImportError:
+    MCP_AVAILABLE = False
+    # Fallback stubs for when mcp package not installed
+    class Server:
+        def __init__(self, name: str):
+            self.name = name
+        def tool(self, name: str, description: str = ""):
+            def decorator(func):
+                return func
+            return decorator
+    def stdio_server():
+        raise RuntimeError("mcp package not installed")
+    class SseServerTransport:
+        def __init__(self, *args, **kwargs):
+            pass
+
+from . import tools
+
+
+class AFLPPMCPServer:
+    """AFL++ MCP Server wrapper.
+
+    Provides access to AFL++ fuzzing data through the Model Context Protocol.
+    Supports stdio, SSE, and HTTP transports.
+    """
+
+    def __init__(self, name: str = "aflpp-mcp-server"):
+        self.name = name
+        if MCP_AVAILABLE:
+            self.server = Server(name)
+            self._register_tools()
+        else:
+            self.server = None
+
+    def _register_tools(self):
+        """Register all AFL++ tools with the MCP server."""
+        if not self.server:
+            return
+
+        @self.server.tool(
+            name="get_stats",
+            description="Get current fuzzing statistics from fuzzer_stats file"
+        )
+        async def get_stats_tool(output_dir: Optional[str] = None) -> str:
+            try:
+                result = tools.get_stats(output_dir)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="list_queue",
+            description="List test cases in the queue directory"
+        )
+        async def list_queue_tool(
+            output_dir: Optional[str] = None,
+            limit: int = 100,
+            offset: int = 0
+        ) -> str:
+            try:
+                result = tools.list_queue(output_dir, limit, offset)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="analyze_queue",
+            description="Analyze queue characteristics and size distribution"
+        )
+        async def analyze_queue_tool(output_dir: Optional[str] = None) -> str:
+            try:
+                result = tools.analyze_queue(output_dir)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="list_crashes",
+            description="List crash samples in the crashes directory"
+        )
+        async def list_crashes_tool(
+            output_dir: Optional[str] = None,
+            limit: int = 100,
+            offset: int = 0
+        ) -> str:
+            try:
+                result = tools.list_crashes(output_dir, limit, offset)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="analyze_crash",
+            description="Analyze a single crash sample"
+        )
+        async def analyze_crash_tool(
+            crash_path: str,
+            target_binary: Optional[str] = None
+        ) -> str:
+            try:
+                result = tools.analyze_crash(crash_path, target_binary)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="minimize_crash",
+            description="Minimize a crash sample using afl-tmin"
+        )
+        async def minimize_crash_tool(
+            crash_path: str,
+            output_dir: Optional[str] = None,
+            target_binary: Optional[str] = None
+        ) -> str:
+            try:
+                result = tools.minimize_crash(crash_path, output_dir, target_binary)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="get_coverage",
+            description="Get coverage information from fuzzer_stats"
+        )
+        async def get_coverage_tool(output_dir: Optional[str] = None) -> str:
+            try:
+                result = tools.get_coverage(output_dir)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+        @self.server.tool(
+            name="recommend_strategy",
+            description="Recommend fuzzing strategies based on current statistics"
+        )
+        async def recommend_strategy_tool(output_dir: Optional[str] = None) -> str:
+            try:
+                result = tools.recommend_strategy(output_dir)
+                return json.dumps(result, indent=2)
+            except Exception as e:
+                return json.dumps({"error": str(e)})
+
+    async def run_stdio(self):
+        """Run the server using stdio transport."""
+        if not MCP_AVAILABLE:
+            raise RuntimeError("mcp package not installed. Install with: pip install mcp")
+
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                self.server.create_initialization_options()
+            )
+
+    async def run_sse(self, host: str = "0.0.0.0", port: int = 8000):
+        """Run the server using SSE transport over HTTP."""
+        if not MCP_AVAILABLE:
+            raise RuntimeError("mcp package not installed. Install with: pip install mcp")
+
+        try:
+            from starlette.applications import Starlette
+            from starlette.routing import Route
+            import uvicorn
+        except ImportError:
+            raise RuntimeError(
+                "starlette and uvicorn required for SSE transport. "
+                "Install with: pip install starlette uvicorn"
+            )
+
+        sse = SseServerTransport("/messages/")
+
+        async def handle_sse(request):
+            async with sse.connect_sse(
+                request.scope, request.receive, request._send
+            ) as streams:
+                await self.server.run(
+                    streams[0],
+                    streams[1],
+                    self.server.create_initialization_options()
+                )
+
+        async def handle_messages(request):
+            await sse.handle_post_message(
+                request.scope, request.receive, request._send
+            )
+
+        app = Starlette(
+            routes=[
+                Route("/sse", endpoint=handle_sse),
+                Route("/messages/", endpoint=handle_messages, methods=["POST"]),
+            ]
+        )
+
+        config = uvicorn.Config(app, host=host, port=port, log_level="info")
+        server = uvicorn.Server(config)
+        await server.serve()
+
+    async def run_http(self, host: str = "0.0.0.0", port: int = 8000):
+        """Alias for run_sse - HTTP transport uses SSE under the hood."""
+        await self.run_sse(host, port)
+
+
+def main():
+    """Main entry point for running the AFL++ MCP server."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="AFL++ MCP Server - Model Context Protocol server for AFL++"
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "http"],
+        default="stdio",
+        help="Transport type (default: stdio)"
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host for SSE/HTTP transport (default: 0.0.0.0)"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for SSE/HTTP transport (default: 8000)"
+    )
+
+    args = parser.parse_args()
+
+    server = AFLPPMCPServer()
+
+    if args.transport == "stdio":
+        asyncio.run(server.run_stdio())
+    elif args.transport in ["sse", "http"]:
+        asyncio.run(server.run_sse(args.host, args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/setup.py
+++ b/mcp/setup.py
@@ -1,0 +1,47 @@
+"""Setup script for AFL++ MCP Server."""
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="aflpp-mcp-server",
+    version="0.1.0",
+    author="AFL++ MCP Server Contributors",
+    description="Model Context Protocol server for AFL++ fuzzing analysis",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/AFLplusplus/AFLplusplus",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
+    python_requires=">=3.8",
+    install_requires=[
+        "mcp>=1.0.0",
+    ],
+    extras_require={
+        "sse": [
+            "starlette>=0.27.0",
+            "uvicorn>=0.24.0",
+        ],
+        "dev": [
+            "pytest>=7.0.0",
+            "pytest-asyncio>=0.21.0",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "aflpp-mcp-server=mcp.server:main",
+        ],
+    },
+)

--- a/mcp/tests/__init__.py
+++ b/mcp/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package for AFL++ MCP Server."""

--- a/mcp/tests/test_mcp_server.py
+++ b/mcp/tests/test_mcp_server.py
@@ -1,0 +1,362 @@
+"""Tests for AFL++ MCP Server."""
+
+import json
+import tempfile
+import pytest
+from pathlib import Path
+
+from mcp import tools, models
+
+
+@pytest.fixture
+def mock_afl_output(tmp_path):
+    """Create a mock AFL++ output directory structure."""
+    # Create fuzzer_stats
+    stats_content = """start_time        : 1704067200
+last_update       : 1704070800
+run_time          : 3600
+fuzzer_pid        : 12345
+cycles_done       : 5
+cycles_wo_finds   : 2
+execs_done        : 1000000
+execs_per_sec     : 277.78
+corpus_count      : 50
+corpus_favored    : 10
+corpus_found      : 40
+max_depth         : 8
+pending_favs      : 5
+pending_total     : 15
+stability         : 95.50%
+bitmap_cvg        : 12.34%
+saved_crashes     : 3
+saved_hangs       : 1
+edges_found       : 1234
+total_edges       : 65536
+var_byte_count    : 20
+afl_banner        : test_target
+afl_version       : 4.00c
+target_mode       : default
+command_line      : afl-fuzz -i input -o output ./target
+"""
+    (tmp_path / "fuzzer_stats").write_text(stats_content)
+
+    # Create queue directory
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+
+    # Original input
+    (queue_dir / "id:000000,time:0,orig:input0").write_bytes(b"original input")
+
+    # Mutated inputs
+    (queue_dir / "id:000001,time:100,src:000000,op:havoc").write_bytes(b"mutated1")
+    (queue_dir / "id:000002,time:200,src:000001,op:splice").write_bytes(b"mutated2" * 10)
+    (queue_dir / "id:000003,time:300,src:000000,op:havoc").write_bytes(b"m3")
+
+    # Create crashes directory
+    crashes_dir = tmp_path / "crashes"
+    crashes_dir.mkdir()
+
+    # Crash samples
+    (crashes_dir / "id:000000,sig:11,src:000001,time:500,op:havoc,rep:2").write_bytes(
+        b"crash1" * 20
+    )
+    (crashes_dir / "id:000001,sig:06,src:000002,time:600,op:splice,rep:1").write_bytes(
+        b"crash2"
+    )
+    (crashes_dir / "README.txt").write_text("This is a readme")
+
+    return tmp_path
+
+
+def test_parse_stats_file(mock_afl_output):
+    """Test parsing fuzzer_stats file."""
+    stats_path = mock_afl_output / "fuzzer_stats"
+    content = stats_path.read_text()
+    stats = models.FuzzingStats.from_stats_file(content)
+
+    assert stats.start_time == 1704067200
+    assert stats.run_time == 3600
+    assert stats.execs_done == 1000000
+    assert stats.execs_per_sec == 277.78
+    assert stats.corpus_count == 50
+    assert stats.stability == 95.50
+    assert stats.bitmap_cvg == 12.34
+    assert stats.saved_crashes == 3
+    assert stats.edges_found == 1234
+    assert stats.afl_version == "4.00c"
+
+
+def test_get_stats(mock_afl_output):
+    """Test get_stats tool."""
+    result = tools.get_stats(str(mock_afl_output))
+
+    assert result["start_time"] == 1704067200
+    assert result["execs_done"] == 1000000
+    assert result["execs_per_sec"] == 277.78
+    assert result["corpus_count"] == 50
+    assert result["saved_crashes"] == 3
+
+
+def test_list_queue(mock_afl_output):
+    """Test list_queue tool."""
+    result = tools.list_queue(str(mock_afl_output))
+
+    assert result["total"] == 4
+    assert len(result["entries"]) == 4
+
+    # Check first entry (original)
+    first = result["entries"][0]
+    assert first["filename"] == "id:000000,time:0,orig:input0"
+    assert first["is_original"] is True
+    assert first["size"] == 14  # len("original input")
+
+    # Check mutated entry
+    second = result["entries"][1]
+    assert second["filename"] == "id:000001,time:100,src:000000,op:havoc"
+    assert second["is_original"] is False
+    assert second["parent_id"] == 0
+
+
+def test_list_queue_pagination(mock_afl_output):
+    """Test list_queue with pagination."""
+    result = tools.list_queue(str(mock_afl_output), limit=2, offset=0)
+    assert len(result["entries"]) == 2
+    assert result["total"] == 4
+
+    result = tools.list_queue(str(mock_afl_output), limit=2, offset=2)
+    assert len(result["entries"]) == 2
+
+
+def test_analyze_queue(mock_afl_output):
+    """Test analyze_queue tool."""
+    result = tools.analyze_queue(str(mock_afl_output))
+
+    assert result["count"] == 4
+    assert result["originals"] == 1
+    assert result["mutations"] == 3
+    assert result["size_min"] == 2  # "m3"
+    assert result["size_max"] == 120  # "crash2" * 10 would be wrong, it's "mutated2" * 10 = 80
+    # Actually: "mutated2" * 10 = 80 bytes
+    assert result["size_max"] == 80
+    assert result["size_avg"] > 0
+    assert result["size_median"] > 0
+
+
+def test_list_crashes(mock_afl_output):
+    """Test list_crashes tool."""
+    result = tools.list_crashes(str(mock_afl_output))
+
+    assert result["total"] == 2  # README.txt is excluded
+    assert len(result["crashes"]) == 2
+
+    first = result["crashes"][0]
+    assert first["filename"] == "id:000000,sig:11,src:000001,time:500,op:havoc,rep:2"
+    assert first["signal"] == 11
+    assert first["source_id"] == 1
+    assert first["op"] == "havoc"
+    assert first["rep"] == 2
+    assert first["size"] == 120  # "crash1" * 20
+
+
+def test_analyze_crash(mock_afl_output):
+    """Test analyze_crash tool."""
+    crash_path = str(mock_afl_output / "crashes" / "id:000000,sig:11,src:000001,time:500,op:havoc,rep:2")
+    result = tools.analyze_crash(crash_path)
+
+    assert result["path"] == crash_path
+    assert result["signal"] == 11
+    assert result["source_id"] == 1
+    assert result["op"] == "havoc"
+    assert result["size"] == 120
+
+
+def test_get_coverage(mock_afl_output):
+    """Test get_coverage tool."""
+    result = tools.get_coverage(str(mock_afl_output))
+
+    assert result["edges_found"] == 1234
+    assert result["total_edges"] == 65536
+    assert result["bitmap_cvg"] == 12.34
+    assert result["stability"] == 95.50
+    assert result["var_byte_count"] == 20
+    # count_coverage = (65536 * 8) / 1234 = 424.78
+    assert result["count_coverage"] > 0
+
+
+def test_recommend_strategy_slow(mock_afl_output):
+    """Test recommend_strategy with slow execution."""
+    # Modify stats to have low exec/s
+    stats_path = mock_afl_output / "fuzzer_stats"
+    content = stats_path.read_text()
+    content = content.replace("execs_per_sec     : 277.78", "execs_per_sec     : 10.00")
+    stats_path.write_text(content)
+
+    result = tools.recommend_strategy(str(mock_afl_output))
+
+    assert "strategies" in result
+    strategies = result["strategies"]
+    assert len(strategies) > 0
+
+    # Should recommend persistent mode for slow exec/s
+    found = any(s["name"] == "enable_persistent_mode" for s in strategies)
+    assert found, "Should recommend persistent mode for slow execution"
+
+
+def test_recommend_strategy_crashes(mock_afl_output):
+    """Test recommend_strategy with crashes."""
+    result = tools.recommend_strategy(str(mock_afl_output))
+
+    strategies = result["strategies"]
+    # Should recommend triage since we have crashes
+    found = any(s["name"] == "triage_crashes" for s in strategies)
+    assert found, "Should recommend crash triage when crashes exist"
+
+
+def test_recommend_strategy_healthy(mock_afl_output):
+    """Test recommend_strategy with healthy metrics."""
+    # Modify stats to look healthy
+    stats_path = mock_afl_output / "fuzzer_stats"
+    content = stats_path.read_text()
+    content = content.replace("execs_per_sec     : 277.78", "execs_per_sec     : 500.00")
+    content = content.replace("saved_crashes     : 3", "saved_crashes     : 0")
+    content = content.replace("cycles_wo_finds   : 2", "cycles_wo_finds   : 0")
+    stats_path.write_text(content)
+
+    result = tools.recommend_strategy(str(mock_afl_output))
+
+    strategies = result["strategies"]
+    # Should recommend continuing
+    found = any(s["name"] == "continue_fuzzing" for s in strategies)
+    assert found, "Should recommend continuing when metrics are healthy"
+
+
+def test_parse_queue_filename():
+    """Test queue filename parsing."""
+    # Original input
+    result = tools._parse_queue_filename("id:000000,time:0,orig:input0")
+    assert result["id"] == 0
+    assert result["is_original"] is True
+    assert result["original_name"] == "input0"
+
+    # Mutated input
+    result = tools._parse_queue_filename("id:000123,time:5000,src:000042,op:havoc")
+    assert result["id"] == 123
+    assert result["time"] == 5000
+    assert result["parent_id"] == 42
+    assert result["op"] == "havoc"
+    assert result["is_original"] is False
+
+    # SIMPLE_FILES format
+    result = tools._parse_queue_filename("id_000456")
+    assert result["id"] == 456
+
+
+def test_parse_crash_filename():
+    """Test crash filename parsing."""
+    result = tools._parse_crash_filename(
+        "id:000005,sig:11,src:000123,time:45678,op:havoc,rep:3"
+    )
+    assert result["id"] == 5
+    assert result["signal"] == 11
+    assert result["source_id"] == 123
+    assert result["time"] == 45678
+    assert result["op"] == "havoc"
+    assert result["rep"] == 3
+
+
+def test_missing_output_dir():
+    """Test error when output_dir is missing."""
+    with pytest.raises(ValueError, match="output_dir is required"):
+        tools.get_stats(None)
+
+
+def test_missing_stats_file(tmp_path):
+    """Test error when fuzzer_stats doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="fuzzer_stats not found"):
+        tools.get_stats(str(tmp_path))
+
+
+def test_missing_queue_dir(tmp_path):
+    """Test error when queue directory doesn't exist."""
+    # Create stats file but no queue
+    (tmp_path / "fuzzer_stats").write_text("start_time: 0\n")
+
+    with pytest.raises(FileNotFoundError, match="queue directory not found"):
+        tools.list_queue(str(tmp_path))
+
+
+def test_missing_crashes_dir(tmp_path):
+    """Test error when crashes directory doesn't exist."""
+    # Create stats file but no crashes
+    (tmp_path / "fuzzer_stats").write_text("start_time: 0\n")
+
+    with pytest.raises(FileNotFoundError, match="crashes directory not found"):
+        tools.list_crashes(str(tmp_path))
+
+
+def test_empty_queue(tmp_path):
+    """Test analyze_queue with empty queue."""
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    (tmp_path / "fuzzer_stats").write_text("start_time: 0\n")
+
+    result = tools.analyze_queue(str(tmp_path))
+    assert result["count"] == 0
+    assert result["originals"] == 0
+    assert result["mutations"] == 0
+
+
+def test_models_to_dict():
+    """Test dataclass to_dict methods."""
+    stats = models.FuzzingStats(
+        start_time=1000,
+        execs_done=5000,
+        stability=98.5,
+    )
+    d = stats.to_dict()
+    assert d["start_time"] == 1000
+    assert d["execs_done"] == 5000
+    assert d["stability"] == 98.5
+
+    entry = models.QueueEntry(
+        path="/tmp/queue/id:000000",
+        filename="id:000000",
+        size=100,
+        favored=True,
+    )
+    d = entry.to_dict()
+    assert d["path"] == "/tmp/queue/id:000000"
+    assert d["size"] == 100
+    assert d["favored"] is True
+
+    crash = models.CrashInfo(
+        path="/tmp/crashes/id:000000,sig:11",
+        signal=11,
+        unique=True,
+    )
+    d = crash.to_dict()
+    assert d["signal"] == 11
+    assert d["unique"] is True
+
+    strategy = models.Strategy(
+        name="test",
+        type="config",
+        priority=2,
+    )
+    d = strategy.to_dict()
+    assert d["name"] == "test"
+    assert d["priority"] == 2
+
+
+def test_coverage_info_model():
+    """Test CoverageInfo model."""
+    cov = models.CoverageInfo(
+        edges_found=1000,
+        total_edges=65536,
+        bitmap_cvg=15.26,
+        stability=99.0,
+    )
+    d = cov.to_dict()
+    assert d["edges_found"] == 1000
+    assert d["bitmap_cvg"] == 15.26
+    assert d["stability"] == 99.0

--- a/mcp/tools.py
+++ b/mcp/tools.py
@@ -1,0 +1,494 @@
+"""AFL++ MCP Server tools implementation."""
+
+import os
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+from dataclasses import asdict
+
+from .models import (
+    FuzzingStats,
+    QueueEntry,
+    CrashInfo,
+    Strategy,
+    CoverageInfo,
+)
+
+
+def _resolve_output_dir(output_dir: Optional[str]) -> str:
+    """Resolve the AFL++ output directory."""
+    if output_dir:
+        return output_dir
+    env = os.environ.get("AFL_OUTPUT_DIR")
+    if env:
+        return env
+    raise ValueError(
+        "output_dir is required: pass it explicitly or set AFL_OUTPUT_DIR"
+    )
+
+
+def _parse_queue_filename(filename: str) -> Dict[str, Any]:
+    """Parse an AFL++ queue filename into its components.
+
+    Format: id:NNNNNN,time:NNNN,orig:NAME[,op:OP,src:NNNNNN]
+    Or SIMPLE_FILES: id_NNNNNN
+    """
+    info: Dict[str, Any] = {"filename": filename}
+    if filename.startswith("id:"):
+        parts = filename.split(",")
+        for part in parts:
+            if ":" in part:
+                k, _, v = part.partition(":")
+                if k == "id":
+                    info["id"] = int(v)
+                elif k == "time":
+                    info["time"] = int(v)
+                elif k == "orig":
+                    info["is_original"] = True
+                    info["original_name"] = v
+                elif k == "src":
+                    info["parent_id"] = int(v)
+                elif k == "op":
+                    info["op"] = v
+    elif filename.startswith("id_"):
+        try:
+            info["id"] = int(filename.split("_")[1].split(",")[0])
+        except (IndexError, ValueError):
+            pass
+    return info
+
+
+def _parse_crash_filename(filename: str) -> Dict[str, Any]:
+    """Parse an AFL++ crash filename into its components.
+
+    Format: id:NNNNNN,sig:NN,src:NNNNNN,time:NNNN,op:OP,rep:NN
+    """
+    info: Dict[str, Any] = {"filename": filename}
+    if not filename.startswith("id:") and not filename.startswith("id_"):
+        return info
+    parts = filename.split(",")
+    for part in parts:
+        if ":" not in part:
+            continue
+        k, _, v = part.partition(":")
+        if k == "id":
+            info["id"] = int(v)
+        elif k == "sig":
+            info["signal"] = int(v)
+        elif k == "src":
+            info["source_id"] = int(v)
+        elif k == "time":
+            info["time"] = int(v)
+        elif k == "op":
+            info["op"] = v
+        elif k == "rep":
+            info["rep"] = int(v)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+def get_stats(output_dir: Optional[str] = None) -> Dict[str, Any]:
+    """Get current fuzzing statistics by parsing fuzzer_stats.
+
+    Returns a dict mirroring FuzzingStats fields.
+    """
+    out = _resolve_output_dir(output_dir)
+    stats_path = Path(out) / "fuzzer_stats"
+    if not stats_path.exists():
+        raise FileNotFoundError(f"fuzzer_stats not found at {stats_path}")
+    content = stats_path.read_text(errors="replace")
+    stats = FuzzingStats.from_stats_file(content)
+    return stats.to_dict()
+
+
+def list_queue(
+    output_dir: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List test cases in the queue/ directory."""
+    out = _resolve_output_dir(output_dir)
+    queue_dir = Path(out) / "queue"
+    if not queue_dir.exists():
+        raise FileNotFoundError(f"queue directory not found at {queue_dir}")
+
+    entries: List[Dict[str, Any]] = []
+    files = sorted(queue_dir.iterdir())
+    for fpath in files:
+        if not fpath.is_file():
+            continue
+        parsed = _parse_queue_filename(fpath.name)
+        entry = QueueEntry(
+            path=str(fpath),
+            filename=fpath.name,
+            size=fpath.stat().st_size,
+            is_original=parsed.get("is_original", False),
+            parent_id=parsed.get("parent_id"),
+        )
+        entries.append(entry.to_dict())
+
+    total = len(entries)
+    page = entries[offset : offset + limit]
+    return {"total": total, "offset": offset, "limit": limit, "entries": page}
+
+
+def analyze_queue(output_dir: Optional[str] = None) -> Dict[str, Any]:
+    """Analyze queue characteristics: size distribution, origins, etc."""
+    out = _resolve_output_dir(output_dir)
+    queue_dir = Path(out) / "queue"
+    if not queue_dir.exists():
+        raise FileNotFoundError(f"queue directory not found at {queue_dir}")
+
+    sizes: List[int] = []
+    originals = 0
+    mutations = 0
+    for fpath in queue_dir.iterdir():
+        if not fpath.is_file():
+            continue
+        sizes.append(fpath.stat().st_size)
+        parsed = _parse_queue_filename(fpath.name)
+        if parsed.get("is_original"):
+            originals += 1
+        else:
+            mutations += 1
+
+    if not sizes:
+        return {
+            "count": 0,
+            "originals": 0,
+            "mutations": 0,
+            "size_min": 0,
+            "size_max": 0,
+            "size_avg": 0.0,
+            "size_median": 0,
+        }
+
+    sizes_sorted = sorted(sizes)
+    n = len(sizes_sorted)
+    median = (
+        sizes_sorted[n // 2]
+        if n % 2
+        else (sizes_sorted[n // 2 - 1] + sizes_sorted[n // 2]) / 2
+    )
+    return {
+        "count": n,
+        "originals": originals,
+        "mutations": mutations,
+        "size_min": min(sizes),
+        "size_max": max(sizes),
+        "size_avg": sum(sizes) / n,
+        "size_median": median,
+    }
+
+
+def list_crashes(
+    output_dir: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List crash samples in the crashes/ directory."""
+    out = _resolve_output_dir(output_dir)
+    crashes_dir = Path(out) / "crashes"
+    if not crashes_dir.exists():
+        raise FileNotFoundError(f"crashes directory not found at {crashes_dir}")
+
+    entries: List[Dict[str, Any]] = []
+    for fpath in sorted(crashes_dir.iterdir()):
+        if not fpath.is_file():
+            continue
+        if fpath.name == "README.txt":
+            continue
+        parsed = _parse_crash_filename(fpath.name)
+        info = CrashInfo(
+            path=str(fpath),
+            filename=fpath.name,
+            signal=parsed.get("signal", 0),
+            source_id=parsed.get("source_id"),
+            time=parsed.get("time"),
+            op=parsed.get("op", ""),
+            rep=parsed.get("rep"),
+            size=fpath.stat().st_size,
+        )
+        entries.append(info.to_dict())
+
+    total = len(entries)
+    page = entries[offset : offset + limit]
+    return {"total": total, "offset": offset, "limit": limit, "crashes": page}
+
+
+def analyze_crash(
+    crash_path: str,
+    target_binary: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Analyze a single crash sample.
+
+    If target_binary is provided, runs it under the binary to capture the
+    signal and stderr output. Otherwise, only reports file metadata.
+    """
+    p = Path(crash_path)
+    if not p.exists():
+        raise FileNotFoundError(f"crash file not found: {crash_path}")
+
+    parsed = _parse_crash_filename(p.name)
+    info: Dict[str, Any] = {
+        "path": str(p),
+        "filename": p.name,
+        "size": p.stat().st_size,
+        "signal": parsed.get("signal", 0),
+        "source_id": parsed.get("source_id"),
+        "op": parsed.get("op", ""),
+    }
+
+    if target_binary and shutil.which(target_binary):
+        try:
+            result = subprocess.run(
+                [target_binary, crash_path],
+                input=p.read_bytes(),
+                capture_output=True,
+                timeout=10,
+            )
+            info["exit_code"] = result.returncode
+            info["stderr_tail"] = result.stderr.decode(errors="replace")[-1024:]
+            if result.returncode < 0:
+                info["observed_signal"] = -result.returncode
+        except subprocess.TimeoutExpired:
+            info["error"] = "timeout running target binary"
+        except Exception as e:
+            info["error"] = str(e)
+
+    return info
+
+
+def minimize_crash(
+    crash_path: str,
+    output_dir: Optional[str] = None,
+    target_binary: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Minimize a crash sample using afl-tmin if available.
+
+    Returns the path to the minimized crash and size reduction info.
+    """
+    out = _resolve_output_dir(output_dir)
+    crash_p = Path(crash_path)
+    if not crash_p.exists():
+        raise FileNotFoundError(f"crash file not found: {crash_path}")
+
+    if not target_binary:
+        raise ValueError("target_binary is required for crash minimization")
+
+    afl_tmin = shutil.which("afl-tmin")
+    if not afl_tmin:
+        raise RuntimeError(
+            "afl-tmin not found in PATH; install AFL++ or provide path"
+        )
+
+    minimized = Path(out) / "crashes" / f"{crash_p.name}.minimized"
+    original_size = crash_p.stat().st_size
+
+    try:
+        result = subprocess.run(
+            [
+                afl_tmin,
+                "-i",
+                str(crash_p),
+                "-o",
+                str(minimized),
+                "-t",
+                "5000",
+                "--",
+                target_binary,
+            ],
+            capture_output=True,
+            timeout=120,
+            text=True,
+        )
+        if minimized.exists():
+            new_size = minimized.stat().st_size
+            return {
+                "original_path": str(crash_p),
+                "minimized_path": str(minimized),
+                "original_size": original_size,
+                "minimized_size": new_size,
+                "reduction_bytes": original_size - new_size,
+                "reduction_percent": (
+                    (original_size - new_size) / original_size * 100
+                    if original_size
+                    else 0
+                ),
+                "afl_tmin_stderr": result.stderr[-2048:],
+            }
+        return {
+            "error": "afl-tmin did not produce output",
+            "stderr": result.stderr[-2048:],
+        }
+    except subprocess.TimeoutExpired:
+        return {"error": "afl-tmin timed out"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def get_coverage(output_dir: Optional[str] = None) -> Dict[str, Any]:
+    """Get coverage information from fuzzer_stats and bitmap."""
+    stats = get_stats(output_dir)
+    edges_found = stats.get("edges_found", 0)
+    total_edges = stats.get("total_edges", 0)
+    bitmap_cvg = stats.get("bitmap_cvg", 0.0)
+    stability = stats.get("stability", 0.0)
+    var_byte_count = stats.get("var_byte_count", 0)
+
+    count_coverage = 0.0
+    if edges_found:
+        count_coverage = (total_edges * 8) / edges_found
+
+    cov = CoverageInfo(
+        edges_found=edges_found,
+        total_edges=total_edges,
+        bitmap_cvg=bitmap_cvg,
+        stability=stability,
+        var_byte_count=var_byte_count,
+        count_coverage=count_coverage,
+    )
+    return cov.to_dict()
+
+
+def recommend_strategy(output_dir: Optional[str] = None) -> Dict[str, Any]:
+    """Recommend fuzzing strategies based on current statistics.
+
+    Heuristics mirror common AFL++ tuning advice:
+    - Low stability -> suggest AFL_DISABLE_TRIM or longer timeout
+    - Low exec/s -> suggest AFL_FAST_CAL or persistent mode
+    - Coverage plateau -> suggest dictionary, radamsa, or custom mutator
+    - Many crashes -> suggest crash triage workflow
+    - Few finds -> suggest -D deterministic mode or longer run
+    """
+    stats = get_stats(output_dir)
+    strategies: List[Dict[str, Any]] = []
+
+    execs_per_sec = stats.get("execs_per_sec", 0)
+    stability = stats.get("stability", 100.0)
+    bitmap_cvg = stats.get("bitmap_cvg", 0.0)
+    saved_crashes = stats.get("saved_crashes", 0)
+    cycles_wo_finds = stats.get("cycles_wo_finds", 0)
+    pending_total = stats.get("pending_total", 0)
+    corpus_count = stats.get("corpus_count", 0)
+
+    # Speed recommendation
+    if execs_per_sec < 50:
+        strategies.append(
+            Strategy(
+                name="enable_persistent_mode",
+                type="config",
+                parameters={"env": {"AFL_FAST_CAL": "1"}},
+                rationale=(
+                    f"exec/s is {execs_per_sec:.1f}, which is very slow. "
+                    "Persistent mode or AFL_FAST_CAL can speed things up."
+                ),
+                expected_effect="10x-100x speedup if target supports it",
+                priority=2,
+            ).to_dict()
+        )
+
+    # Stability recommendation
+    if stability < 90.0 and stats.get("var_byte_count", 0) > 40:
+        strategies.append(
+            Strategy(
+                name="improve_stability",
+                type="config",
+                parameters={"env": {"AFL_DISABLE_TRIM": "1"}},
+                rationale=(
+                    f"stability is {stability:.1f}%. Unstable bits may be "
+                    "causing noise. Disable trim or increase timeout."
+                ),
+                expected_effect="cleaner coverage signals, fewer wasted execs",
+                priority=1,
+            ).to_dict()
+        )
+
+    # Coverage plateau
+    if cycles_wo_finds > 5 and bitmap_cvg < 30.0:
+        strategies.append(
+            Strategy(
+                name="add_dictionary",
+                type="dictionary",
+                parameters={"action": "provide a dictionary with -x"},
+                rationale=(
+                    "Coverage has stalled with many cycles without finds. "
+                    "A dictionary can help break through magic-value checks."
+                ),
+                expected_effect="new edges past string/integer comparisons",
+                priority=2,
+            ).to_dict()
+        )
+
+    if cycles_wo_finds > 10:
+        strategies.append(
+            Strategy(
+                name="try_radamsa_or_custom_mutator",
+                type="mutation",
+                parameters={
+                    "option_a": "AFL_CUSTOM_MUTATOR_LIBRARY=radamsa",
+                    "option_b": "use a grammar-based custom mutator",
+                },
+                rationale=(
+                    "Long plateau with no new finds. Structural mutators "
+                    "may explore deeper paths."
+                ),
+                expected_effect="new coverage for structured inputs",
+                priority=1,
+            ).to_dict()
+        )
+
+    # Pending entries
+    if pending_total > corpus_count * 2 and corpus_count > 0:
+        strategies.append(
+            Strategy(
+                name="reduce_pending_queue",
+                type="config",
+                parameters={
+                    "action": "let the fuzzer run longer or trim corpus"
+                },
+                rationale=(
+                    f"pending_total={pending_total} is much larger than "
+                    f"corpus_count={corpus_count}. The fuzzer has a lot "
+                    "of work queued."
+                ),
+                expected_effect="faster cycle completion",
+                priority=0,
+            ).to_dict()
+        )
+
+    # Crashes found
+    if saved_crashes > 0:
+        strategies.append(
+            Strategy(
+                name="triage_crashes",
+                type="triage",
+                parameters={
+                    "action": "use analyze_crash on each crash in crashes/"
+                },
+                rationale=f"{saved_crashes} crashes saved; triage for unique bugs.",
+                expected_effect="identify unique vulnerabilities",
+                priority=2,
+            ).to_dict()
+        )
+
+    # Default: keep going
+    if not strategies:
+        strategies.append(
+            Strategy(
+                name="continue_fuzzing",
+                type="config",
+                parameters={},
+                rationale="Current metrics look healthy. Keep fuzzing.",
+                expected_effect="continued coverage growth",
+                priority=0,
+            ).to_dict()
+        )
+
+    strategies.sort(key=lambda s: s.get("priority", 0), reverse=True)
+    return {"strategies": strategies}


### PR DESCRIPTION
## What Problem This Solves

Modern fuzzing workflows increasingly involve AI agents that need programmatic access to fuzzer state for automated analysis, strategy recommendation, and crash triage. Currently, there is no standard way for AI agents (Claude, ChatGPT, Codex, etc.) to interact with AFL++ fuzzing results without custom scripting.

The Model Context Protocol (MCP) provides a standardized interface for AI agents to interact with external tools. This PR adds an MCP server for AFL++, enabling AI-driven fuzzing optimization.

Closes #2843

## Why This Change Was Made

This implementation provides 8 core tools that give AI agents structured access to AFL++ fuzzing data:

1. **get_stats** - Parse and analyze `fuzzer_stats` file for execution metrics, coverage, and timing data
2. **list_queue** - List test cases in the queue with metadata extraction from filenames
3. **analyze_queue** - Analyze queue characteristics including size distribution and mutation statistics
4. **list_crashes** - List crash samples with signal, source, and operation metadata
5. **analyze_crash** - Analyze individual crash samples with optional live binary execution
6. **minimize_crash** - Minimize crash samples using `afl-tmin` for easier debugging
7. **get_coverage** - Extract coverage metrics from bitmap data
8. **recommend_strategy** - Provide intelligent fuzzing strategy recommendations based on current metrics

### Key Benefits

- **Automated Strategy Recommendation**: AI agents can analyze fuzzing metrics and recommend configuration changes (e.g., enable persistent mode, adjust mutation strategies)
- **Crash Triage Automation**: Automated crash analysis, minimization, and signal classification
- **Progress Monitoring**: Real-time access to execution speed, coverage, and corpus growth
- **Multi-Transport Support**: Supports stdio (local agents), SSE, and HTTP (remote agents)

## User Impact

Users can now integrate AFL++ with AI agents like Claude Desktop, ChatGPT, or custom MCP clients. Example configuration for Claude Desktop:

```json
{
  "mcpServers": {
    "aflpp": {
      "command": "python",
      "args": ["-m", "mcp.server", "--transport", "stdio"],
      "env": {
        "AFL_OUTPUT_DIR": "/path/to/afl/output"
      }
    }
  }
}
```

### Quick Start Example

```python
from mcp import tools

# Get fuzzing statistics
stats = tools.get_stats("/path/to/afl/output")
print(f"Exec/s: {stats['execs_per_sec']}")
print(f"Coverage: {stats['bitmap_cvg']}%")

# Get strategy recommendations
strategies = tools.recommend_strategy("/path/to/afl/output")
for strategy in strategies['strategies']:
    print(f"{strategy['name']}: {strategy['rationale']}")
```

## Evidence

- **Test Coverage**: Comprehensive test suite in `mcp/tests/test_mcp_server.py` covering all 8 tools
- **Documentation**: Complete README with API reference, examples, and integration guides in `mcp/README.md`
- **File Format Parsing**: Directly parses AFL++ output files (`fuzzer_stats`, queue/crash filenames) based on source code analysis of `src/afl-fuzz-stats.c` and `src/afl-fuzz-queue.c`
- **Architecture**: Clean separation into `models.py` (data models), `tools.py` (core implementations), and `server.py` (MCP server wrapper)
- **Dependencies**: Minimal dependencies (Python 3.8+, optional MCP libraries for server mode)
- **License**: Apache-2.0 (same as AFL++)

## Implementation Details

The server parses AFL++ output files directly without requiring database access or complex setup:

- **fuzzer_stats**: Key-value pairs separated by `:`
- **Queue files**: Filename metadata like `id:NNNNNN,time:NNNN,orig:NAME` or `id:NNNNNN,time:NNNN,src:NNNNNN,op:OP`
- **Crash files**: Filename metadata like `id:NNNNNN,sig:NN,src:NNNNNN,time:NNNN,op:OP,rep:NN`

All tools are implemented as pure functions that can be used standalone or through the MCP server interface.
