### PR TITLE
frida_mode: fix AArch64 ADRP fixups without suppression

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -89,6 +89,9 @@
     - more speed, more info, a few fixes
   - custom_mutators:
     - removed outdated and pointless radamsa
+  - frida_mode:
+    - fix arm64 inline coverage ADRP fixups when instrumentation suppression is
+      disabled
 
 
 ### Version ++5.02c (release)

--- a/frida_mode/src/instrument/instrument_arm64.c
+++ b/frida_mode/src/instrument/instrument_arm64.c
@@ -385,6 +385,13 @@ bool instrument_write_inline(GumArm64Writer *cw, GumAddress code_addr,
   afl_log_code code = {0};
   code.code = template;
 
+  /* code_addr points to the first byte actually emitted. When coverage
+   * suppression is disabled, the template's branch and restoration prologue
+   * are skipped, so account for them when calculating page-relative fixups. */
+  size_t offset =
+      instrument_suppress ? 0 : offsetof(afl_log_code, code.stp_x0_x1);
+  GumAddress template_addr = code_addr - offset;
+
   /*
    * Given our map is allocated on a 64KB boundary and our map is a multiple of
    * 64KB in size, then it should also end on a 64 KB boundary. It is followed
@@ -395,7 +402,7 @@ bool instrument_write_inline(GumArm64Writer *cw, GumAddress code_addr,
 
   if (!instrument_patch_ardp(
           &code.code.adrp_x0_prev_loc1,
-          code_addr + offsetof(afl_log_code, code.adrp_x0_prev_loc1),
+          template_addr + offsetof(afl_log_code, code.adrp_x0_prev_loc1),
           GUM_ADDRESS(instrument_previous_pc_addr))) {
 
     return false;
@@ -414,7 +421,7 @@ bool instrument_write_inline(GumArm64Writer *cw, GumAddress code_addr,
 
   if (!instrument_patch_ardp(
           &code.code.adrp_x1_area_ptr,
-          code_addr + offsetof(afl_log_code, code.adrp_x1_area_ptr),
+          template_addr + offsetof(afl_log_code, code.adrp_x1_area_ptr),
           GUM_ADDRESS(__afl_area_ptr))) {
 
     return false;
@@ -423,7 +430,7 @@ bool instrument_write_inline(GumArm64Writer *cw, GumAddress code_addr,
 
   if (!instrument_patch_ardp(
           &code.code.adrp_x0_prev_loc2,
-          code_addr + offsetof(afl_log_code, code.adrp_x0_prev_loc2),
+          template_addr + offsetof(afl_log_code, code.adrp_x0_prev_loc2),
           GUM_ADDRESS(instrument_previous_pc_addr))) {
 
     return false;
@@ -438,7 +445,6 @@ bool instrument_write_inline(GumArm64Writer *cw, GumAddress code_addr,
 
   } else {
 
-    size_t offset = offsetof(afl_log_code, code.stp_x0_x1);
     gum_arm64_writer_put_bytes(cw, &code.bytes[offset],
                                sizeof(afl_log_code) - offset);
 


### PR DESCRIPTION
## Summary

- account for the inline template prefix omitted when coverage suppression is disabled on AArch64
- patch all three `ADRP` instructions using their actual emitted addresses
- reuse the same offset for fixups and byte emission so they cannot drift

## Problem

`instrument_write_inline()` receives `code_addr` as the address of the first byte that will actually be emitted. When instrumentation suppression is disabled, it skips the template's 8-byte branch/restoration prefix and starts emitting at `stp_x0_x1`.

The existing `ADRP` fixups still add offsets from the start of the full template to `code_addr`. Their assumed instruction addresses are therefore 8 bytes too high. This normally has no effect, but if an actual `ADRP` and its assumed address land on opposite sides of a 4 KiB boundary, the encoded page-relative target is off by one page. The resulting inline coverage code can access the wrong `previous_pc` or coverage-map page and fault.

The fix derives the omitted prefix with `offsetof()`, computes the logical template base from the actual emission address, and uses that base for every `ADRP` fixup. Suppression-enabled behavior is unchanged.

## Validation

- formatted the modified C source with the project's Linux formatter and clang-format 18
- built `frida_mode/build/obj/instrument_arm64.o` on arm64 macOS
- built `frida_mode/build/afl-frida-trace.so` on arm64 macOS
- ran `frida_mode/test/testinstr` with `AFL_FRIDA_INST_NO_SUPPRESS=1` and the rebuilt Frida trace library
- checked all 4 KiB code-address offsets: the old calculation selects the wrong page for 8 placements per `ADRP`; the corrected calculation matches the actual instruction address for every placement
