### PR TITLE
frameshift: fix narrow length field overflow

### DIFF
--- a/src/afl-fuzz-frameshift.c
+++ b/src/afl-fuzz-frameshift.c
@@ -48,13 +48,12 @@ int rel_on_insert(fs_relation_t *rel, u64 idx, u64 size) {
   // Check if we should update the value of the field.
   if (idx >= rel->anchor && idx <= rel->insert) {
 
-    u64 pre = rel->val;
+    u64 max = rel->size < 8 ? (1ULL << (rel->size * 8)) - 1 : UINT64_MAX;
+
+    // Check before adding: masking first misses increments that wrap by a
+    // complete field width, such as adding 256 to an 8-bit length.
+    if (size > max - rel->val) { return 1; }
     rel->val += size;
-
-    if (rel->size < 8) { rel->val &= (1ULL << (rel->size * 8)) - 1; }
-
-    // Check if we overflowed the field.
-    if (rel->val < pre) { return 1; }
 
   }
 

--- a/test/unittests/unit_frameshift.c
+++ b/test/unittests/unit_frameshift.c
@@ -13,6 +13,8 @@
 int  rel_on_insert(fs_relation_t *rel, u64 idx, u64 size);
 int  rel_on_remove(fs_relation_t *rel, u64 idx, u64 size);
 void rel_apply(u8 *buf, fs_relation_t *rel);
+int fs_track_insert(fs_meta_t *meta, u64 idx, u64 data_size, u8 ignore_invalid);
+void fs_sanitize(fs_meta_t *meta, u8 *buf, u32 len);
 u8   lightweight_run(afl_state_t *afl, u8 *out_buf, u32 len);
 u64  frameshift_slice_budget(u64 spent_ms, u64 allowed_ms);
 
@@ -124,6 +126,42 @@ static void test_rel_insert_between_anchor_insert_updates_val(void **state) {
   assert_int_equal(rel_on_insert(&rel, 25, 3), 0);
   assert_int_equal(rel.val, 8);
   assert_int_equal(rel.pos, 53);
+
+}
+
+static void test_rel_insert_rejects_full_width_wrap(void **state) {
+
+  (void)state;
+  fs_relation_t rel = {.pos = 50,
+                       .val = 5,
+                       .anchor = 20,
+                       .insert = 30,
+                       .size = 1,
+                       .le = 1,
+                       .enabled = 1};
+
+  assert_int_equal(rel_on_insert(&rel, 25, 256), 1);
+
+}
+
+static void test_tracking_disables_wrapped_relation(void **state) {
+
+  (void)state;
+  fs_relation_t rel = {.pos = 0,
+                       .val = 5,
+                       .anchor = 1,
+                       .insert = 10,
+                       .size = 1,
+                       .le = 1,
+                       .enabled = 1};
+  fs_meta_t     meta = {.relations = &rel, .rel_count = 1, .rel_capacity = 1};
+  u8            buf[300] = {99};
+
+  assert_int_equal(fs_track_insert(&meta, 5, 256, 1), 0);
+  assert_int_equal(rel.enabled, 0);
+
+  fs_sanitize(&meta, buf, sizeof(buf));
+  assert_int_equal(buf[0], 99);
 
 }
 
@@ -269,6 +307,8 @@ int main(void) {
       cmocka_unit_test(test_rel_insert_inside_field_errors),
       cmocka_unit_test(test_rel_insert_after_field_no_shift),
       cmocka_unit_test(test_rel_insert_between_anchor_insert_updates_val),
+      cmocka_unit_test(test_rel_insert_rejects_full_width_wrap),
+      cmocka_unit_test(test_tracking_disables_wrapped_relation),
       cmocka_unit_test(test_rel_remove_overlapping_field_errors),
       cmocka_unit_test(test_rel_apply_endianness),
       cmocka_unit_test(test_lightweight_run_reports_skip),


### PR DESCRIPTION
## Overview

**Type of PR**: Bugfix
**Purpose of this PR**: 

* reject insertions that exceed a tracked length field's representable range
* disable invalid `FrameShift` relations through the existing tracking path
* add unit tests for narrow-field wrapping

**I have tested the changes**: yes

## Problem

`rel_on_insert()` updates tracked length fields by adding the inserted size, masking the result to the field width, and then comparing it with the previous value to detect overflow.

Masking before the comparison misses some overflows. For example, adding `256` to an 8-bit length field containing `5` wraps back to `5` and is accepted as a valid update:

```text
before: enabled=1 value=5 byte=99
after: enabled=1 value=5 byte=5
```

Standard havoc mutations can generate insertions larger than an 8-bit field can represent. When such an update is accepted, `fs_sanitize()` keeps applying the wrapped relation and writes an incorrect length into the mutated testcase. This can turn otherwise useful mutations into malformed inputs and reduce the coverage benefit provided by `FrameShift`.

The fix checks the insertion size against the field's remaining representable range before performing the addition. Existing tracking behavior then disables the relation instead of applying a wrapped value.

## Validation

* added a test case where adding `256` to an 8-bit relation must fail and a test confirming `fs_track_insert()` disables the relation and `fs_sanitize()` leaves the testcase unchanged
* ran existing unit tests and `make code-format`
* built `afl-fuzz`
* formatted the modified sources with the project formatter