### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: update
         run: sudo apt-get update && sudo apt-get upgrade -y
       - name: debug
@@ -38,8 +38,8 @@ jobs:
         run: sudo apt install -y libclang-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
-      - name: build afl++
-        run: export NO_NYX=1; export NO_UNICORN=1; export NO_FRIDA=1; export NO_QEMU=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+      - name: install afl++
+        run: export NO_NYX=1; export NO_UNICORN=1; export NO_FRIDA=1; export NO_QEMU=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; export DESTDIR=/tmp; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} install
       - name: Check llvm passes
         run: make NO_QEMU=1 NO_UNICORN=1 NO_FRIDA=1 ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
@@ -54,7 +54,7 @@ jobs:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: update
         run: sudo apt-get update && sudo apt-get upgrade -y
       - name: debug
@@ -76,8 +76,8 @@ jobs:
         run: sudo apt install -y libclang-${{ matrix.version }}-dev
       - name: compiler installed
         run: gcc -v; echo; clang -v
-      - name: build afl++
-        run: export NO_NYX=1; export NO_UNICORN=1; export NO_FRIDA=1; export NO_QEMU=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} all
+      - name: install afl++
+        run: export NO_NYX=1; export NO_UNICORN=1; export NO_FRIDA=1; export NO_QEMU=1; export ASAN_BUILD=1; export LLVM_CONFIG=llvm-config-${{ matrix.version }}; export DESTDIR=/tmp; make ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} install
       - name: Check llvm passes
         run: make NO_QEMU=1 NO_UNICORN=1 NO_FRIDA=1 ASAN_BUILD=1 NO_NYX=1 LLVM_CONFIG=llvm-config-${{ matrix.version }} llvm-build-test || exit 1
       - name: run tests
@@ -98,7 +98,7 @@ jobs:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: update
         run: sudo apt-get update && sudo apt-get upgrade -y
       - name: install packages
@@ -133,7 +133,7 @@ jobs:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: update
         run: sudo apt-get update && sudo apt-get upgrade -y
       - name: debug
@@ -155,7 +155,7 @@ jobs:
       AFL_SKIP_CPUFREQ: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: install
         run: brew install make gcc llvm
 #     - name: fix install

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -21,7 +21,7 @@ jobs:
     container: docker.io/aflplusplus/aflplusplus:dev
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Format
         run: |
           git config --global --add safe.directory /__w/AFLplusplus/AFLplusplus

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Fix for using external repo in container build # https://github.com/actions/checkout/issues/760
         run: git config --global --add safe.directory /__w/AFLplusplus/AFLplusplus
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build ${{ matrix.arch }}
@@ -70,7 +70,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.repository == 'AFLplusplus/AFLplusplus' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to docker.io

--- a/.github/workflows/qemu_bridge.yml
+++ b/.github/workflows/qemu_bridge.yml
@@ -27,7 +27,7 @@ jobs:
       AFL_NO_AFFINITY: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: false
       - name: install dependencies
@@ -92,7 +92,7 @@ jobs:
       AFL_NO_AFFINITY: 1
       AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: false
       - name: install dependencies
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: false
       - name: install dependencies

--- a/.github/workflows/rust_custom_mutator.yml
+++ b/.github/workflows/rust_custom_mutator.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
**Type of PR**: Bugfix
**Purpose of this PR**: Detect failing `make install` next time
**I have tested the changes**: yes

This is related to fix #2879, that added a missing target to the Makefile.
In `ci.yml` now a `make install` is done instead of `make all` (since: `install: all $(MANPAGES)` also includes the manpages). In addition checkout actions were updated.
  
