### PR TITLE
Fix afl-merge man page generation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -526,6 +526,9 @@ ifdef IS_IOS
 	@ldid -Sentitlements.plist $@ && echo "[+] Signed $@" || { echo "[-] Failed to sign $@"; }
 endif
 
+afl-merge: afl-cmin
+	ln -sf afl-cmin $@
+
 afl-tmin: src/afl-tmin.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o src/afl-fuzz-python.o src/afl-fuzz-mutators.o $(COMM_HDR) | test_x86
 	$(CC) $(CFLAGS) $(COMPILE_STATIC) $(CFLAGS_FLTO) $(SPECIAL_PERFORMANCE) src/$@.c src/afl-common.o src/afl-sharedmem.o src/afl-forkserver.o src/afl-performance.o src/afl-fuzz-python.o src/afl-fuzz-mutators.o -o $@ $(PYFLAGS) $(LDFLAGS)
 ifdef IS_IOS


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: Fix man page generation
**I have tested the changes**: yes
  
`afl-merge.8` was [recently added](https://github.com/AFLplusplus/AFLplusplus/commit/c12d296b4e45917643e7743648cff42ae522cb67) to `MANPAGES`, but Make had no rule for its `afl-merge` prerequisite. This broke `make man` and builds that install man pages. This PR adds an explicit `afl-merge` target that creates the required symlink.