### PR TITLE
Prevent occasional hangs in the forkserver process on FreeBSD

### DIFF
--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -233,9 +233,11 @@ static u8 *__afl_area_ptr_backup = __afl_area_initial;
 u8  *__afl_area_ptr = __afl_area_initial;
 u8  *__afl_dictionary;
 u32 *__afl_child_sync = NULL;
+#if defined(__linux__) || defined(__APPLE__)
 /* Byte offset of the child_sync word inside the trace_bits shared map (0 if
    none). */
 static u32 __afl_child_sync_off = 0;
+#endif
 /* Lengths we mmap()ed for each shared region, so __afl_unmap_shm() can undo
    exactly what was done. A length of 0 means the region was not mmap()ed -
    either it was never attached, or it came in as a SysV segment that has to be

--- a/instrumentation/afl-compiler-rt.o.c
+++ b/instrumentation/afl-compiler-rt.o.c
@@ -2220,6 +2220,7 @@ static void __afl_start_forkserver(void) {
     if (unlikely(child_stopped && was_killed)) {
 
       child_stopped = 0;
+      kill(child_pid, SIGKILL);
       if (unlikely(waitpid(child_pid, &status, 0) < 0)) {
 
         write_error("child_stopped && was_killed");


### PR DESCRIPTION
Using afl-fuzz to fuzz Privoxy on ElectroBSD systems based on FreeBSD stable/15 I noticed that the fuzzing would occasionally stall after a couple of hours.

This is not a recent regression, but it took me a while to look into it.

The problem seems to be caused by the forkserver process hanging in waitpid():

```
(gdb) where
 #0  _wait4 () at _wait4.S:4
 #1  0x000000080058e77c in __thr_wait4 (pid=76988, status=0x7fffffffd090, options=0, rusage=0x0) at /usr/src/lib/libthr/thread/thr_syscalls.c:563
 #2  0x00000000002b2952 in ___interceptor_waitpid () at /wrkdirs/usr/ports/devel/llvm21/work-default/llvm-project-21.1.8.src/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:2739
 #3  0x000000000041f5ab in __afl_start_forkserver () at instrumentation/afl-compiler-rt.o.c:1731
 #4  __afl_manual_init () at instrumentation/afl-compiler-rt.o.c:2071
 #5  0x0000000800437661 in objlist_call_init (list=list@entry=0x7fffffffe060, lockstate=lockstate@entry=0x7fffffffde60) at /usr/src/libexec/rtld-elf/rtld.c:3277
 #6  0x0000000800435cc6 in _rtld (sp=<optimized out>, exit_proc=0x7fffffffe0f0, objp=0x7fffffffe0f8) at /usr/src/libexec/rtld-elf/rtld.c:1019
 #7  0x0000000800432b89 in rtld_start () at /usr/src/libexec/rtld-elf/amd64/rtld_start.S:40

```

Explicitly killing the child before writing it off when it appears to be stopped and killed at the same time seems to prevent the issue.

While at it, the PR prevents an unused-variable warning.