### PR TITLE
feat: add riscv qasan report context

### DIFF
--- a/qemu_bridge/README.md
+++ b/qemu_bridge/README.md
@@ -342,7 +342,7 @@ AFL_USE_QASAN=1 afl-fuzz -Q -i in -o out -- ./target @@
 via `AFL_PATH` or next to `afl-qemu-bridge`) and enables the in-QEMU shadow — no
 manual `AFL_PRELOAD` is needed. Overflow **detection** works on all
 architectures; the report's PC/BP/SP context and backtraces are populated on
-x86/x86_64, arm, and aarch64.
+x86/x86_64, arm, aarch64, and riscv.
 
 Current limitations versus a full ASan build:
 
@@ -381,7 +381,7 @@ target with that target's feature set.
 | CMPLOG (routines / RTN)          |  yes   |  no  | no  |   no    |  no  | no  | no    |
 | Persistent mode + futex sync     |  yes   | yes  | no  |   no    |  no  | no  | no    |
 | QASan — overflow detection       |  yes   | yes  | yes |  yes    | yes  | yes | yes   |
-| QASan — report context           |  yes   | yes  | yes |  yes    |  no  | no  | no    |
+| QASan — report context           |  yes   | yes  | yes |  yes    |  no  | no  | yes   |
 
 x86_64 is the primary, fully-supported target. The HOST is fully supported on
 x86_64; other hosts (e.g. aarch64) are expected to work via QEMU's native TCG

--- a/qemu_bridge/TODO.md
+++ b/qemu_bridge/TODO.md
@@ -21,12 +21,12 @@ runtime-tested) · ⚠️ partial/degraded · ❌ not implemented.
 | CmpLog (INS / operands) | ✅ | 🟡 | 🟡 | 🟡 | ❌ | ❌ | 🟡 |
 | CmpLog (RTN / call args) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Persistent mode + futex sync | ✅ | 🟡 | ❌ | ❌ | ❌ | ❌ | ❌ |
-| QASan — overflow detection | ✅ | 🟡 | 🟡 | 🟡 | ⚠️ | ⚠️ | ⚠️ |
-| QASan — report context (pc/bp/sp, backtrace) | ✅ | 🟡 | 🟡 | 🟡 | ❌ | ❌ | ❌ |
+| QASan — overflow detection | ✅ | 🟡 | 🟡 | 🟡 | ⚠️ | ⚠️ | ✅ |
+| QASan — report context (pc/bp/sp, backtrace) | ✅ | 🟡 | 🟡 | 🟡 | ❌ | ❌ | ✅ |
 
 Notes:
-- "Runtime-verified" today = **x86_64** (all features) and **arm32 edge coverage**
-  (the only non-x86 guest with a cross-compiler available during development).
+- "Runtime-verified" today = **x86_64** (all features), **arm32 edge coverage**,
+  and **riscv QASan overflow detection/report context**.
   Everything marked 🟡 is implemented in code and build-verified but has not yet
   been exercised at runtime — see "Runtime verification gaps" below.
 - riscv is not a requested target but is instrumented by the bridge, so it inherits
@@ -126,9 +126,9 @@ per-arch loop-back exists.
 
 ### 4. QASan report context on mips / ppc — AFL-layer gap (cosmetic)
 `libaflqemubridge/afl_qasan.c:21-37` defines `QASAN_PC/BP/SP_GET` for x86/i386, aarch64,
-arm; mips/ppc fall to the `0` fallback. Overflow **detection still works** (the shadow
-check rides the arch-generic read/write hooks in `tcg/tcg-op-ldst.c`); only the
-printed pc/bp/sp and the alloc/free backtraces are empty.
+arm, and riscv; mips/ppc fall to the `0` fallback. Overflow **detection still works**
+(the shadow check rides the arch-generic read/write hooks in `tcg/tcg-op-ldst.c`);
+only the printed pc/bp/sp and the alloc/free backtraces are empty.
 
 ### 5. Deferred from the migration (all arches) — see also `docs/qemu_bridge_migration.md`
 - **Persistent-hook ABI** + `utils/aflpp_driver/aflpp_qemu_driver_hook.c`: not ported.
@@ -150,9 +150,8 @@ printed pc/bp/sp and the alloc/free backtraces are empty.
   (correct, not dirty-page-optimized) — a perf TODO.
 
 ### 6. Runtime verification gaps
-Only x86_64 (all features) and arm32 (edge) have been runtime-tested. aarch64, mips,
-ppc, i386, and riscv are build-verified only — no cross-toolchains were available
-during development for runtime self-tests. The CI workflow
+Only x86_64 (all features), arm32 (edge), and riscv (overflow/report-context) have been
+runtime-tested. aarch64, mips, ppc, and the i386 are build-verified only. The CI workflow
 (`.github/workflows/qemu_bridge.yml`) is set up to run the per-arch matrix once
 cross-toolchains/runners are present.
 

--- a/qemu_bridge/libaflqemubridge/afl_qasan.c
+++ b/qemu_bridge/libaflqemubridge/afl_qasan.c
@@ -30,6 +30,10 @@
 #define QASAN_PC_GET(env) ((env)->regs[15])
 #define QASAN_BP_GET(env) ((env)->regs[11])
 #define QASAN_SP_GET(env) ((env)->regs[13])
+#elif defined(TARGET_RISCV)
+#define QASAN_PC_GET(env) ((env)->pc)
+#define QASAN_BP_GET(env) ((env)->gpr[8])
+#define QASAN_SP_GET(env) ((env)->gpr[2])
 #else
 #define QASAN_PC_GET(env) (0)
 #define QASAN_BP_GET(env) (0)


### PR DESCRIPTION
# Your pull request

## Please give basic information

**Type of PR**: Enhancement
**Purpose of this PR**: Add RISC-V QASan report-context support in `qemu_bridge`.
**I have tested the changes**: yes

For RISC-V:
- `pc`: comes from `env->pc`
- `bp`: uses `env->gpr[8]`, RISC-V ABI `x8`, `s0/fp`
- `sp`: uses `env->gpr[2]`, RISC-V ABI `x2`, `sp`

## IMPORTANT

- **We only accept PRs to the `dev` branch!**
- **Run `make code-format`** before submitting
- **No AI slop.** Using AI is fine, but opening a PR that is clearly not working will get you banned from the repository!
- Think about where your **changes needs to be documented** and add the documentation!
  - environment variables need to be in docs/env_variables.md and the help output of the tools where they apply
  - various README.md and other MD files might need updated
  - please don't touch the `Changelog.md` file, this will only create unnecessary merge conflicts :-)
- **Licensing:** AFL++ is licensed under **AGPL-3.0-or-later**, with original files also available under Apache-2.0 (see [LICENSING.md](../LICENSING.md)). By creating a PR you accept that your contribution is licensed under the same `SPDX-License-Identifier` as the file you edit (Apache-2.0 for Apache-2.0 files, AGPL-3.0-or-later for AGPL files, new files must be under AGPL-3.0-or-later), and that you grant the maintainers the right to re-license it under any of the project's licensing options, including the commercial license. See [CONTRIBUTING.md](../CONTRIBUTING.md#licensing-of-contributions).
  
## References

- QEMU RISC-V CPU state has `gpr[32]` and `pc`, https://github.com/AFLplusplus/qemu-libafl-bridge/blob/c5ce3aade3a142a7e4fcf8cb1208b331dee0ddc1/target/riscv/cpu.h#L219
- RISC-V ABI: https://docs.riscv.org/reference/abi/v1.0/riscv-cc-register-convention.html