### PR TITLE
afl-proxy: enable AFL_MAP_SIZE env var override

### DIFF
--- a/utils/afl_proxy/afl-proxy.c
+++ b/utils/afl_proxy/afl-proxy.c
@@ -70,18 +70,12 @@ static void __afl_map_shm(void) {
   char *id_str = getenv(SHM_ENV_VAR);
   char *ptr;
 
-  /* NOTE TODO BUG FIXME: if you want to supply a variable sized map then
-     uncomment the following: */
-
-  /*
   if ((ptr = getenv("AFL_MAP_SIZE")) != NULL) {
 
     u32 val = atoi(ptr);
     if (val > 0) __afl_map_size = val;
 
   }
-
-  */
 
   if (__afl_map_size > MAP_SIZE) {
 


### PR DESCRIPTION
## Please give basic information

**Type of PR**: Bugfix / Enhancement
**Purpose of this PR**:
This PR enables the `AFL_MAP_SIZE` environment variable override in `utils/afl_proxy/afl-proxy.c`'s `__afl_map_shm()`.

`afl-proxy.c` serves as the reference skeleton for building custom fuzzing harnesses. Currently, the `getenv("AFL_MAP_SIZE")` logic is active in `instrumentation/afl-compiler-rt.o.c` but was left commented out in `afl-proxy.c`. This inconsistency forced anyone building a custom harness from this template to manually edit and recompile the source just to change the map size at runtime.

Uncommenting this block aligns the proxy skeleton's behavior with the rest of AFL++ and restores the documented runtime configuration capability.

Fixes #2852

**I have tested the changes**: yes

## IMPORTANT

* **We only accept PRs to the `dev` branch!**
* **Run `make code-format**` before submitting
* **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
* Think about where your **changes needs to be documented** and add the documentation!
* environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
* various README.md and other MD files might need updated
* please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)


* **Licensing:** AFL++ is licensed under **AGPL-3.0-or-later**, with original files also available under Apache-2.0 (see [[LICENSING.md](https://www.google.com/search?q=../LICENSING.md&authuser=2)](https://www.google.com/search?q=../LICENSING.md)). By creating a PR you accept that your contribution is licensed under the same `SPDX-License-Identifier` as the file you edit (Apache-2.0 for Apache-2.0 files, AGPL-3.0-or-later for AGPL files, new files must be under AGPL-3.0-or-later), and that you grant the maintainers the right to re-license it under any of the project's licensing options, including the commercial license. See [[CONTRIBUTING.md](https://www.google.com/search?q=../CONTRIBUTING.md%23licensing-of-contributions&authuser=2)](https://www.google.com/search?q=../CONTRIBUTING.md%23licensing-of-contributions).