### PR TITLE
libqasan: build and hotpatch correctly on musl

### DIFF
--- a/qemu_mode/libqasan/Makefile
+++ b/qemu_mode/libqasan/Makefile
@@ -24,6 +24,16 @@ CFLAGS      += -I ../qemuafl/qemuafl/
 CFLAGS      += -Wno-int-to-void-pointer-cast -ggdb
 LDFLAGS     += -ldl -pthread
 
+# Does this libc expose the layout of FILE? glibc does, musl does not (the C
+# standard allows keeping it opaque), others vary, so ask the compiler instead
+# of maintaining a list of libcs. See QASAN_FILE_CHECK_SIZE in hooks.c.
+FILE_IS_COMPLETE := $(shell echo 'char probe[sizeof(FILE)];' | \
+                    $(CC) -include stdio.h -x c -c -o /dev/null - 2>/dev/null \
+                    && echo 1)
+ifeq "$(FILE_IS_COMPLETE)" "1"
+  CFLAGS += -DQASAN_FILE_IS_COMPLETE=1
+endif
+
 SRC := libqasan.c hooks.c malloc.c string.c uninstrument.c patch.c dlmalloc.c
 HDR := libqasan.h
 

--- a/qemu_mode/libqasan/README.md
+++ b/qemu_mode/libqasan/README.md
@@ -16,6 +16,28 @@ For debugging purposes, we still suggest to run the original QASan as the
 stacktrace support for ARM (just a debug feature, it does not affect the bug
 finding capabilities during fuzzing) is WIP.
 
+### Building for musl
+
+If your target is linked against musl instead of glibc, build the runtime with a
+musl compiler so that it matches the libc of the target:
+
+```
+make -C qemu_mode/libqasan CC=musl-gcc
+```
+
+On Debian/Ubuntu `musl-gcc` comes from the `musl-tools` package, on Alpine the
+system `gcc` is already a musl compiler.
+
+Two things differ on musl:
+
+* As on any other libc, the runtime is injected via LD_PRELOAD, so only
+  dynamically linked targets can be instrumented. Statically linked musl
+  binaries (the Alpine default for Rust and Go, for instance) are out of reach.
+* musl keeps `FILE` opaque, so the `fgets` hook cannot use `sizeof(FILE)` and
+  checks a conservative prefix of the stream instead. It checks less of the
+  object than on glibc, but it never reports a bug that did not happen. The
+  build works this out per libc, see `QASAN_FILE_CHECK_SIZE` in `hooks.c`.
+
 ### When should I use QASan?
 
 If your target binary is PIC x86_64, you should also give a try to

--- a/qemu_mode/libqasan/hooks.c
+++ b/qemu_mode/libqasan/hooks.c
@@ -35,6 +35,33 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #undef strrchr
 #undef strstr
 
+/* How much of the FILE object fgets() checks. Erring low is deliberate: libc
+   allocates its streams through the malloc we replace, so a size larger than
+   the real object reaches into one of our redzones and reports an overflow
+   that never happened. A size that is too small only checks less of the
+   object, it still catches a freed or wild stream.
+
+   The Makefile asks the compiler whether this libc exposes the layout of FILE,
+   which is the only way to get the exact size without keeping a list of libcs,
+   and defines QASAN_FILE_IS_COMPLETE if it does (glibc, and every other libc
+   whose headers are equally forthcoming).
+
+   musl keeps FILE opaque, as the C standard allows, and deliberately defines no
+   macro identifying itself, so it is recognized here by the guard its
+   <stdio.h> leaves behind. Its struct _IO_FILE is 232 bytes on LP64 (its
+   fopen() requests sizeof(FILE) + UNGET + BUFSIZ = 1264) and around 150 on
+   ILP32, so 16 pointers stay comfortably inside it on both.
+
+   For a libc we can neither introspect nor identify, check a single pointer,
+   the largest prefix every FILE object is guaranteed to have. */
+#if defined(QASAN_FILE_IS_COMPLETE) || defined(__GLIBC__)
+  #define QASAN_FILE_CHECK_SIZE sizeof(FILE)
+#elif defined(__DEFINED_FILE)                                       /* musl */
+  #define QASAN_FILE_CHECK_SIZE (16 * sizeof(void *))
+#else
+  #define QASAN_FILE_CHECK_SIZE sizeof(void *)
+#endif
+
 char *(*__lq_libc_fgets)(char *, int, FILE *);
 int (*__lq_libc_atoi)(const char *);
 long (*__lq_libc_atol)(const char *);
@@ -210,7 +237,7 @@ char *fgets(char *s, int size, FILE *stream) {
   QASAN_DEBUG("%14p: fgets(%p, %d, %p)\n", rtv, s, size, stream);
   QASAN_STORE(s, size);
 #ifndef __ANDROID__
-  QASAN_LOAD(stream, sizeof(FILE));
+  QASAN_LOAD(stream, QASAN_FILE_CHECK_SIZE);
 #endif
   char *r = __lq_libc_fgets(s, size, stream);
   QASAN_DEBUG("\t\t = %p\n", r);

--- a/qemu_mode/libqasan/patch.c
+++ b/qemu_mode/libqasan/patch.c
@@ -173,6 +173,7 @@ void __libqasan_hotpatch(void) {
 #else
 
 static void *libc_start, *libc_end;
+static char  libc_path[512];
 int          libc_perms;
 
 static void find_libc(void) {
@@ -200,11 +201,16 @@ static void find_libc(void) {
 
     if ((fields < 10) || (fields > 11)) continue;
 
+    /* musl maps its libc as /lib/ld-musl-<arch>.so.1 (loader and libc are the
+       same file), Alpine additionally symlinks it as libc.musl-<arch>.so.1 */
     if (flag_x == 'x' && (__libqasan_strstr(path, "/libc.so") ||
-                          __libqasan_strstr(path, "/libc-"))) {
+                          __libqasan_strstr(path, "/libc-") ||
+                          __libqasan_strstr(path, "/ld-musl") ||
+                          __libqasan_strstr(path, "/libc.musl"))) {
 
       libc_start = (void *)min;
       libc_end = (void *)max;
+      __libqasan_memcpy(libc_path, path, __libqasan_strlen(path) + 1);
 
       libc_perms = PROT_EXEC;
       if (flag_w == 'w') libc_perms |= PROT_WRITE;
@@ -237,7 +243,24 @@ void __libqasan_hotpatch(void) {
                PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
     return;
 
-  void *libc = dlopen("libc.so.6", RTLD_LAZY);
+  /* Prefer the very file that find_libc() located, its soname is not the same
+     on every libc (libc.so.6 on glibc, ld-musl-<arch>.so.1 on musl), and it is
+     the mapping we just made writable. Keep the old name as a fallback for the
+     cases where the path from the maps cannot be reopened, e.g. an upgraded
+     and thus deleted file. */
+  void *libc = NULL;
+  if (libc_path[0]) libc = dlopen(libc_path, RTLD_LAZY);
+  if (!libc) libc = dlopen("libc.so.6", RTLD_LAZY);
+
+  /* Never continue without a handle: NULL is RTLD_DEFAULT, so every dlsym()
+     below would resolve to our own preloaded symbols and patch them to jump to
+     themselves. */
+  if (!libc) {
+
+    mprotect(libc_start, libc_end - libc_start, libc_perms);
+    return;
+
+  }
 
   #define HOTPATCH(fn)                             \
     uint8_t *p_##fn = (uint8_t *)dlsym(libc, #fn); \


### PR DESCRIPTION
Fixes #2832. Supersedes #2836 — same starting point (thanks @celi0n), but it takes the review there into account, and also fixes the musl side of the hotpatch path.

### The FILE size

`hooks.c` sized the shadow check on the `fgets` stream with `sizeof(FILE)`, which does not compile on musl:

```
hooks.c:213:29: error: invalid application of 'sizeof' to incomplete type 'FILE'
```

@vanhauser-thc was right that `sizeof(void *)` is not the answer. There is a constraint that decides the whole question though, and it runs the other way: **the size must never be larger than the real object.** libc allocates its streams through the `malloc` libqasan replaces, so reading past the end of a stream lands in one of our own redzones and reports an overflow that never happened. Forcing the check to 4096 on musl demonstrates it, on a program with no bug at all:

```
==ERROR: QEMU-AddressSanitizer: heap-buffer-overflow ...
READ of size 4096 at 0x00007ac160a681f0
0x00007ac160a686e0 is located 0 bytes to the right of 1264-byte region
```

A size that is too small is only less sensitive, and still catches a freed or wild stream. So the size is rounded down wherever it is not exactly known:

* **Whatever the compiler can see.** The Makefile probes whether the libc exposes the layout of `FILE` and defines `QASAN_FILE_IS_COMPLETE` if it does. This is the part that answers "does not break dietlibc, ulibc, etc." without hardcoding a list: any libc whose headers define the struct gets the exact `sizeof(FILE)` automatically, now and in the future. glibc is unchanged.
* **musl**, per your suggestion of taking the internal size and subtracting a bit. `struct _IO_FILE` is 232 bytes on LP64 — measured rather than assumed, its `fopen()` requests `sizeof(FILE) + UNGET + BUFSIZ` = 1264 — and around 150 on ILP32. The check uses `16 * sizeof(void *)`, i.e. 128 and 64, which stays inside both. musl publishes no macro identifying itself, so it is recognized by the `__DEFINED_FILE` guard its `<stdio.h>` leaves behind.
* **Anything else**, neither introspectable nor identifiable: one pointer, the largest prefix every `FILE` is guaranteed to have.

### The hotpatch path

That one line was the only compile blocker, the `!__GLIBC__` dlmalloc backend already covered the rest. But `patch.c` was still glibc-only at runtime:

* `find_libc()` matched only `/libc.so` and `/libc-`. musl maps loader and libc as the same file, `/lib/ld-musl-<arch>.so.1` (Alpine additionally symlinks it as `libc.musl-<arch>.so.1`), so libc was never found and `__libqasan_hotpatch()` was a silent no-op on musl.
* `__libqasan_hotpatch()` `dlopen`'d the hardcoded soname `libc.so.6` and passed the handle to `dlsym()` unchecked. `RTLD_DEFAULT` is `(void *)0`, so if that `dlopen` ever failed, every `dlsym()` below would resolve to libqasan's *own* preloaded symbol and `HOTPATCH()` would patch each function to jump to itself. It now reopens the path `find_libc()` took from the maps (the mapping it just made writable), keeps `libc.so.6` as a fallback, and bails out — restoring the page permissions it widened — if both fail.

Worth noting for anyone reading `libqasan.c`: musl calls the `__libc_start_main` hook *before* shared library constructors, the reverse of glibc. The `__libqasan_is_initialized` guard already handles both orders and `getenv()` is live in either, so nothing needed to change there.

### Verification

Built with `musl-gcc` (musl 1.2.5) and `gcc`, both `qemu_mode/libqasan` and `qemu_bridge/libqasan`; every undefined symbol of the musl build resolves against musl libc.

End to end with `afl-qemu-trace` on a musl-linked target that overflows a 16 byte allocation by one byte:

```
==ERROR: QEMU-AddressSanitizer: heap-buffer-overflow on address 0x00007dc2d04030c0 ...
WRITE of size 1 at 0x00007dc2d04030c0 thread T68396
    #0 ... in main qasan-target.c:29
0x00007dc2d04030c0 is located 0 bytes to the right of 16-byte region [...0b0,...0c0)
allocated by thread T68396 here:
    #0 ... in __libqasan_malloc qemu_mode/libqasan/malloc.c:197
```

The same target without the bug exits 0, so the 128 byte stream check does not false-positive on real musl streams. With `QASAN_HOTPACH=1`, musl's `memcpy` prologue becomes the `mov rax, dest; jmp rax` stub (`48 b8 .. ff e0`), while an otherwise identical build carrying the old `find_libc()` leaves it as `48 89 f8 48 83 fa 08 ...`. glibc was re-checked the same way in QEMU and behaves as before.

Docs: a short "Building for musl" section in `qemu_mode/libqasan/README.md`, including the reminder that LD_PRELOAD injection means statically linked musl binaries remain out of reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
