### PR TITLE
Link afl-cc with librt to support glibc < 2.17

### DIFF
--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -33,6 +33,10 @@ VERSION     = $(shell grep '^ *$(HASH)define VERSION ' ./config.h | cut -d '"' -
 
 SYS = $(shell uname -s)
 
+ifneq "$(filter Linux GNU%,$(SYS))" ""
+  override LDFLAGS += -lrt
+endif
+
 override LLVM_TOO_NEW_DEFAULT := 23
 override LLVM_TOO_OLD_DEFAULT := 14
 

--- a/GNUmakefile.llvm
+++ b/GNUmakefile.llvm
@@ -373,12 +373,12 @@ ifeq "$(SYS)" "OpenBSD"
   CLANG_CPPFL += -mno-retpoline
   CFLAGS += -mno-retpoline
   # Needed for unwind symbols
-  LDFLAGS += -lc++abi -lpthread
+  override LDFLAGS += -lc++abi -lpthread
 endif
 
 # needed for backtrace under FreeBSD
 ifeq "$(SYS)" "FreeBSD"
-  LDFLAGS += -lexecinfo
+  override LDFLAGS += -lexecinfo
 endif
 
 ifeq "$(shell echo '$(HASH)include <sys/ipc.h>@$(HASH)include <sys/shm.h>@int main() { int _id = shmget(IPC_PRIVATE, 65536, IPC_CREAT | IPC_EXCL | 0600); shmctl(_id, IPC_RMID, 0); return 0;}' | tr @ '\n' | $(CC) -x c - -o .test2 2>/dev/null && echo 1 || echo 0 ; rm -f .test2 )" "1"
@@ -386,13 +386,13 @@ ifeq "$(shell echo '$(HASH)include <sys/ipc.h>@$(HASH)include <sys/shm.h>@int ma
 else
         SHMAT_OK=0
         CFLAGS_SAFE += -DUSEMMAP=1
-        LDFLAGS += -Wno-deprecated-declarations
+        override LDFLAGS += -Wno-deprecated-declarations
 endif
 
 ifeq "$(TEST_MMAP)" "1"
         SHMAT_OK=0
         CFLAGS_SAFE += -DUSEMMAP=1
-        LDFLAGS += -Wno-deprecated-declarations
+        override LDFLAGS += -Wno-deprecated-declarations
 endif
 
 PROGS_ALWAYS = ./afl-cc ./afl-compiler-rt.o ./afl-compiler-rt-32.o ./afl-compiler-rt-64.o


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: Support older glibc by linking librt
**I have tested the changes**: yes

`gettimeofday()` was [recently replaced](https://github.com/AFLplusplus/AFLplusplus/commit/f3c739fc8c29e725832e60e23401684530b0e02d#diff-4508068dbd706015292112facf49308042c1e24e57f20fa12324afcb5aaa3e01R1108-R1130) with `clock_gettime()`. Prior to glibc 2.17, `clock_gettime()` lived in `librt`, so we need a `-lrt`. Only `GNUmakefile.llvm` needs this fix; other makefiles already include `-lrt`.

This also exposed some missing `override` keywords, which are fixed as well.