### PR TITLE
Fix custom post-process buffer ownership

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1115,6 +1115,7 @@ struct custom_mutator {
   char       *name_short;
   void       *dh;
   u8         *post_process_buf;
+  u8         *post_process_buf_scratch;
   u8          stacked_custom_prob, stacked_custom;
 
   void *data;                                    /* custom mutator data ptr */

--- a/src/afl-fuzz-mutators.c
+++ b/src/afl-fuzz-mutators.c
@@ -156,6 +156,13 @@ void destroy_custom_mutators(afl_state_t *afl) {
 
       }
 
+      if (el->post_process_buf_scratch) {
+
+        afl_free(el->post_process_buf_scratch);
+        el->post_process_buf_scratch = NULL;
+
+      }
+
       ck_free(el);
 
     });

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -152,8 +152,11 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
     ssize_t new_size = len;
     u8     *new_mem = *mem;
     u8     *new_buf = NULL;
+    struct custom_mutator *staging_mutator = NULL;
 
     LIST_FOREACH(&afl->custom_mutator_list, struct custom_mutator, {
+
+      staging_mutator = el;
 
       if (el->afl_custom_post_process) {
 
@@ -183,6 +186,7 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
       if (fix) {
 
         new_size = len;
+        new_mem = *mem;
 
       } else {
 
@@ -193,6 +197,7 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
     }
 
     ssize_t valid_size = new_size;
+    u8     *original_mem = *mem;
 
     if (unlikely(new_size < afl->min_length && !fix)) {
 
@@ -207,27 +212,28 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
     if ((new_mem != *mem || new_size > valid_size) && new_mem != NULL &&
         new_size > 0) {
 
-      new_buf = afl_realloc(AFL_BUF_PARAM(out_scratch), new_size);
+      u8 **staging_buf_p = (original_mem == staging_mutator->post_process_buf)
+                               ? &staging_mutator->post_process_buf_scratch
+                               : &staging_mutator->post_process_buf;
+      u8 *staging_buf = *staging_buf_p;
+      u8  source_is_staging = new_mem == staging_buf;
+
+      new_buf = afl_realloc((void **)staging_buf_p, new_size);
       if (unlikely(!new_buf)) { PFATAL("alloc"); }
       ssize_t copy_size = new_size < valid_size ? new_size : valid_size;
-      if (copy_size > 0) { memcpy(new_buf, new_mem, copy_size); }
+      if (copy_size > 0 && !source_is_staging) {
+
+        memcpy(new_buf, new_mem, copy_size);
+
+      }
+
       if (new_size > copy_size) {
 
         memset(new_buf + copy_size, 0, new_size - copy_size);
 
       }
 
-      /* if AFL_POST_PROCESS_KEEP_ORIGINAL is set then save the original memory
-         prior post-processing in new_mem to restore it later */
-      if (unlikely(afl->afl_env.afl_post_process_keep_original)) {
-
-        new_mem = *mem;
-
-      }
-
       *mem = new_buf;
-      afl_swap_bufs(AFL_BUF_PARAM(out), AFL_BUF_PARAM(out_scratch));
-      did_swap = 1;
 
     }
 
@@ -263,12 +269,10 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
 
       len = new_size;
 
-    } else if (did_swap) {
+    } else {
 
-      /* restore the original memory which was saved in new_mem */
-      *mem = new_mem;
-      afl_swap_bufs(AFL_BUF_PARAM(out), AFL_BUF_PARAM(out_scratch));
-      did_swap = 0;
+      /* Restore the memory from before post-processing. */
+      *mem = original_mem;
 
     }
 
@@ -1653,4 +1657,3 @@ u8 __attribute__((hot)) common_fuzz_stuff(afl_state_t *afl, u8 *out_buf,
   return 0;
 
 }
-

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -149,9 +149,9 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
 
   if (unlikely(afl->custom_mutators_count)) {
 
-    ssize_t new_size = len;
-    u8     *new_mem = *mem;
-    u8     *new_buf = NULL;
+    ssize_t                new_size = len;
+    u8                    *new_mem = *mem;
+    u8                    *new_buf = NULL;
     struct custom_mutator *staging_mutator = NULL;
 
     LIST_FOREACH(&afl->custom_mutator_list, struct custom_mutator, {
@@ -215,8 +215,8 @@ u32 __attribute__((hot)) write_to_testcase(afl_state_t *afl, void **mem,
       u8 **staging_buf_p = (original_mem == staging_mutator->post_process_buf)
                                ? &staging_mutator->post_process_buf_scratch
                                : &staging_mutator->post_process_buf;
-      u8 *staging_buf = *staging_buf_p;
-      u8  source_is_staging = new_mem == staging_buf;
+      u8  *staging_buf = *staging_buf_p;
+      u8   source_is_staging = new_mem == staging_buf;
 
       new_buf = afl_realloc((void **)staging_buf_p, new_size);
       if (unlikely(!new_buf)) { PFATAL("alloc"); }
@@ -1657,3 +1657,4 @@ u8 __attribute__((hot)) common_fuzz_stuff(afl_state_t *afl, u8 *out_buf,
   return 0;
 
 }
+

--- a/test/test-custom-mutators.sh
+++ b/test/test-custom-mutators.sh
@@ -5,7 +5,9 @@
 $ECHO "$BLUE[*] Testing: custom mutator"
 # normalize path
 CUSTOM_MUTATOR_PATH=$(cd $(pwd)/../custom_mutators/examples;pwd)
-test -e test-custom-mutator.c -a -e ${CUSTOM_MUTATOR_PATH}/example.c -a -e ${CUSTOM_MUTATOR_PATH}/example.py && {
+test -e test-custom-mutator.c -a -e test-custom-post-process.c \
+    -a -e ${CUSTOM_MUTATOR_PATH}/example.c \
+    -a -e ${CUSTOM_MUTATOR_PATH}/example.py && {
   unset AFL_CC
   # Compile the vulnerable program for single mutator
   test -e ../afl-clang-fast && {
@@ -22,6 +24,7 @@ test -e test-custom-mutator.c -a -e ${CUSTOM_MUTATOR_PATH}/example.c -a -e ${CUS
   # Compile the custom mutator
   cc -D_FIXED_CHAR=0x41 -g -fPIC -shared -I../include ../custom_mutators/examples/simple_example.c -o libexamplemutator.so > /dev/null 2>&1
   cc -D_FIXED_CHAR=0x42 -g -fPIC -shared -I../include ../custom_mutators/examples/simple_example.c -o libexamplemutator2.so > /dev/null 2>&1
+  cc -DBUILD_POST_PROCESS_MUTATOR -g -fPIC -shared -I../include test-custom-post-process.c -o libpostprocessmutator.so > /dev/null 2>&1
   test -e test-custom-mutator -a -e ./libexamplemutator.so && {
     # Create input directory
     mkdir -p in
@@ -46,6 +49,31 @@ test -e test-custom-mutator.c -a -e ${CUSTOM_MUTATOR_PATH}/example.c -a -e ${CUS
 
     # Clean
     rm -rf out errors core.*
+
+    # A post_process buffer must not alias AFL++'s mutation buffers.
+    test -e ../afl-clang-fast && {
+      ../afl-clang-fast -o test-custom-post-process test-custom-post-process.c > /dev/null 2>&1
+    } || {
+      ../afl-gcc-fast -o test-custom-post-process test-custom-post-process.c > /dev/null 2>&1
+    }
+    mkdir -p in-post
+    printf A > in-post/s1
+    printf CRxyz > in-post/s2
+
+    $ECHO "$GREY[*] running afl-fuzz with a separate post_process buffer, this will take approx 8 seconds"
+    AFL_CUSTOM_MUTATOR_LIBRARY=./libpostprocessmutator.so AFL_TESTCACHE_SIZE=0 AFL_EXIT_WHEN_DONE=0 ../afl-fuzz -s 9 -V8 -m ${MEM_LIMIT} -i in-post -o out-post -- ./test-custom-post-process >>errors 2>&1
+    test "$?" = "0" && {
+      $ECHO "$GREEN[+] afl-fuzz is working correctly with a separate post_process buffer"
+    } || {
+      echo CUT------------------------------------------------------------------CUT
+      cat errors
+      echo CUT------------------------------------------------------------------CUT
+      $ECHO "$RED[!] afl-fuzz corrupts memory with a separate post_process buffer"
+      CODE=1
+    }
+
+    # Clean
+    rm -rf in-post out-post errors core.*
 
     # Run afl-fuzz w/ multiple C mutators
     $ECHO "$GREY[*] running afl-fuzz with multiple custom C mutators, this will take approx 10 seconds"
@@ -100,6 +128,7 @@ test "1" = "`../afl-fuzz 2>/dev/null | grep -i 'without python' >/dev/null; echo
       rm -rf in out errors core.*
       rm -rf ${CUSTOM_MUTATOR_PATH}/__pycache__/
       rm -f test-multiple-mutators test-custom-mutator libexamplemutator.so libexamplemutator2.so
+      rm -f test-custom-post-process libpostprocessmutator.so
     } || {
       ls .
       ls ${CUSTOM_MUTATOR_PATH}
@@ -113,5 +142,6 @@ test "1" = "`../afl-fuzz 2>/dev/null | grep -i 'without python' >/dev/null; echo
 
 make -C ../utils/custom_mutators clean > /dev/null 2>&1
 rm -f test-custom-mutator test-custom-mutators
+rm -f test-custom-post-process libpostprocessmutator.so
 
 . ./test-post.sh

--- a/test/test-custom-post-process.c
+++ b/test/test-custom-post-process.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+
 #ifdef BUILD_POST_PROCESS_MUTATOR
 
   #include "afl-fuzz.h"
@@ -7,37 +9,45 @@
   #include <string.h>
 
 typedef struct post_process_mutator {
+
   u8 *buf;
 
 } post_process_mutator_t;
 
 post_process_mutator_t *afl_custom_init(afl_state_t *afl, unsigned int seed) {
+
   (void)afl;
   (void)seed;
   return calloc(1, sizeof(post_process_mutator_t));
+
 }
 
 u32 afl_custom_fuzz_count(post_process_mutator_t *data, const u8 *buf,
                           size_t buf_size) {
+
   (void)data;
   (void)buf;
   (void)buf_size;
   return 0;  // Exercise AFL++'s mutations, not a custom mutation stage.
+
 }
 
 size_t afl_custom_fuzz(post_process_mutator_t *data, u8 *buf, size_t buf_size,
                        u8 **out_buf, u8 *add_buf, size_t add_buf_size,
                        size_t max_size) {
+
   (void)data;
   (void)add_buf;
   (void)add_buf_size;
   (void)max_size;
   *out_buf = buf;
   return buf_size;
+
 }
 
 size_t afl_custom_post_process(post_process_mutator_t *data, u8 *buf,
                                size_t buf_size, u8 **out_buf) {
+
   if (buf_size > MAX_FILE / 2) return 0;
 
   u8 *new_buf = realloc(data->buf, buf_size * 2);
@@ -48,11 +58,14 @@ size_t afl_custom_post_process(post_process_mutator_t *data, u8 *buf,
   memcpy(data->buf + buf_size, buf, buf_size);
   *out_buf = data->buf;
   return buf_size * 2;
+
 }
 
 void afl_custom_deinit(post_process_mutator_t *data) {
+
   free(data->buf);
   free(data);
+
 }
 
 #else
@@ -62,18 +75,25 @@ void afl_custom_deinit(post_process_mutator_t *data) {
   #include <string.h>
 
 static uint32_t crc32(const uint8_t *data, size_t len) {
+
   uint32_t crc = ~0U;
   for (size_t i = 0; i < len; ++i) {
+
     crc ^= data[i];
     for (uint8_t k = 0; k < 8; ++k) {
-      crc = (crc >> 1) ^ (0xedb88320U & (uint32_t)-(int32_t)(crc & 1));
+
+      crc = (crc >> 1) ^ (0xedb88320U & (uint32_t) - (int32_t)(crc & 1));
+
     }
+
   }
 
   return ~crc;
+
 }
 
 int main(void) {
+
   uint8_t buf[4096];
   size_t  len = fread(buf, 1, sizeof(buf), stdin);
   if (len < 11 || buf[0] != 'C' || buf[1] != 'R') return 0;
@@ -87,6 +107,8 @@ int main(void) {
   uint32_t expected;
   memcpy(&expected, buf + 6 + payload_len, sizeof(expected));
   return expected != crc32(buf + 6, payload_len);
+
 }
 
 #endif
+

--- a/test/test-custom-post-process.c
+++ b/test/test-custom-post-process.c
@@ -1,0 +1,92 @@
+#ifdef BUILD_POST_PROCESS_MUTATOR
+
+  #include "afl-fuzz.h"
+
+  #include <stdint.h>
+  #include <stdlib.h>
+  #include <string.h>
+
+typedef struct post_process_mutator {
+  u8 *buf;
+
+} post_process_mutator_t;
+
+post_process_mutator_t *afl_custom_init(afl_state_t *afl, unsigned int seed) {
+  (void)afl;
+  (void)seed;
+  return calloc(1, sizeof(post_process_mutator_t));
+}
+
+u32 afl_custom_fuzz_count(post_process_mutator_t *data, const u8 *buf,
+                          size_t buf_size) {
+  (void)data;
+  (void)buf;
+  (void)buf_size;
+  return 0;  // Exercise AFL++'s mutations, not a custom mutation stage.
+}
+
+size_t afl_custom_fuzz(post_process_mutator_t *data, u8 *buf, size_t buf_size,
+                       u8 **out_buf, u8 *add_buf, size_t add_buf_size,
+                       size_t max_size) {
+  (void)data;
+  (void)add_buf;
+  (void)add_buf_size;
+  (void)max_size;
+  *out_buf = buf;
+  return buf_size;
+}
+
+size_t afl_custom_post_process(post_process_mutator_t *data, u8 *buf,
+                               size_t buf_size, u8 **out_buf) {
+  if (buf_size > MAX_FILE / 2) return 0;
+
+  u8 *new_buf = realloc(data->buf, buf_size * 2);
+  if (!new_buf) return 0;
+  data->buf = new_buf;
+
+  memcpy(data->buf, buf, buf_size);
+  memcpy(data->buf + buf_size, buf, buf_size);
+  *out_buf = data->buf;
+  return buf_size * 2;
+}
+
+void afl_custom_deinit(post_process_mutator_t *data) {
+  free(data->buf);
+  free(data);
+}
+
+#else
+
+  #include <stdint.h>
+  #include <stdio.h>
+  #include <string.h>
+
+static uint32_t crc32(const uint8_t *data, size_t len) {
+  uint32_t crc = ~0U;
+  for (size_t i = 0; i < len; ++i) {
+    crc ^= data[i];
+    for (uint8_t k = 0; k < 8; ++k) {
+      crc = (crc >> 1) ^ (0xedb88320U & (uint32_t)-(int32_t)(crc & 1));
+    }
+  }
+
+  return ~crc;
+}
+
+int main(void) {
+  uint8_t buf[4096];
+  size_t  len = fread(buf, 1, sizeof(buf), stdin);
+  if (len < 11 || buf[0] != 'C' || buf[1] != 'R') return 0;
+
+  uint32_t payload_len;
+  memcpy(&payload_len, buf + 2, sizeof(payload_len));
+  if (!payload_len || payload_len > 512 ||
+      len < 6 + (size_t)payload_len + sizeof(uint32_t))
+    return 0;
+
+  uint32_t expected;
+  memcpy(&expected, buf + 6 + payload_len, sizeof(expected));
+  return expected != crc32(buf + 6, payload_len);
+}
+
+#endif


### PR DESCRIPTION
Fixes #2868

`write_to_testcase()` stages out-of-place custom `post_process` results in
`afl->out_scratch_buf` and swaps the global `out` and `out_scratch` buffers.
Callers retain their own by-value buffer pointers, so a later call can
reallocate the same scratch allocation while a caller still references it.
On current `dev` (verified at `1ce1ac1b`), a C-only out-of-place
post-processor reproduces a heap-use-after-free during calibration within
seconds under ASan; the same ownership error can also produce overlapping
copies during havoc.

Keep post-processed testcases in dedicated AFL-owned buffers associated with
the custom mutator instead. Two buffers are used because calibration can call
`write_to_testcase()` again with the result of an earlier call. The mutation
engine's `out` and `out_scratch` buffers are no longer swapped by the custom
post-processing path.

The failed-post-processing fallback now restores both the original length and
the original pointer. Previously, multiple post-processors could leave the
pointer from an earlier processor paired with the original length.

Includes a C-only regression test wired into `test/test-custom-mutators.sh`;
it goes red on unpatched `dev` under ASan within seconds. Python is not
required to trigger the bug.

Fixes: 8f6d9d66 ("fix post_process")

This is related to the post-processing ownership failures discussed in #1699
and #1424, but remains reproducible on current `dev` without
`AFL_POST_PROCESS_KEEP_ORIGINAL`.

**Type of PR**: Bugfix
**Purpose of this PR**: Prevent custom post-processing from invalidating AFL++ mutation-buffer pointers
**I have tested the changes**: yes
